### PR TITLE
fix: support uv setup paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ pre-commit install --install-hooks
 
 # Set up Codex pre-push review (optional)
 npm install -g @openai/codex && codex login
+
+# Re-run dependency setup later without reinstalling hooks/tools
+bash setup.sh --deps-only
 ```
 
 ## Commands
@@ -63,6 +66,8 @@ When you run `toolkit new`, these files get copied into your project:
 - `scripts/merge-pr.sh` — Squash-merge + sync main
 - `scripts/cleanup-branches.sh` — Safe branch hygiene
 - `scripts/run-pytest-in-venv.sh` — Run pytest through `.venv` or `agent/.venv`
+
+`setup.sh` installs Python dependencies into project virtualenvs. It supports `requirements.txt`, `uv.lock`, and `pyproject.toml` at the repo root and under `agent/`.
 
 ### Keeping projects up to date
 

--- a/setup.sh
+++ b/setup.sh
@@ -22,10 +22,25 @@ ok()    { printf "  ${GREEN}✓${RESET} %s\n" "$*"; }
 warn()  { printf "  ${YELLOW}!${RESET} %s\n" "$*"; }
 fail()  { printf "  ${RED}✗${RESET} %s\n" "$*"; }
 
+DEPS_ONLY=false
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --deps-only) DEPS_ONLY=true; shift ;;
+    -h|--help)
+      echo "Usage: bash setup.sh [--deps-only]"
+      exit 0
+      ;;
+    *) fail "Unknown argument: $1"; exit 1 ;;
+  esac
+done
+
 PROJECT_NAME="$(basename "$(pwd)")"
 echo ""
 printf "${BOLD}Setting up ${PROJECT_NAME}${RESET}\n"
 echo ""
+
+if [ "$DEPS_ONLY" = false ]; then
 
 # --------------------------------------------------------------------------
 # 1. Homebrew (required foundation)
@@ -131,6 +146,8 @@ else
   warn "gh not authenticated. Run: gh auth login"
 fi
 
+fi
+
 # --------------------------------------------------------------------------
 # 8. Project dependencies
 # --------------------------------------------------------------------------
@@ -196,6 +213,33 @@ install_python_requirements() {
   done
 }
 
+install_uv_if_missing() {
+  if command -v uv >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if command -v brew >/dev/null 2>&1; then
+    warn "Installing uv..."
+    brew install uv 2>/dev/null
+    ok "uv installed"
+    return 0
+  fi
+
+  warn "uv is required for uv.lock/pyproject.toml projects. Install uv first."
+  return 1
+}
+
+install_uv_project() {
+  local label="$1"
+  local project_dir="$2"
+
+  if install_uv_if_missing; then
+    (cd "$project_dir" && uv sync) 2>&1 | tail -1 | while read -r line; do
+      ok "$label dependencies synced: $line"
+    done
+  fi
+}
+
 DEPS_FOUND=false
 
 if [ -f "pnpm-lock.yaml" ]; then
@@ -223,12 +267,24 @@ elif [ -f "package.json" ]; then
   fi
 fi
 
-if [ -f "requirements.txt" ]; then
+if [ -f "uv.lock" ]; then
+  DEPS_FOUND=true
+  install_uv_project "Python" "."
+elif [ -f "pyproject.toml" ] && [ ! -f "requirements.txt" ]; then
+  DEPS_FOUND=true
+  install_uv_project "Python" "."
+elif [ -f "requirements.txt" ]; then
   DEPS_FOUND=true
   install_python_requirements "Python" "requirements.txt" ".venv"
 fi
 
-if [ -f "agent/requirements.txt" ]; then
+if [ -f "agent/uv.lock" ]; then
+  DEPS_FOUND=true
+  install_uv_project "agent Python" "agent"
+elif [ -f "agent/pyproject.toml" ] && [ ! -f "agent/requirements.txt" ]; then
+  DEPS_FOUND=true
+  install_uv_project "agent Python" "agent"
+elif [ -f "agent/requirements.txt" ]; then
   DEPS_FOUND=true
   install_python_requirements "agent Python" "agent/requirements.txt" "agent/.venv"
 fi

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -32,6 +32,9 @@
 ## Testing
 
 ```bash
