### PR TITLE
fix: run python hooks through project venv

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     hooks:
       - id: codex-review
         name: Codex pre-push review
-        entry: bash hooks/codex-review.sh
+        entry: /usr/bin/env bash hooks/codex-review.sh
         language: system
         stages: [pre-push]
         always_run: true
@@ -31,7 +31,7 @@ repos:
     hooks:
       - id: self-tests
         name: Toolkit self-tests
-        entry: bash -c 'set -e; for test in tests/test-*.sh; do bash "$test"; done'
+        entry: /usr/bin/env bash -c 'set -e; for test in tests/test-*.sh; do /usr/bin/env bash "$test"; done'
         language: system
         stages: [pre-push]
         always_run: true

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ $EDITOR ~/Repos/my-new-project/AGENTS.md
 
 # Set up pre-commit hooks (optional but recommended)
 cd ~/Repos/my-new-project
-pip install pre-commit && pre-commit install --install-hooks
+brew install pre-commit
+pre-commit install --install-hooks
 
 # Set up Codex pre-push review (optional)
 npm install -g @openai/codex && codex login
@@ -61,6 +62,7 @@ When you run `toolkit new`, these files get copied into your project:
 - `scripts/open-pr.sh` — Push + create PR via `gh`
 - `scripts/merge-pr.sh` — Squash-merge + sync main
 - `scripts/cleanup-branches.sh` — Safe branch hygiene
+- `scripts/run-pytest-in-venv.sh` — Run pytest through `.venv` or `agent/.venv`
 
 ### Keeping projects up to date
 

--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -215,6 +215,7 @@ copy_file_force "$TOOLKIT_ROOT/hooks/codex-review.sh" "$PROJECT_DIR/scripts/code
 copy_file_force "$TOOLKIT_ROOT/scripts/open-pr.sh" "$PROJECT_DIR/scripts/open-pr.sh"
 copy_file_force "$TOOLKIT_ROOT/scripts/merge-pr.sh" "$PROJECT_DIR/scripts/merge-pr.sh"
 copy_file_force "$TOOLKIT_ROOT/scripts/cleanup-branches.sh" "$PROJECT_DIR/scripts/cleanup-branches.sh"
+copy_file_force "$TOOLKIT_ROOT/scripts/run-pytest-in-venv.sh" "$PROJECT_DIR/scripts/run-pytest-in-venv.sh"
 chmod +x "$PROJECT_DIR/scripts/"*.sh
 
 # Write toolkit version.

--- a/bootstrap/update-project.sh
+++ b/bootstrap/update-project.sh
@@ -137,6 +137,7 @@ update_file "$TOOLKIT_ROOT/hooks/codex-review.sh" "$PROJECT_DIR/scripts/codex-re
 update_file "$TOOLKIT_ROOT/scripts/open-pr.sh" "$PROJECT_DIR/scripts/open-pr.sh"
 update_file "$TOOLKIT_ROOT/scripts/merge-pr.sh" "$PROJECT_DIR/scripts/merge-pr.sh"
 update_file "$TOOLKIT_ROOT/scripts/cleanup-branches.sh" "$PROJECT_DIR/scripts/cleanup-branches.sh"
+update_file "$TOOLKIT_ROOT/scripts/run-pytest-in-venv.sh" "$PROJECT_DIR/scripts/run-pytest-in-venv.sh"
 
 # Ensure scripts are executable.
 if [ "$DRY_RUN" = false ] && [ -d "$PROJECT_DIR/scripts" ]; then

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -14,7 +14,8 @@ codex login
 ### 2. Install pre-commit
 
 ```bash
-pip install pre-commit   # or: brew install pre-commit
+brew install pre-commit
+# or: python3 -m pip install --user pre-commit
 ```
 
 ### 3. Wire the hook
