### PR TITLE
Cache clean Codex pre-push reviews

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -50,12 +50,13 @@ Fill in `AGENTS.md` at the repo root with your project-specific review prioritie
 On every `git push`, the pre-push hook:
 
 1. Computes the diff between your branch and the default branch
-2. Sends the diff to Codex with the review prompt + your AGENTS.md rubric
-3. Codex reviews and outputs one of three sentinels:
+2. Skips Codex if the exact same diff and review inputs already passed cleanly
+3. Sends the diff to Codex with the review prompt + your AGENTS.md rubric
+4. Codex reviews and outputs one of three sentinels:
    - `CODEX_REVIEW_CLEAN` — no issues, push proceeds
    - `CODEX_REVIEW_FIXED` — Codex applied auto-fixes, the hook commits them and re-reviews
    - `CODEX_REVIEW_BLOCKED` — Codex found issues it won't auto-fix, push is blocked
-4. The loop repeats up to `max_iterations` times (default 3)
+5. The loop repeats up to `max_iterations` times (default 3)
 
 ## Configuration reference
 
@@ -63,6 +64,7 @@ On every `git push`, the pre-push hook:
 |---------|---------|-------------|
 | `max_iterations` | 3 | Max review-fix-review loops before aborting |
 | `max_diff_lines` | 5000 | Skip review if diff exceeds this |
+| `cache_clean_reviews` | true | Cache exact-input clean reviews under `.git/` to avoid repeat Codex calls |
 | `safe_by_default` | false | Whether unlisted paths allow auto-fix |
 | `unsafe_paths` | [] | Paths where auto-fix is never allowed |
 
@@ -73,12 +75,15 @@ On every `git push`, the pre-push hook:
 | `CODEX_REVIEW_BASE` | Base ref to diff against (default: `origin/<default-branch>`) |
 | `CODEX_REVIEW_MAX_ITERATIONS` | Overrides config file's `max_iterations` |
 | `CODEX_REVIEW_MAX_DIFF_LINES` | Overrides config file's `max_diff_lines` |
+| `CODEX_REVIEW_CACHE_CLEAN` | Overrides `cache_clean_reviews` |
+| `CODEX_REVIEW_DISABLE_CACHE` | Set to `1`/`true` to force a fresh Codex review |
 
 ## Graceful behavior
 
 - If Codex CLI is not installed: skips review, push proceeds
 - If `codex exec` fails (network, auth, quota): skips review, push proceeds
 - If diff exceeds `max_diff_lines`: skips review, push proceeds
+- If the exact diff and review inputs already passed cleanly: skips repeat review, push proceeds
 - If Codex output doesn't match the sentinel contract: skips review, push proceeds
 - If `.codex-review.toml` is missing: all paths treated as unsafe (no auto-fix)
 

--- a/hooks/codex-review.config.example.toml
+++ b/hooks/codex-review.config.example.toml
@@ -12,6 +12,11 @@ max_iterations = 3
 # Very large diffs take too long and produce noisy reviews.
 max_diff_lines = 5000
 
+# Cache exact-input CODEX_REVIEW_CLEAN results locally under .git/.
+# This skips repeated Codex calls when you push the same branch diff again.
+# Set CODEX_REVIEW_DISABLE_CACHE=1 to force a fresh review for one push.
+cache_clean_reviews = true
+
 # Default auto-fix policy for paths not listed in unsafe_paths.
 #   true  = Codex may auto-fix issues in any path not explicitly listed as unsafe
 #   false = Codex will NOT auto-fix anything unless you add safe path logic (conservative)

--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -23,6 +23,8 @@
 #   CODEX_REVIEW_BASE             — base ref to diff against (default: origin/<default-branch>)
 #   CODEX_REVIEW_MAX_ITERATIONS   — fix loop cap (default: from config, or 3)
 #   CODEX_REVIEW_MAX_DIFF_LINES   — skip review if diff > this many lines (default: 5000)
+#   CODEX_REVIEW_CACHE_CLEAN      — cache exact-input clean reviews (default: true)
+#   CODEX_REVIEW_DISABLE_CACHE    — set to true/1 to force a fresh Codex review
 #
 # To bypass entirely in an emergency: git push --no-verify
 #
@@ -44,6 +46,7 @@ cd "$REPO_ROOT"
 SAFE_BY_DEFAULT=false
 MAX_ITERATIONS="${CODEX_REVIEW_MAX_ITERATIONS:-3}"
 MAX_DIFF_LINES="${CODEX_REVIEW_MAX_DIFF_LINES:-5000}"