+# Reinstall dependencies without rerunning the full machine setup
+bash setup.sh --deps-only
+
 # Before any push — replace with your project's test command
 {{TEST_COMMAND — e.g., scripts/run-pytest-in-venv.sh tests/ -v --timeout=60 -x}}
 ```

--- a/templates/setup.sh
+++ b/templates/setup.sh
@@ -22,10 +22,25 @@ ok()    { printf "  ${GREEN}✓${RESET} %s\n" "$*"; }
 warn()  { printf "  ${YELLOW}!${RESET} %s\n" "$*"; }
 fail()  { printf "  ${RED}✗${RESET} %s\n" "$*"; }
 
+DEPS_ONLY=false
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --deps-only) DEPS_ONLY=true; shift ;;
+    -h|--help)
+      echo "Usage: bash setup.sh [--deps-only]"
+      exit 0
+      ;;
+    *) fail "Unknown argument: $1"; exit 1 ;;
+  esac
+done
+
 PROJECT_NAME="$(basename "$(pwd)")"
 echo ""
 printf "${BOLD}Setting up ${PROJECT_NAME}${RESET}\n"
 echo ""
+
+if [ "$DEPS_ONLY" = false ]; then
 
 # --------------------------------------------------------------------------
 # 1. Homebrew (required foundation)
@@ -131,6 +146,8 @@ else
   warn "gh not authenticated. Run: gh auth login"
 fi
 
+fi
+
 # --------------------------------------------------------------------------
 # 8. Project dependencies
 # --------------------------------------------------------------------------
@@ -196,6 +213,33 @@ install_python_requirements() {
   done
 }
 
+install_uv_if_missing() {
+  if command -v uv >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if command -v brew >/dev/null 2>&1; then
+    warn "Installing uv..."
+    brew install uv 2>/dev/null
+    ok "uv installed"
+    return 0
+  fi
+
+  warn "uv is required for uv.lock/pyproject.toml projects. Install uv first."
+  return 1
+}
+
+install_uv_project() {
+  local label="$1"
+  local project_dir="$2"
+
+  if install_uv_if_missing; then
+    (cd "$project_dir" && uv sync) 2>&1 | tail -1 | while read -r line; do
+      ok "$label dependencies synced: $line"
+    done
+  fi
+}
+
 DEPS_FOUND=false
 
 if [ -f "pnpm-lock.yaml" ]; then
@@ -223,12 +267,24 @@ elif [ -f "package.json" ]; then
   fi
 fi
 
-if [ -f "requirements.txt" ]; then
+if [ -f "uv.lock" ]; then
+  DEPS_FOUND=true
+  install_uv_project "Python" "."
+elif [ -f "pyproject.toml" ] && [ ! -f "requirements.txt" ]; then
+  DEPS_FOUND=true
+  install_uv_project "Python" "."
+elif [ -f "requirements.txt" ]; then
   DEPS_FOUND=true
   install_python_requirements "Python" "requirements.txt" ".venv"
 fi
 
-if [ -f "agent/requirements.txt" ]; then
+if [ -f "agent/uv.lock" ]; then
+  DEPS_FOUND=true
+  install_uv_project "agent Python" "agent"
+elif [ -f "agent/pyproject.toml" ] && [ ! -f "agent/requirements.txt" ]; then
+  DEPS_FOUND=true
+  install_uv_project "agent Python" "agent"
+elif [ -f "agent/requirements.txt" ]; then
   DEPS_FOUND=true
   install_python_requirements "agent Python" "agent/requirements.txt" "agent/.venv"
 fi

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -142,6 +142,37 @@ assert_contains "$PYTEST_WRAPPER_PROJECT/pytest-args.txt" '^pytest$'
 assert_contains "$PYTEST_WRAPPER_PROJECT/pytest-args.txt" '^tests/unit$'
 assert_contains "$PYTEST_WRAPPER_PROJECT/pytest-args.txt" '^-x$'
 
+# setup.sh --deps-only should support uv projects at the repo root and in agent/.
+FAKE_BIN="$TEST_DIR/fake-bin"
+UV_LOG="$TEST_DIR/uv.log"
+mkdir -p "$FAKE_BIN" "$PROJECT/agent"
+cat > "$FAKE_BIN/uv" <<'FAKEUV'
+#!/usr/bin/env bash
+printf '%s|%s\n' "$PWD" "$*" >> "$UV_LOG"
+mkdir -p .venv/bin
+cat > .venv/bin/python <<'FAKEPY'
+#!/usr/bin/env bash
+exit 0
+FAKEPY
+chmod +x .venv/bin/python
+printf 'uv synced\n'
+FAKEUV
+chmod +x "$FAKE_BIN/uv"
+
+printf '[project]\nname = "root-project"\nversion = "0.0.0"\n' > "$PROJECT/pyproject.toml"
+touch "$PROJECT/uv.lock"
+printf '[project]\nname = "agent-project"\nversion = "0.0.0"\n' > "$PROJECT/agent/pyproject.toml"
+printf '3.11\n' > "$PROJECT/agent/.python-version"
+
+(cd "$PROJECT" && PATH="$FAKE_BIN:$PATH" UV_LOG="$UV_LOG" bash setup.sh --deps-only) >/dev/null
+assert_exists "$PROJECT/.venv/bin/python"
+assert_exists "$PROJECT/agent/.venv/bin/python"
+UV_SYNC_COUNT="$(grep -c '|sync$' "$UV_LOG" 2>/dev/null || true)"
+if [ "$UV_SYNC_COUNT" -ne 2 ]; then
+  echo "FAIL: expected setup.sh --deps-only to run uv sync twice, got $UV_SYNC_COUNT" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
 echo ""
 if [ "$ERRORS" -eq 0 ]; then
   echo "==> PASS: all assertions passed"


### PR DESCRIPTION
## Summary
Adds a lightweight setup dependency mode and uv/pyproject support so generated projects can set up Python dependencies without depending on system Python or rerunning full machine bootstrap.

## Changes
- Adds setup.sh --deps-only to skip Homebrew/tool/hook setup and run only project dependency setup.
- Supports uv.lock and pyproject.toml at the repo root via uv sync.
- Supports agent/uv.lock and agent/pyproject.toml via uv sync inside agent/.
- Auto-installs uv with Homebrew when available, otherwise warns clearly.
- Documents --deps-only and the supported Python dependency files.
- Adds bootstrap regression coverage using a fake uv binary to avoid network/package-manager dependency in tests.

## Testing
- [x] bash tests/test-bootstrap.sh
- [x] Full local test sweep across tests/test-*.sh with set -e
- [x] pre-commit run --hook-stage pre-push self-tests
- [x] pre-commit validate-config
- [x] shellcheck -S warning on touched setup/test scripts
- [x] git diff --check
- [x] Pre-push Codex review passed

## Risk
- [x] Medium risk - touches generated setup.sh and bootstrap coverage

## Rollback
Clean revert of this PR commit. No data migration required.