@@ -23,6 +24,12 @@ The toolkit's `.pre-commit-config.yaml` template already includes the Codex hook
 
 ```bash
 pre-commit install --install-hooks
+```
+
+For Python test hooks, prefer the toolkit wrapper over `python3 -m pytest` so the hook uses the project's virtualenv:
+
+```yaml
+entry: /usr/bin/env bash scripts/run-pytest-in-venv.sh tests/
 ```
 
 ### 4. Configure per-project behavior

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -6,4 +6,4 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-exec bash "$SCRIPT_DIR/../hooks/codex-review.sh" "$@"
+exec /usr/bin/env bash "$SCRIPT_DIR/../hooks/codex-review.sh" "$@"

--- a/scripts/run-pytest-in-venv.sh
+++ b/scripts/run-pytest-in-venv.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Run pytest with the project's virtualenv Python instead of system python3.
+#
+# Usage:
+#   bash scripts/run-pytest-in-venv.sh tests/
+#
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+find_python() {
+  local candidate
+
+  if [ -n "${PYTEST_PYTHON:-}" ]; then
+    if command -v "$PYTEST_PYTHON" >/dev/null 2>&1; then
+      command -v "$PYTEST_PYTHON"
+      return 0
+    fi
+
+    echo "ERROR: PYTEST_PYTHON is set but not executable: $PYTEST_PYTHON" >&2
+    return 1
+  fi
+
+  for candidate in ".venv/bin/python" "agent/.venv/bin/python"; do
+    if [ -x "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  echo "ERROR: no project virtualenv found for pytest." >&2
+  echo "       Expected .venv/bin/python or agent/.venv/bin/python." >&2
+  echo "       Run: bash setup.sh" >&2
+  return 1
+}
+
+PYTHON_BIN="$(find_python)"
+exec "$PYTHON_BIN" -m pytest "$@"

--- a/setup.sh
+++ b/setup.sh
@@ -135,26 +135,114 @@ fi
 # 8. Project dependencies
 # --------------------------------------------------------------------------
 info "Installing project dependencies"
-if [ -f "pnpm-lock.yaml" ] && command -v pnpm >/dev/null 2>&1; then
-  pnpm install 2>&1 | tail -1 | while read -r line; do ok "$line"; done
-elif [ -f "package-lock.json" ] && command -v npm >/dev/null 2>&1; then
-  npm install 2>&1 | tail -1 | while read -r line; do ok "$line"; done
+
+select_python_for_venv() {
+  local python_dir="${1:-.}"
+  local pyenv_python
+
+  if [ -n "${PYTHON:-}" ]; then
+    if command -v "$PYTHON" >/dev/null 2>&1; then
+      command -v "$PYTHON"
+      return 0
+    fi
+    fail "PYTHON is set but not executable: $PYTHON"
+    return 1
+  fi
+
+  if command -v pyenv >/dev/null 2>&1; then
+    if [ -f "$python_dir/.python-version" ] || [ -f ".python-version" ]; then
+      pyenv_python="$(cd "$python_dir" && pyenv which python 2>/dev/null || true)"
+      if [ -n "$pyenv_python" ] && [ -x "$pyenv_python" ]; then
+        printf '%s\n' "$pyenv_python"
+        return 0
+      fi
+    fi
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    command -v python3
+    return 0
+  fi
+  if command -v python >/dev/null 2>&1; then
+    command -v python
+    return 0
+  fi
+
+  fail "Python is required to create a virtualenv"
+  return 1
+}
+
+install_python_requirements() {
+  local label="$1"
+  local requirements_file="$2"
+  local venv_dir="$3"
+  local python_bin python_dir python_version
+  python_dir="$(dirname "$requirements_file")"
+
+  if [ ! -x "$venv_dir/bin/python" ]; then
+    python_bin="$(select_python_for_venv "$python_dir")"
+    python_version="$("$python_bin" --version 2>&1)"
+    if [ ! -f "$python_dir/.python-version" ] && [ ! -f ".python-version" ]; then
+      warn "No .python-version found — creating $venv_dir with $python_version"
+    else
+      ok "Using $python_version for $venv_dir"
+    fi
+    "$python_bin" -m venv "$venv_dir"
+    ok "$venv_dir created"
+  fi
+
+  "$venv_dir/bin/python" -m pip install -r "$requirements_file" 2>&1 | tail -1 | while read -r line; do
+    ok "$label dependencies installed: $line"
+  done
+}
+
+DEPS_FOUND=false
+
+if [ -f "pnpm-lock.yaml" ]; then
+  DEPS_FOUND=true
+  if command -v pnpm >/dev/null 2>&1; then
+    pnpm install 2>&1 | tail -1 | while read -r line; do ok "$line"; done
+  else
+    warn "pnpm-lock.yaml found, but pnpm is not installed. Run: brew install pnpm"
+  fi
+elif [ -f "package-lock.json" ]; then
+  DEPS_FOUND=true
+  if command -v npm >/dev/null 2>&1; then
+    npm install 2>&1 | tail -1 | while read -r line; do ok "$line"; done
+  else
+    warn "package-lock.json found, but npm is not installed. Install Node.js/npm first."
+  fi
 elif [ -f "package.json" ]; then
+  DEPS_FOUND=true
   if command -v pnpm >/dev/null 2>&1; then
     pnpm install 2>&1 | tail -1 | while read -r line; do ok "$line"; done
   elif command -v npm >/dev/null 2>&1; then
     npm install 2>&1 | tail -1 | while read -r line; do ok "$line"; done
+  else
+    warn "package.json found, but neither pnpm nor npm is installed."
   fi
-elif [ -f "requirements.txt" ]; then
-  pip install -r requirements.txt 2>&1 | tail -1 | while read -r line; do ok "$line"; done
-elif [ -f "Cargo.toml" ]; then
-  ok "Rust project — run: cargo build"
-elif [ -f "Package.swift" ]; then
-  ok "Swift project — run: swift build"
-elif [ -f "go.mod" ]; then
-  go mod download 2>&1 && ok "Go modules downloaded"
-else
-  ok "No recognized dependency file — skipping"
+fi
+
+if [ -f "requirements.txt" ]; then
+  DEPS_FOUND=true
+  install_python_requirements "Python" "requirements.txt" ".venv"
+fi
+
+if [ -f "agent/requirements.txt" ]; then
+  DEPS_FOUND=true
+  install_python_requirements "agent Python" "agent/requirements.txt" "agent/.venv"
+fi
+
+if [ "$DEPS_FOUND" = false ]; then
+  if [ -f "Cargo.toml" ]; then
+    ok "Rust project — run: cargo build"
+  elif [ -f "Package.swift" ]; then
+    ok "Swift project — run: swift build"
+  elif [ -f "go.mod" ]; then
+    go mod download 2>&1 && ok "Go modules downloaded"
+  else
+    ok "No recognized dependency file — skipping"
+  fi
 fi
 
 # --------------------------------------------------------------------------

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -33,7 +33,7 @@
 
 ```bash
 # Before any push — replace with your project's test command
-{{TEST_COMMAND — e.g., pytest tests/ -v --timeout=60 -x}}
+{{TEST_COMMAND — e.g., scripts/run-pytest-in-venv.sh tests/ -v --timeout=60 -x}}
 ```
 
 Fix failing tests before pushing.

--- a/templates/pre-commit-config.yaml
+++ b/templates/pre-commit-config.yaml
@@ -46,7 +46,10 @@ repos:
     hooks:
       - id: branch-naming
         name: Branch naming convention
-        entry: bash -c 'branch="$(git rev-parse --abbrev-ref HEAD)"; [[ "$branch" == "main" || "$branch" == "master" || "$branch" =~ ^(feat|fix|chore|refactor|docs)/ ]] || { echo "Branch name must match: feat/, fix/, chore/, refactor/, or docs/"; exit 1; }'
+        entry: >-
+          /usr/bin/env bash -c 'branch="$(git rev-parse --abbrev-ref HEAD)";
+          [[ "$branch" == "main" || "$branch" == "master" || "$branch" =~ ^(feat|fix|chore|refactor|docs)/ ]] ||
+          { echo "Branch name must match: feat/, fix/, chore/, refactor/, or docs/"; exit 1; }'
         language: system
         stages: [pre-push]
         always_run: true
@@ -57,7 +60,7 @@ repos:
     hooks:
       - id: codex-review
         name: Codex pre-push review
-        entry: bash scripts/codex-review.sh
+        entry: /usr/bin/env bash scripts/codex-review.sh
         language: system
         stages: [pre-push]
         always_run: true
@@ -79,7 +82,7 @@ repos:
   #   hooks:
   #     - id: tests
   #       name: Run tests
-  #       entry: bash -c 'YOUR_TEST_COMMAND_HERE'
+  #       entry: /usr/bin/env bash scripts/run-pytest-in-venv.sh tests/
   #       language: system
   #       stages: [pre-push]
   #       always_run: true

--- a/templates/setup.sh
+++ b/templates/setup.sh
@@ -135,26 +135,114 @@ fi
 # 8. Project dependencies
 # --------------------------------------------------------------------------
 info "Installing project dependencies"
-if [ -f "pnpm-lock.yaml" ] && command -v pnpm >/dev/null 2>&1; then
-  pnpm install 2>&1 | tail -1 | while read -r line; do ok "$line"; done
-elif [ -f "package-lock.json" ] && command -v npm >/dev/null 2>&1; then
-  npm install 2>&1 | tail -1 | while read -r line; do ok "$line"; done
+
+select_python_for_venv() {
+  local python_dir="${1:-.}"
+  local pyenv_python
+
+  if [ -n "${PYTHON:-}" ]; then
+    if command -v "$PYTHON" >/dev/null 2>&1; then
+      command -v "$PYTHON"
+      return 0
+    fi
+    fail "PYTHON is set but not executable: $PYTHON"
+    return 1
+  fi
+
+  if command -v pyenv >/dev/null 2>&1; then
+    if [ -f "$python_dir/.python-version" ] || [ -f ".python-version" ]; then
+      pyenv_python="$(cd "$python_dir" && pyenv which python 2>/dev/null || true)"
+      if [ -n "$pyenv_python" ] && [ -x "$pyenv_python" ]; then
+        printf '%s\n' "$pyenv_python"
+        return 0
+      fi
+    fi
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    command -v python3
+    return 0
+  fi
+  if command -v python >/dev/null 2>&1; then
+    command -v python
+    return 0
+  fi
+
+  fail "Python is required to create a virtualenv"
+  return 1
+}
+
+install_python_requirements() {
+  local label="$1"
+  local requirements_file="$2"
+  local venv_dir="$3"
+  local python_bin python_dir python_version
+  python_dir="$(dirname "$requirements_file")"
+
+  if [ ! -x "$venv_dir/bin/python" ]; then
+    python_bin="$(select_python_for_venv "$python_dir")"
+    python_version="$("$python_bin" --version 2>&1)"
+    if [ ! -f "$python_dir/.python-version" ] && [ ! -f ".python-version" ]; then
+      warn "No .python-version found — creating $venv_dir with $python_version"
+    else
+      ok "Using $python_version for $venv_dir"
+    fi
+    "$python_bin" -m venv "$venv_dir"
+    ok "$venv_dir created"
+  fi
+
+  "$venv_dir/bin/python" -m pip install -r "$requirements_file" 2>&1 | tail -1 | while read -r line; do
+    ok "$label dependencies installed: $line"
+  done
+}
+
+DEPS_FOUND=false
+
+if [ -f "pnpm-lock.yaml" ]; then
+  DEPS_FOUND=true
+  if command -v pnpm >/dev/null 2>&1; then
+    pnpm install 2>&1 | tail -1 | while read -r line; do ok "$line"; done
+  else
+    warn "pnpm-lock.yaml found, but pnpm is not installed. Run: brew install pnpm"
+  fi
+elif [ -f "package-lock.json" ]; then
+  DEPS_FOUND=true
+  if command -v npm >/dev/null 2>&1; then
+    npm install 2>&1 | tail -1 | while read -r line; do ok "$line"; done
+  else
+    warn "package-lock.json found, but npm is not installed. Install Node.js/npm first."
+  fi
 elif [ -f "package.json" ]; then
+  DEPS_FOUND=true
   if command -v pnpm >/dev/null 2>&1; then
     pnpm install 2>&1 | tail -1 | while read -r line; do ok "$line"; done
   elif command -v npm >/dev/null 2>&1; then
     npm install 2>&1 | tail -1 | while read -r line; do ok "$line"; done
+  else
+    warn "package.json found, but neither pnpm nor npm is installed."
   fi
-elif [ -f "requirements.txt" ]; then
-  pip install -r requirements.txt 2>&1 | tail -1 | while read -r line; do ok "$line"; done
-elif [ -f "Cargo.toml" ]; then
-  ok "Rust project — run: cargo build"
-elif [ -f "Package.swift" ]; then
-  ok "Swift project — run: swift build"
-elif [ -f "go.mod" ]; then
-  go mod download 2>&1 && ok "Go modules downloaded"
-else
-  ok "No recognized dependency file — skipping"
+fi
+
+if [ -f "requirements.txt" ]; then
+  DEPS_FOUND=true
+  install_python_requirements "Python" "requirements.txt" ".venv"
+fi
+
+if [ -f "agent/requirements.txt" ]; then
+  DEPS_FOUND=true
+  install_python_requirements "agent Python" "agent/requirements.txt" "agent/.venv"
+fi
+
+if [ "$DEPS_FOUND" = false ]; then
+  if [ -f "Cargo.toml" ]; then
+    ok "Rust project — run: cargo build"
+  elif [ -f "Package.swift" ]; then
+    ok "Swift project — run: swift build"
+  elif [ -f "go.mod" ]; then
+    go mod download 2>&1 && ok "Go modules downloaded"
+  else
+    ok "No recognized dependency file — skipping"
+  fi
 fi
 
 # --------------------------------------------------------------------------

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -67,10 +67,13 @@ assert_exists "$PROJECT/scripts/codex-review.sh"
 assert_exists "$PROJECT/scripts/open-pr.sh"
 assert_exists "$PROJECT/scripts/merge-pr.sh"
 assert_exists "$PROJECT/scripts/cleanup-branches.sh"
+assert_exists "$PROJECT/scripts/run-pytest-in-venv.sh"
 assert_executable "$PROJECT/scripts/codex-review.sh"
 assert_executable "$PROJECT/scripts/open-pr.sh"
 assert_executable "$PROJECT/scripts/merge-pr.sh"
 assert_executable "$PROJECT/scripts/cleanup-branches.sh"
+assert_executable "$PROJECT/scripts/run-pytest-in-venv.sh"
+assert_contains "$PROJECT/.pre-commit-config.yaml" 'run-pytest-in-venv.sh'
 
 # Toolkit version
 assert_exists "$PROJECT/.toolkit-version"
@@ -111,6 +114,33 @@ if grep -q 'src/auth' "$PROJECT_EXISTING_CONFIG/.codex-review.toml"; then
   echo "FAIL: expected existing .codex-review.toml unsafe_paths to remain unchanged" >&2
   ERRORS=$((ERRORS + 1))
 fi
+
+# Pytest wrapper should use project virtualenvs instead of system python.
+PYTEST_WRAPPER_PROJECT="$TEST_DIR/pytest-wrapper"
+mkdir -p "$PYTEST_WRAPPER_PROJECT"
+if (cd "$PYTEST_WRAPPER_PROJECT" && "$TOOLKIT_ROOT/scripts/run-pytest-in-venv.sh" tests) >"$TEST_DIR/pytest-missing-venv.txt" 2>&1; then
+  echo "FAIL: expected run-pytest-in-venv.sh to fail without a venv" >&2
+  ERRORS=$((ERRORS + 1))
+else
+  assert_contains "$TEST_DIR/pytest-missing-venv.txt" 'Run: bash setup.sh'
+fi
+
+mkdir -p "$PYTEST_WRAPPER_PROJECT/.venv/bin"
+cat > "$PYTEST_WRAPPER_PROJECT/.venv/bin/python" <<'FAKEPYTHON'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$PWD/pytest-args.txt"
+if [ "$1" = "-m" ] && [ "$2" = "pytest" ]; then
+  exit 0
+fi
+exit 1
+FAKEPYTHON
+chmod +x "$PYTEST_WRAPPER_PROJECT/.venv/bin/python"
+
+(cd "$PYTEST_WRAPPER_PROJECT" && "$TOOLKIT_ROOT/scripts/run-pytest-in-venv.sh" tests/unit -x)
+assert_contains "$PYTEST_WRAPPER_PROJECT/pytest-args.txt" '^-m$'
+assert_contains "$PYTEST_WRAPPER_PROJECT/pytest-args.txt" '^pytest$'
+assert_contains "$PYTEST_WRAPPER_PROJECT/pytest-args.txt" '^tests/unit$'
+assert_contains "$PYTEST_WRAPPER_PROJECT/pytest-args.txt" '^-x$'
 
 echo ""
 if [ "$ERRORS" -eq 0 ]; then

--- a/tests/test-update.sh
+++ b/tests/test-update.sh
@@ -62,6 +62,7 @@ echo "--- Step 3: Modify a toolkit-owned file, then update ---"
 
 # Simulate local modification to a toolkit-owned file.
 echo "# locally modified" >> "$PROJECT/principles/engineering-principles.md"
+rm "$PROJECT/scripts/run-pytest-in-venv.sh"
 
 # Fake a new toolkit version by writing a different SHA so update thinks
 # there's something new. We write a fake old SHA to .toolkit-version.
@@ -71,6 +72,7 @@ echo "0000000000000000000000000000000000000000" > "$PROJECT/.toolkit-version"
 
 # Verify .bak was created.
 assert_exists "$PROJECT/principles/engineering-principles.md.bak"
+assert_exists "$PROJECT/scripts/run-pytest-in-venv.sh"
 
 # Verify the current file matches the toolkit version (not the modified one).
 if diff -q "$TOOLKIT_ROOT/principles/engineering-principles.md" "$PROJECT/principles/engineering-principles.md" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
Adds a venv-aware pytest wrapper for downstream pre-push hooks and updates setup/docs so Python and Node dependency setup is deterministic instead of depending on system Python or accidental package-manager fallbacks.

## Changes
- Adds scripts/run-pytest-in-venv.sh, which uses .venv/bin/python or agent/.venv/bin/python and fails with a setup.sh hint if neither exists.
- Copies the wrapper during new-project and update-project flows.
- Updates setup.sh and templates/setup.sh to create/populate .venv and agent/.venv from requirements.txt files.
- Makes setup respect agent/.python-version and avoid falling back from pnpm-lock.yaml to npm when pnpm is missing.
- Updates pre-commit hook entries/examples to invoke bash through /usr/bin/env and points Python test guidance at the wrapper.
- Replaces bare pip/pytest documentation examples with brew or venv-safe commands.
- Adds bootstrap/update regression assertions for the new wrapper.

## Testing
- [x] bash tests/test-bootstrap.sh
- [x] bash tests/test-update.sh
- [x] Full local test sweep across tests/test-*.sh with set -e
- [x] pre-commit validate-config
- [x] pre-commit run --hook-stage pre-push self-tests
- [x] shellcheck -S warning on touched scripts/tests
- [x] git diff --check
- [x] Pre-push Codex review passed

## Risk
- [x] Medium risk - touches bootstrap/update, setup, and hook templates

## Rollback
Clean revert of this PR commit. No data migration required.