+CACHE_CLEAN_REVIEWS="${CODEX_REVIEW_CACHE_CLEAN:-true}"
 UNSAFE_PATHS=""
 
 trim() {
@@ -133,6 +136,22 @@ append_unsafe_paths_csv() {
   done
 }
 
+normalize_bool() {
+  local value="$1"
+  value="$(trim "$value")"
+  value="${value%\"}"
+  value="${value#\"}"
+  value="${value%\'}"
+  value="${value#\'}"
+  value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
+
+  case "$value" in
+    true|1|yes|on) printf 'true' ;;
+    false|0|no|off) printf 'false' ;;
+    *) printf '%s' "$value" ;;
+  esac
+}
+
 # Parse .codex-review.toml if it exists.
 # We do minimal TOML parsing in bash — just key = value pairs and string arrays.
 if [ -f "$CONFIG_FILE" ]; then
@@ -159,6 +178,9 @@ if [ -f "$CONFIG_FILE" ]; then
       max_diff_lines*=*)
         MAX_DIFF_LINES="${CODEX_REVIEW_MAX_DIFF_LINES:-$(trim "${line#*=}")}"
         ;;
+      cache_clean_reviews*=*)
+        CACHE_CLEAN_REVIEWS="${CODEX_REVIEW_CACHE_CLEAN:-$(normalize_bool "${line#*=}")}"
+        ;;
       safe_by_default*=*)
         val="$(trim "${line#*=}")"
         val="$(printf '%s' "$val" | tr '[:upper:]' '[:lower:]')"
@@ -178,12 +200,23 @@ if [ -f "$CONFIG_FILE" ]; then
   done < "$CONFIG_FILE"
 fi
 
-# Resolve default branch
-if command -v gh >/dev/null 2>&1; then
-  DEFAULT_BRANCH="$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo main)"
-else
-  DEFAULT_BRANCH="main"
-fi
+resolve_default_branch() {
+  local local_ref
+
+  local_ref="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+  if [ -n "$local_ref" ]; then
+    printf '%s\n' "${local_ref#origin/}"
+    return 0
+  fi
+
+  if command -v gh >/dev/null 2>&1; then
+    gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo main
+  else
+    echo main
+  fi
+}
+
+DEFAULT_BRANCH="$(resolve_default_branch)"
 BASE="${CODEX_REVIEW_BASE:-origin/$DEFAULT_BRANCH}"
 
 # --------------------------------------------------------------------------
@@ -244,8 +277,11 @@ if ! command -v codex >/dev/null 2>&1; then
   exit 0
 fi
 
-# Fetch latest base ref (silent on failure — offline, rebasing, etc.)
-git fetch origin "$DEFAULT_BRANCH" --quiet 2>/dev/null || true
+# Fetch latest base ref for the default review target (silent on failure —
+# offline, rebasing, etc.). If CODEX_REVIEW_BASE is set, trust the caller.
+if [ -z "${CODEX_REVIEW_BASE:-}" ]; then
+  git fetch origin "$DEFAULT_BRANCH" --quiet 2>/dev/null || true
+fi
 
 # Find merge base so we review only this branch's commits.
 if ! MERGE_BASE="$(git merge-base "$BASE" HEAD 2>/dev/null)"; then
@@ -299,6 +335,88 @@ If you emit CODEX_REVIEW_FIXED, briefly describe what you fixed (one line per fi
 
 Do not invent new sentinels. Do not output anything after the sentinel line.
 PROMPT_EOF
+
+# --------------------------------------------------------------------------
+# Clean-review cache
+# --------------------------------------------------------------------------
+
+cache_enabled() {
+  case "$(normalize_bool "${CODEX_REVIEW_DISABLE_CACHE:-false}")" in
+    true) return 1 ;;
+  esac
+
+  case "$(normalize_bool "$CACHE_CLEAN_REVIEWS")" in
+    true) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+hash_stdin() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | awk '{print $1}'
+  else
+    cksum | awk '{print $1 "-" $2}'
+  fi
+}
+
+append_cache_file() {
+  local label="$1"
+  local path="$2"
+
+  printf '\n-- %s --\n' "$label"
+  if [ -f "$path" ]; then
+    cat "$path"
+  else
+    printf '<missing>\n'
+  fi
+}
+
+review_cache_key() {
+  {
+    printf 'toolkit-codex-review-cache-v1\n'
+    printf 'base=%s\n' "$BASE"
+    printf 'merge_base=%s\n' "$MERGE_BASE"
+    printf 'worktree_dirty_before_review=%s\n' "$WORKTREE_DIRTY_BEFORE_REVIEW"
+    printf '\n-- prompt --\n%s\n' "$REVIEW_PROMPT"
+    append_cache_file "AGENTS.md" "$REPO_ROOT/AGENTS.md"
+    append_cache_file "CLAUDE.md" "$REPO_ROOT/CLAUDE.md"
+    append_cache_file ".codex-review.toml" "$CONFIG_FILE"
+    append_cache_file "codex-review.sh" "$0"
+    printf '\n-- branch diff --\n'
+    git diff --binary "$MERGE_BASE"..HEAD
+  } | hash_stdin
+}
+
+clean_review_cache_dir() {
+  git rev-parse --git-path toolkit/codex-review-clean
+}
+
+clean_review_cache_file() {
+  local key="$1"
+  printf '%s/%s.clean' "$(clean_review_cache_dir)" "$key"
+}
+
+write_clean_review_cache() {
+  local key="$1"
+  local line_count="$2"
+  local cache_dir cache_file
+
+  [ -n "$key" ] || return 0
+  cache_dir="$(clean_review_cache_dir)"
+  cache_file="$(clean_review_cache_file "$key")"
+
+  mkdir -p "$cache_dir" 2>/dev/null || return 0
+  {
+    printf 'result=CODEX_REVIEW_CLEAN\n'
+    printf 'base=%s\n' "$BASE"
+    printf 'merge_base=%s\n' "$MERGE_BASE"
+    printf 'head=%s\n' "$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+    printf 'diff_lines=%s\n' "$line_count"
+    printf 'reviewed_at=%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  } > "$cache_file" 2>/dev/null || true
+}
 
 changed_paths() {
   {
@@ -370,6 +488,7 @@ $path"
 # --------------------------------------------------------------------------
 
 FIX_COMMITS=0
+BANNER_PRINTED=false
 
 # Colors (respect NO_COLOR).
 if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
@@ -379,8 +498,10 @@ else
   C_DIM='' C_GREEN='' C_YELLOW='' C_RED='' C_CYAN='' C_RESET=''
 fi
 
-printf "${C_CYAN}"
-cat <<'BANNER'
+print_banner() {
+  [ "$BANNER_PRINTED" = false ] || return 0
+  printf "${C_CYAN}"
+  cat <<'BANNER'
 
   ╔══════════════════════════════════════╗
   ║         ⚡ TOOLKIT REVIEW ⚡        ║
@@ -388,7 +509,9 @@ cat <<'BANNER'
   ╚══════════════════════════════════════╝
 
 BANNER
-printf "${C_RESET}"
+  printf "${C_RESET}"
+  BANNER_PRINTED=true
+}
 
 for iter in $(seq 1 "$MAX_ITERATIONS"); do
   DIFF_LINE_COUNT="$(git diff "$MERGE_BASE"..HEAD | wc -l | tr -d ' ')"
@@ -398,6 +521,17 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
     exit 0
   fi
 
+  REVIEW_CACHE_KEY=""
+  if cache_enabled; then
+    REVIEW_CACHE_KEY="$(review_cache_key 2>/dev/null || true)"
+    if [ -n "$REVIEW_CACHE_KEY" ] && [ -f "$(clean_review_cache_file "$REVIEW_CACHE_KEY")" ]; then
+      echo "==> Codex review previously passed for this exact diff — skipping repeat review."
+      echo "    Force a fresh review with: CODEX_REVIEW_DISABLE_CACHE=1 git push"
+      exit 0
+    fi
+  fi
+
+  print_banner
   printf "  ${C_DIM}iteration ${iter}/${MAX_ITERATIONS} · ${DIFF_LINE_COUNT} lines vs ${BASE}${C_RESET}\n"
 
   set +e
@@ -427,6 +561,7 @@ PASS
         printf "  ${C_DIM}($FIX_COMMITS auto-fix commit(s) applied)${C_RESET}\n"
       fi
       echo ""
+      write_clean_review_cache "$REVIEW_CACHE_KEY" "$DIFF_LINE_COUNT"
       exit 0
       ;;
 

--- a/tests/test-review-hook.sh
+++ b/tests/test-review-hook.sh
@@ -15,6 +15,8 @@ REPO_UNSAFE="$TEST_DIR/repo-unsafe"
 FAKE_BIN="$TEST_DIR/bin"
 PROMPT_FILE="$TEST_DIR/review-prompt.txt"
 PROMPT_HASH_FILE="$TEST_DIR/review-prompt-hash.txt"
+CACHE_OUTPUT="$TEST_DIR/cache-output.txt"
+CODEX_CALLS_FILE="$TEST_DIR/codex-calls.txt"
 UNSAFE_OUTPUT="$TEST_DIR/unsafe-output.txt"
 ERRORS=0
 
@@ -53,6 +55,7 @@ chmod +x "$FAKE_BIN/gh" "$FAKE_BIN/codex"
   PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
     PROMPT_FILE="$PROMPT_FILE" \
     CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
     bash "$TOOLKIT_ROOT/hooks/codex-review.sh" >/dev/null
 )
 
@@ -67,7 +70,70 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
+echo "==> Test: review hook caches exact clean reviews"
+rm -rf "$(cd "$REPO_DIR" && git rev-parse --git-path toolkit/codex-review-clean)"
+cat > "$FAKE_BIN/codex" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'called\n' >> "$CODEX_CALLS_FILE"
+printf 'CODEX_REVIEW_CLEAN\n'
+EOF
+chmod +x "$FAKE_BIN/codex"
+: > "$CODEX_CALLS_FILE"
+
+(
+  cd "$REPO_DIR"
+  PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CODEX_CALLS_FILE="$CODEX_CALLS_FILE" \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    bash "$TOOLKIT_ROOT/hooks/codex-review.sh" >/dev/null
+)
+
+(
+  cd "$REPO_DIR"
+  PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CODEX_CALLS_FILE="$CODEX_CALLS_FILE" \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    bash "$TOOLKIT_ROOT/hooks/codex-review.sh" > "$CACHE_OUTPUT" 2>&1
+)
+
+CODEX_CALL_COUNT="$(wc -l < "$CODEX_CALLS_FILE" | tr -d ' ')"
+if [ "$CODEX_CALL_COUNT" = "1" ] && grep -q 'previously passed for this exact diff' "$CACHE_OUTPUT"; then
+  echo "==> PASS: clean review cache skipped the repeated Codex call"
+else
+  echo "FAIL: expected clean review cache to skip the repeated Codex call" >&2
+  echo "codex call count: $CODEX_CALL_COUNT" >&2
+  cat "$CACHE_OUTPUT" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+(
+  cd "$REPO_DIR"
+  PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CODEX_CALLS_FILE="$CODEX_CALLS_FILE" \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    bash "$TOOLKIT_ROOT/hooks/codex-review.sh" >/dev/null
+)
+
+CODEX_CALL_COUNT="$(wc -l < "$CODEX_CALLS_FILE" | tr -d ' ')"
+if [ "$CODEX_CALL_COUNT" = "2" ]; then
+  echo "==> PASS: CODEX_REVIEW_DISABLE_CACHE forces a fresh review"
+else
+  echo "FAIL: expected CODEX_REVIEW_DISABLE_CACHE to force a fresh review" >&2
+  echo "codex call count: $CODEX_CALL_COUNT" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
 echo "==> Test: review hook preserves # inside quoted unsafe_paths"
+cat > "$FAKE_BIN/codex" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+prompt="${@: -1}"
+printf '%s' "$prompt" > "$PROMPT_FILE"
+printf 'CODEX_REVIEW_CLEAN\n'
+EOF
+chmod +x "$FAKE_BIN/codex"
 {
   printf '[codex_review]\n'
   printf 'safe_by_default = true\n'
@@ -84,6 +150,7 @@ git -C "$REPO_DIR" commit -m "change again" >/dev/null 2>&1
   PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
     PROMPT_FILE="$PROMPT_HASH_FILE" \
     CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
     bash "$TOOLKIT_ROOT/hooks/codex-review.sh" >/dev/null
 )
 


### PR DESCRIPTION
## Summary
- cache exact-input `CODEX_REVIEW_CLEAN` results under Git metadata to avoid repeat Codex calls for the same branch diff
- avoid the `gh repo view` default-branch lookup when `origin/HEAD` is already available
- avoid fetching `origin/<default>` when `CODEX_REVIEW_BASE` is explicitly provided
- document `cache_clean_reviews`, `CODEX_REVIEW_CACHE_CLEAN`, and `CODEX_REVIEW_DISABLE_CACHE`

## Tests
- `bash -n hooks/codex-review.sh tests/test-review-hook.sh`
- `bash tests/test-review-hook.sh`
- `for t in tests/test-*.sh; do echo "==> $t"; bash "$t"; done`
- `pre-commit run --all-files`
- `git diff --check`
- manual temp-repo smoke: first hook run called fake Codex once and wrote one `.git/toolkit/codex-review-clean` cache file; second identical run skipped Codex
- pre-push hook on this branch: Codex review passed; toolkit self-tests passed

## Notes
The cache only stores clean reviews. Blocked, failed, ambiguous, or auto-fixed pre-clean states are not cached. Users can force a fresh review with `CODEX_REVIEW_DISABLE_CACHE=1 git push` or disable the behavior with `cache_clean_reviews = false`.