### PR TITLE
Run Codex at merge and default-branch gates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,11 +15,11 @@ repos:
       - id: no-commit-to-branch
         args: ['--branch', 'main', '--branch', 'master']
 
-  # Codex pre-push review (the toolkit reviews itself)
+  # Codex review for direct pushes to the default branch
   - repo: local
     hooks:
       - id: codex-review
-        name: Codex pre-push review
+        name: Codex default-branch push review
         entry: /usr/bin/env bash hooks/codex-review.sh
         language: system
         stages: [pre-push]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Who You Are on This Project
 
-You are maintaining a shared engineering platform that provides universal principles, reusable scripts, and a Codex pre-push review hook for all of Henry's projects. Changes here propagate to every downstream project via `sync-all.sh`. Quality matters doubly: a bug in the toolkit is a bug in every project that uses it.
+You are maintaining a shared engineering platform that provides universal principles, reusable scripts, and a Codex merge/default-branch review hook for all of Henry's projects. Changes here propagate to every downstream project via `sync-all.sh`. Quality matters doubly: a bug in the toolkit is a bug in every project that uses it.
 
 ## Engineering Principles
 
@@ -20,8 +20,8 @@ You are maintaining a shared engineering platform that provides universal princi
 1. **Pull.** `git pull --rebase` on main before starting work.
 2. **Branch.** `git checkout -b <type>/<short-description>` where `<type>` is one of `feat`, `fix`, `chore`, `refactor`, `docs`.
 3. **Change + commit.** Make the code change, stage explicit file paths, commit with a concise message.
-4. **Push.** `bash scripts/open-pr.sh` (which pushes + creates the PR). The pre-push hook runs Codex review if configured.
-5. **Merge.** `bash scripts/merge-pr.sh <pr-number>` — squash-merge, delete branch, sync main.
+4. **Push.** `bash scripts/open-pr.sh` (which pushes + creates the PR). Feature-branch pushes stay fast.
+5. **Merge.** `bash scripts/merge-pr.sh <pr-number>` — Codex review, squash-merge, delete branch, sync main.
 6. **Clean up.** `git branch -D <feature-branch>` if it still exists locally.
 
 ### Housekeeping
@@ -64,7 +64,7 @@ toolkit/
 | `bootstrap/new-project.sh` | Spin up a new project with all toolkit files |
 | `bootstrap/update-project.sh` | Pull latest toolkit files into an existing project |
 | `bootstrap/sync-all.sh` | Update all registered projects at once |
-| `hooks/codex-review.sh` | Generalized Codex pre-push review + auto-fix hook |
+| `hooks/codex-review.sh` | Generalized Codex merge/default-branch review + auto-fix hook |
 | `VERSION` | Current semver version |
 | `CHANGELOG.md` | Release history |
 | `~/.toolkit-projects` | Registry of all bootstrapped projects |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # toolkit
 
-Shared engineering toolkit — universal principles, reusable scripts, and a Codex pre-push review hook for all your projects.
+Shared engineering toolkit — universal principles, reusable scripts, and a Codex merge/default-branch review hook for all your projects.
 
 ## Install
 
@@ -25,7 +25,7 @@ $EDITOR ~/Repos/my-new-project/AGENTS.md
 cd ~/Repos/my-new-project
 bash setup.sh
 
-# Set up Codex login if you want pre-push AI review
+# Set up Codex login if you want AI review before merging to main
 npm install -g @openai/codex && codex login
 
 # Re-run dependency setup later without reinstalling hooks/tools
@@ -64,9 +64,9 @@ When you run `toolkit new`, these files get copied into your project:
 
 **Toolkit-owned** (auto-updated when you run `toolkit update` or `toolkit sync`):
 - `principles/*.md` — Universal engineering principles
-- `scripts/codex-review.sh` — Codex pre-push review + auto-fix loop
+- `scripts/codex-review.sh` — Codex merge/default-branch review + auto-fix loop
 - `scripts/open-pr.sh` — Push + create PR via `gh`
-- `scripts/merge-pr.sh` — Squash-merge + sync main
+- `scripts/merge-pr.sh` — Codex review + squash-merge + sync main
 - `scripts/cleanup-branches.sh` — Safe branch hygiene
 - `scripts/run-pytest-in-venv.sh` — Run pytest through `.venv` or `agent/.venv`
 
@@ -98,14 +98,15 @@ Universal engineering standards, extracted and battle-tested from production sys
 - **[pre-implementation-checklist.md](principles/pre-implementation-checklist.md)** — 4 questions to answer before writing any code
 - **[audit-weak-points.md](principles/audit-weak-points.md)** — Methodology: find one bug → audit the whole class → ranked fix → guardrail test
 - **[documentation-ownership.md](principles/documentation-ownership.md)** — Single canonical owner per volatile fact
-- **[git-workflow.md](principles/git-workflow.md)** — Feature branch → pre-push review → PR → squash merge
+- **[git-workflow.md](principles/git-workflow.md)** — Feature branch → PR → Codex merge review → squash merge
 
-### Codex pre-push hook
+### Codex Review Gate
 
-Automatically reviews your code before every `git push`:
+Automatically reviews code before it reaches the default branch:
 - Runs `codex exec --full-auto` against your diff
 - Auto-fixes safe issues (typos, missing error logging)
-- Blocks the push for unsafe findings (high-scrutiny paths you configure)
+- Blocks the merge or direct default-branch push for unsafe findings (high-scrutiny paths you configure)
+- Runs from `scripts/merge-pr.sh`, and from the pre-push hook only when pushing directly to the default branch
 - Loops up to N times, gracefully skips if Codex isn't installed
 
 Configure per-project behavior in `.codex-review.toml`. Write your review rubric in `AGENTS.md`. See [hooks/README.md](hooks/README.md) for details.
@@ -113,7 +114,7 @@ Configure per-project behavior in `.codex-review.toml`. Write your review rubric
 ### Helper scripts
 
 - **open-pr.sh** — `git push` + `gh pr create` with your PR template. Idempotent.
-- **merge-pr.sh** — Sanity-check mergeability + squash-merge + delete branch + sync main.
+- **merge-pr.sh** — Sanity-check mergeability + Codex review + squash-merge + delete branch + sync main.
 - **cleanup-branches.sh** — Dry-run by default. Never deletes unmerged work.
 
 ## Project structure
@@ -124,7 +125,7 @@ toolkit/
 ├── lib/             # shared libraries (auto-update)
 ├── principles/      # universal engineering docs
 ├── templates/       # starter files for new projects
-├── hooks/           # Codex pre-push hook
+├── hooks/           # Codex review hook
 ├── scripts/         # helper scripts (open-pr, merge-pr, cleanup)
 ├── bootstrap/       # new-project.sh, update-project.sh, sync-all.sh
 └── tests/           # self-tests

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,6 +1,6 @@
-# Codex Pre-Push Review Hook
+# Codex Review Hook
 
-Automatically reviews your code with [Codex](https://github.com/openai/codex) before every push. Can auto-fix safe issues (typos, missing error logging, etc.) and blocks the push for unsafe findings.
+Reviews your code with [Codex](https://github.com/openai/codex) before it reaches the default branch. Normal feature-branch pushes stay fast; Codex runs from `scripts/merge-pr.sh` and from the pre-push hook only when pushing directly to the default branch.
 
 ## Setup
 
@@ -47,13 +47,13 @@ Fill in `AGENTS.md` at the repo root with your project-specific review prioritie
 
 ## How it works
 
-On every `git push`, the pre-push hook:
+When the review runs, the hook:
 
 1. Computes the diff between your branch and the default branch
 2. Skips Codex if the exact same diff and review inputs already passed cleanly
 3. Sends the diff to Codex with the review prompt + your AGENTS.md rubric
 4. Codex reviews and outputs one of three sentinels:
-   - `CODEX_REVIEW_CLEAN` — no issues, push proceeds
+   - `CODEX_REVIEW_CLEAN` — no issues, operation proceeds
    - `CODEX_REVIEW_FIXED` — Codex applied auto-fixes, the hook commits them and re-reviews
    - `CODEX_REVIEW_BLOCKED` — Codex found issues it won't auto-fix, push is blocked
 5. The loop repeats up to `max_iterations` times (default 3)
@@ -77,13 +77,16 @@ On every `git push`, the pre-push hook:
 | `CODEX_REVIEW_MAX_DIFF_LINES` | Overrides config file's `max_diff_lines` |
 | `CODEX_REVIEW_CACHE_CLEAN` | Overrides `cache_clean_reviews` |
 | `CODEX_REVIEW_DISABLE_CACHE` | Set to `1`/`true` to force a fresh Codex review |
+| `CODEX_REVIEW_FORCE` | Set to `1`/`true` to run on non-default-branch pushes |
+| `CODEX_REVIEW_NO_AUTOFIX` | Set to `1`/`true` for review-only mode |
 
 ## Graceful behavior
 
-- If Codex CLI is not installed: skips review, push proceeds
-- If `codex exec` fails (network, auth, quota): skips review, push proceeds
-- If diff exceeds `max_diff_lines`: skips review, push proceeds
-- If the exact diff and review inputs already passed cleanly: skips repeat review, push proceeds
+- If Codex CLI is not installed: skips review, operation proceeds
+- If pushing a feature branch: skips review, push proceeds
+- If `codex exec` fails (network, auth, quota): skips review, operation proceeds
+- If diff exceeds `max_diff_lines`: skips review, operation proceeds
+- If the exact diff and review inputs already passed cleanly: skips repeat review, operation proceeds
 - If Codex output doesn't match the sentinel contract: skips review, push proceeds
 - If `.codex-review.toml` is missing: all paths treated as unsafe (no auto-fix)
 
@@ -93,6 +96,7 @@ The hook never blocks a push for infrastructure reasons — only for actual code
 
 ```bash
 git push --no-verify
+SKIP_CODEX_REVIEW=1 bash scripts/merge-pr.sh <pr-number>
 ```
 
 The next PR should include an "Emergency-bypass disclosure" section.

--- a/hooks/codex-review.config.example.toml
+++ b/hooks/codex-review.config.example.toml
@@ -1,4 +1,4 @@
-# .codex-review.toml — per-project configuration for the Codex pre-push review hook.
+# .codex-review.toml — per-project configuration for the Codex review hook.
 #
 # Place this file at the repo root. The hook reads it automatically.
 # If this file is missing, the hook uses conservative defaults (all paths unsafe).

--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
-# hooks/codex-review.sh — non-interactive Codex review + auto-fix loop,
-# run as a pre-push hook. Wired into .pre-commit-config.yaml.
+# hooks/codex-review.sh — non-interactive Codex review + auto-fix loop.
+# Wired into merge-pr.sh and default-branch pre-push checks.
 #
 # Loop:
 #   1. Run `codex exec --full-auto` against the local diff vs the default branch
@@ -25,6 +25,8 @@
 #   CODEX_REVIEW_MAX_DIFF_LINES   — skip review if diff > this many lines (default: 5000)
 #   CODEX_REVIEW_CACHE_CLEAN      — cache exact-input clean reviews (default: true)
 #   CODEX_REVIEW_DISABLE_CACHE    — set to true/1 to force a fresh Codex review
+#   CODEX_REVIEW_FORCE            — set to true/1 to run even on non-default-branch pushes
+#   CODEX_REVIEW_NO_AUTOFIX       — set to true/1 for review-only mode
 #
 # To bypass entirely in an emergency: git push --no-verify
 #
@@ -47,6 +49,7 @@ SAFE_BY_DEFAULT=false
 MAX_ITERATIONS="${CODEX_REVIEW_MAX_ITERATIONS:-3}"
 MAX_DIFF_LINES="${CODEX_REVIEW_MAX_DIFF_LINES:-5000}"
 CACHE_CLEAN_REVIEWS="${CODEX_REVIEW_CACHE_CLEAN:-true}"
+NO_AUTOFIX="${CODEX_REVIEW_NO_AUTOFIX:-false}"
 UNSAFE_PATHS=""
 
 trim() {
@@ -218,6 +221,43 @@ resolve_default_branch() {
 
 DEFAULT_BRANCH="$(resolve_default_branch)"
 BASE="${CODEX_REVIEW_BASE:-origin/$DEFAULT_BRANCH}"
+NO_AUTOFIX="$(normalize_bool "$NO_AUTOFIX")"
+
+short_ref_name() {
+  local ref="$1"
+  ref="${ref#refs/heads/}"
+  ref="${ref#refs/remotes/origin/}"
+  printf '%s' "$ref"
+}
+
+is_truthy() {
+  case "$(normalize_bool "${1:-false}")" in
+    true) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_pre_push_hook() {
+  [ "${PRE_COMMIT:-}" = "1" ] && [ -n "${PRE_COMMIT_REMOTE_BRANCH:-}" ]
+}
+
+should_skip_pre_push_review() {
+  local remote_branch default_branch
+
+  is_pre_push_hook || return 1
+  is_truthy "${CODEX_REVIEW_FORCE:-false}" && return 1
+
+  remote_branch="$(short_ref_name "$PRE_COMMIT_REMOTE_BRANCH")"
+  default_branch="$(short_ref_name "$DEFAULT_BRANCH")"
+
+  if [ "$remote_branch" = "$default_branch" ]; then
+    return 1
+  fi
+
+  echo "==> Codex review runs on pushes to $default_branch only — skipping push to $remote_branch."
+  echo "    Force review with: CODEX_REVIEW_FORCE=1 git push"
+  return 0
+}
 
 # --------------------------------------------------------------------------
 # Build the auto-fix policy section of the prompt from config
@@ -225,6 +265,20 @@ BASE="${CODEX_REVIEW_BASE:-origin/$DEFAULT_BRANCH}"
 
 build_autofix_policy() {
   local policy=""
+
+  if [ "$NO_AUTOFIX" = "true" ]; then
+    cat <<'POLICY_EOF'
+Do not edit files in this run. Do not stage, commit, or modify anything.
+
+Review only:
+- If there are no blocking issues, emit CLEAN.
+- If any issue needs a code or documentation change, emit BLOCKED with findings.
+- Do not emit FIXED.
+
+When in doubt, STOP and emit BLOCKED.
+POLICY_EOF
+    return 0
+  fi
 
   if [ "$SAFE_BY_DEFAULT" = "true" ]; then
     policy="By default, all paths are SAFE to auto-fix unless listed as unsafe."
@@ -270,6 +324,12 @@ When in doubt, STOP and emit BLOCKED."
 # Pre-flight checks
 # --------------------------------------------------------------------------
 
+# Feature-branch pushes should stay fast. Manual invocations and direct pushes
+# to the default branch still run the review.
+if should_skip_pre_push_review; then
+  exit 0
+fi
+
 # Graceful skip if Codex CLI not installed.
 if ! command -v codex >/dev/null 2>&1; then
   echo "==> codex CLI not installed — skipping Codex review."
@@ -307,7 +367,7 @@ fi
 AUTOFIX_POLICY="$(build_autofix_policy)"
 
 read -r -d '' REVIEW_PROMPT <<PROMPT_EOF || true
-You are reviewing AND optionally auto-fixing a pull request before it is pushed.
+You are reviewing AND optionally auto-fixing a pull request before it reaches the default branch.
 
 Read AGENTS.md at the repo root for the full review rubric (if it exists).
 Read CLAUDE.md at the repo root for project context (if it exists).
@@ -324,7 +384,7 @@ $AUTOFIX_POLICY
 
 The LAST line of your output must be exactly one of these three sentinels (no extra characters, no trailing whitespace):
 
-- CODEX_REVIEW_CLEAN — no blocking issues found, push should proceed
+- CODEX_REVIEW_CLEAN — no blocking issues found, operation should proceed
 - CODEX_REVIEW_FIXED — you applied auto-fixes, script will commit and re-review
 - CODEX_REVIEW_BLOCKED — you found blocking issues you cannot/should not auto-fix
 
@@ -505,7 +565,7 @@ print_banner() {
 
   ╔══════════════════════════════════════╗
   ║         ⚡ TOOLKIT REVIEW ⚡        ║
-  ║      Codex pre-push code review      ║
+  ║        Codex merge code review       ║
   ╚══════════════════════════════════════╝
 
 BANNER
@@ -566,6 +626,13 @@ PASS
       ;;
 
     CODEX_REVIEW_FIXED)
+      if [ "$NO_AUTOFIX" = "true" ]; then
+        echo "==> Codex emitted FIXED during review-only mode."
+        echo "    Treating this as blocking because CODEX_REVIEW_NO_AUTOFIX=1 was set."
+        echo "    Inspect the working tree before continuing."
+        exit 1
+      fi
+
       AUTOFIX_CHANGED_PATHS="$(changed_paths)"
       if [ -z "$AUTOFIX_CHANGED_PATHS" ]; then
         echo "==> Codex emitted FIXED but no working-tree changes detected."

--- a/principles/README.md
+++ b/principles/README.md
@@ -8,4 +8,4 @@ Universal engineering standards that apply to all projects. These are imported b
 | [pre-implementation-checklist.md](pre-implementation-checklist.md) | 4 questions to answer before writing any code |
 | [audit-weak-points.md](audit-weak-points.md) | Methodology for auditing structural bug patterns |
 | [documentation-ownership.md](documentation-ownership.md) | Single canonical owner per volatile fact |
-| [git-workflow.md](git-workflow.md) | Feature branch lifecycle with pre-push review |
+| [git-workflow.md](git-workflow.md) | Feature branch lifecycle with merge/default-branch review |

--- a/principles/git-workflow.md
+++ b/principles/git-workflow.md
@@ -7,9 +7,9 @@ Every code change goes through a feature branch + PR + merge. No exceptions for 
 1. **Pull.** `git pull --rebase` on the default branch before starting work.
 2. **Branch.** `git checkout -b <type>/<short-description>` where `<type>` is one of `feat`, `fix`, `chore`, `refactor`, `docs`.
 3. **Change + commit.** Make the code change, stage explicit file paths (not `git add -A`), commit with a concise message.
-4. **Push.** `git push -u origin HEAD` or use `scripts/open-pr.sh`. If a pre-push Codex review hook is configured, it runs automatically and may apply auto-fixes or block the push with findings.
+4. **Push.** `git push -u origin HEAD` or use `scripts/open-pr.sh`. Feature-branch pushes should stay fast; Codex review is reserved for merge/default-branch gates.
 5. **Open the PR.** `scripts/open-pr.sh` creates the PR with the project's PR template attached. Idempotent — rerunning on a branch that already has a PR just prints the URL.
-6. **Merge.** `scripts/merge-pr.sh <pr-number>` — sanity-checks mergeability, squash-merges, deletes the remote branch, pulls the updated default branch locally.
+6. **Merge.** `scripts/merge-pr.sh <pr-number>` — sanity-checks mergeability, runs Codex review, squash-merges, deletes the remote branch, pulls the updated default branch locally.
 7. **Clean up.** Delete the local feature branch. Run `scripts/cleanup-branches.sh` periodically for batch hygiene.
 
 ## Commit discipline
@@ -18,12 +18,12 @@ Every code change goes through a feature branch + PR + merge. No exceptions for 
 - Logically grouped changes. One concern per commit where practical.
 - Stage explicit file paths, not `git add -A` or `git add .` — this prevents accidentally staging sensitive files (.env, credentials) or large binaries.
 
-## Pre-push review (optional, recommended)
+## Codex merge review (optional, recommended)
 
-If the project has Codex review configured (see `hooks/codex-review.sh` and `.codex-review.toml`), the pre-push hook:
+If the project has Codex review configured (see `hooks/codex-review.sh` and `.codex-review.toml`), the merge/default-branch review gate:
 - Runs `codex exec --full-auto` against the diff vs the default branch
 - Auto-fixes safe findings (typos, missing error logging, etc.)
-- Blocks the push for unsafe findings (high-scrutiny paths)
+- Blocks the merge or direct default-branch push for unsafe findings (high-scrutiny paths)
 - Loops up to `max_iterations` times (default 3)
 - Gracefully skips if the Codex CLI isn't installed
 

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -7,8 +7,9 @@
 #
 # What this does:
 #   1. Verifies the PR is open and mergeable.
-#   2. Squash-merges and deletes the remote branch.
-#   3. Checks out the default branch and pulls the updated state.
+#   2. Runs Codex review as a merge gate.
+#   3. Squash-merges and deletes the remote branch.
+#   4. Checks out the default branch and pulls the updated state.
 #
 # Exit codes:
 #   0 — merged cleanly
@@ -18,6 +19,9 @@
 set -euo pipefail
 
 PR_NUMBER="${1:-}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REVIEW_SCRIPT="$SCRIPT_DIR/codex-review.sh"
+REVIEWED_HEAD_OID=""
 
 if [ -z "$PR_NUMBER" ] || ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
   echo "Usage: bash scripts/merge-pr.sh <pr-number>" >&2
@@ -32,8 +36,88 @@ fi
 # Resolve the default branch.
 DEFAULT_BRANCH="$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo main)"
 
+truthy() {
+  case "$(printf '%s' "${1:-false}" | tr '[:upper:]' '[:lower:]')" in
+    true|1|yes|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+run_codex_merge_review() {
+  local current_branch default_base_ref local_head pr_head_branch pr_head_oid
+
+  if ! pr_head_branch="$(gh pr view "$PR_NUMBER" --json headRefName --jq '.headRefName' 2>/dev/null)"; then
+    echo "ERROR: Failed to resolve PR #$PR_NUMBER head branch." >&2
+    exit 1
+  fi
+  if ! pr_head_oid="$(gh pr view "$PR_NUMBER" --json headRefOid --jq '.headRefOid' 2>/dev/null)"; then
+    echo "ERROR: Failed to resolve PR #$PR_NUMBER head commit." >&2
+    exit 1
+  fi
+  if [ -z "$pr_head_branch" ]; then
+    echo "ERROR: PR #$PR_NUMBER head branch is empty." >&2
+    exit 1
+  fi
+  if [ -z "$pr_head_oid" ]; then
+    echo "ERROR: PR #$PR_NUMBER head commit is empty." >&2
+    exit 1
+  fi
+
+  REVIEWED_HEAD_OID="$pr_head_oid"
+
+  if truthy "${SKIP_CODEX_REVIEW:-false}"; then
+    echo "==> Skipping Codex merge review because SKIP_CODEX_REVIEW is set."
+    return 0
+  fi
+
+  if [ ! -f "$REVIEW_SCRIPT" ]; then
+    echo "==> Codex review script not found at $REVIEW_SCRIPT — skipping review."
+    return 0
+  fi
+
+  default_base_ref="origin/$DEFAULT_BRANCH"
+  echo "==> Refreshing $default_base_ref for Codex review ..."
+  if ! git fetch origin "+refs/heads/$DEFAULT_BRANCH:refs/remotes/origin/$DEFAULT_BRANCH"; then
+    echo "ERROR: Failed to refresh $default_base_ref before Codex review." >&2
+    exit 1
+  fi
+  if ! git rev-parse --verify --quiet "$default_base_ref^{commit}" >/dev/null; then
+    echo "ERROR: Could not verify $default_base_ref before Codex review." >&2
+    exit 1
+  fi
+
+  if [ -n "$(git status --porcelain)" ]; then
+    echo "ERROR: Working tree has uncommitted changes; refusing to run Codex review against an ambiguous tree." >&2
+    exit 1
+  fi
+
+  current_branch="$(git rev-parse --abbrev-ref HEAD)"
+  local_head="$(git rev-parse HEAD)"
+  if [ "$current_branch" != "$pr_head_branch" ] || [ "$local_head" != "$pr_head_oid" ]; then
+    echo "==> Checking out PR #$PR_NUMBER head ($pr_head_branch) for Codex review ..."
+    gh pr checkout "$PR_NUMBER" --detach
+    local_head="$(git rev-parse HEAD)"
+  fi
+
+  if [ "$local_head" != "$pr_head_oid" ]; then
+    echo "ERROR: Local review checkout does not match PR #$PR_NUMBER head commit." >&2
+    echo "       expected: $pr_head_oid" >&2
+    echo "       actual:   $local_head" >&2
+    exit 1
+  fi
+
+  echo "==> Running Codex merge review ..."
+  CODEX_REVIEW_BASE="$default_base_ref" \
+    CODEX_REVIEW_FORCE=1 \
+    CODEX_REVIEW_NO_AUTOFIX=1 \
+    bash "$REVIEW_SCRIPT"
+}
+
 # 1. Sanity check the PR exists and is open.
-PR_STATE="$(gh pr view "$PR_NUMBER" --json state --jq '.state' 2>/dev/null || echo "")"
+if ! PR_STATE="$(gh pr view "$PR_NUMBER" --json state --jq '.state')"; then
+  echo "ERROR: Failed to inspect PR #$PR_NUMBER state with gh." >&2
+  exit 1
+fi
 if [ "$PR_STATE" != "OPEN" ]; then
   echo "ERROR: PR #$PR_NUMBER is not open (state: $PR_STATE)." >&2
   exit 1
@@ -67,11 +151,18 @@ if [ "$STATE" != "CLEAN" ] || [ "$MERGEABLE" != "MERGEABLE" ]; then
   exit 1
 fi
 
-# 3. Squash-merge and delete the branch.
-echo "==> Squash-merging PR #$PR_NUMBER ..."
-gh pr merge "$PR_NUMBER" --squash --delete-branch
+# 3. Run Codex as the merge gate.
+run_codex_merge_review
 
-# 4. Sync local default branch.
+# 4. Squash-merge and delete the branch.
+echo "==> Squash-merging PR #$PR_NUMBER ..."
+if [ -z "$REVIEWED_HEAD_OID" ]; then
+  echo "ERROR: Cannot merge PR #$PR_NUMBER because no reviewed head commit was recorded." >&2
+  exit 1
+fi
+gh pr merge "$PR_NUMBER" --squash --delete-branch --match-head-commit "$REVIEWED_HEAD_OID"
+
+# 5. Sync local default branch.
 echo "==> Merged. Updating local $DEFAULT_BRANCH ..."
 CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 if [ "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" ]; then

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -20,8 +20,8 @@
 1. **Pull.** `git pull --rebase` on the default branch before starting work.
 2. **Branch.** `git checkout -b <type>/<short-description>` where `<type>` is one of `feat`, `fix`, `chore`, `refactor`, `docs`.
 3. **Change + commit.** Make the code change, stage explicit file paths, commit with a concise message.
-4. **Push.** `bash scripts/open-pr.sh` (which pushes + creates the PR). The pre-push hook runs Codex review if configured.
-5. **Merge.** `bash scripts/merge-pr.sh <pr-number>` — squash-merge, delete branch, sync default branch.
+4. **Push.** `bash scripts/open-pr.sh` (which pushes + creates the PR). Feature-branch pushes stay fast.
+5. **Merge.** `bash scripts/merge-pr.sh <pr-number>` — Codex review, squash-merge, delete branch, sync default branch.
 6. **Clean up.** `git branch -D <feature-branch>` if it still exists locally.
 
 ### Housekeeping

--- a/templates/pre-commit-config.yaml
+++ b/templates/pre-commit-config.yaml
@@ -3,7 +3,7 @@
 #
 # Hooks run at two stages:
 #   pre-commit: fast checks on every commit (formatting, secrets, file hygiene)
-#   pre-push:   heavier checks before pushing (Codex review, tests)
+#   pre-push:   fast branch checks; Codex review only runs for default-branch pushes
 
 repos:
   # ── Standard file hygiene ──────────────────────────────────────────────
@@ -55,11 +55,11 @@ repos:
         always_run: true
         pass_filenames: false
 
-  # ── Codex pre-push review ──────────────────────────────────────────────
+  # ── Codex default-branch push review ───────────────────────────────────
   - repo: local
     hooks:
       - id: codex-review
-        name: Codex pre-push review
+        name: Codex default-branch push review
         entry: /usr/bin/env bash scripts/codex-review.sh
         language: system
         stages: [pre-push]

--- a/tests/test-merge-pr.sh
+++ b/tests/test-merge-pr.sh
@@ -11,7 +11,19 @@ trap 'rm -rf "$TEST_DIR"' EXIT
 echo "==> Test: merge script works without jq in PATH"
 
 FAKE_BIN="$TEST_DIR/bin"
-mkdir -p "$FAKE_BIN"
+MERGE_SCRIPT_DIR="$TEST_DIR/scripts"
+mkdir -p "$FAKE_BIN" "$MERGE_SCRIPT_DIR"
+cp "$TOOLKIT_ROOT/scripts/merge-pr.sh" "$MERGE_SCRIPT_DIR/merge-pr.sh"
+cat > "$MERGE_SCRIPT_DIR/codex-review.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+{
+  printf 'CODEX_REVIEW_BASE=%s\n' "${CODEX_REVIEW_BASE:-}"
+  printf 'CODEX_REVIEW_FORCE=%s\n' "${CODEX_REVIEW_FORCE:-}"
+  printf 'CODEX_REVIEW_NO_AUTOFIX=%s\n' "${CODEX_REVIEW_NO_AUTOFIX:-}"
+} > "$CODEX_REVIEW_LOG"
+EOF
+chmod +x "$MERGE_SCRIPT_DIR/merge-pr.sh" "$MERGE_SCRIPT_DIR/codex-review.sh"
 
 cat > "$FAKE_BIN/gh" <<'EOF'
 #!/usr/bin/env bash
@@ -24,6 +36,10 @@ case "$1 $2" in
   "pr view")
     if [ "$5" = "state" ]; then
       echo "OPEN"
+    elif [ "$5" = "headRefName" ]; then
+      echo "feature/test"
+    elif [ "$5" = "headRefOid" ]; then
+      echo "pr-head-oid"
     elif [ "$5" = "mergeStateStatus,mergeable" ]; then
       echo "CLEAN MERGEABLE"
     else
@@ -31,7 +47,20 @@ case "$1 $2" in
       exit 1
     fi
     ;;
+  "pr checkout")
+    if [ "${4:-}" != "--detach" ]; then
+      echo "unexpected gh pr checkout args: $*" >&2
+      exit 1
+    fi
+    echo "checked-out" > "$GH_CHECKOUT_FILE"
+    echo "checked out PR $3"
+    ;;
   "pr merge")
+    if [ "$4 $5 $6 $7" != "--squash --delete-branch --match-head-commit pr-head-oid" ]; then
+      echo "unexpected gh pr merge args: $*" >&2
+      exit 1
+    fi
+    echo "$7" > "$GH_MERGE_HEAD_FILE"
     echo "merged"
     ;;
   *)
@@ -45,14 +74,33 @@ cat > "$FAKE_BIN/git" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
-case "$1 $2 ${3:-}" in
+case "$*" in
   "rev-parse --abbrev-ref HEAD")
-    echo "feature/test"
+    if [ -f "$GH_CHECKOUT_FILE" ]; then
+      echo "HEAD"
+    else
+      echo "feature/test"
+    fi
     ;;
-  "checkout main ")
+  "rev-parse HEAD")
+    if [ -f "$GH_CHECKOUT_FILE" ]; then
+      echo "pr-head-oid"
+    else
+      echo "stale-local-oid"
+    fi
+    ;;
+  "fetch origin +refs/heads/main:refs/remotes/origin/main")
+    echo "fetched main"
+    ;;
+  "rev-parse --verify --quiet origin/main^{commit}")
+    echo "base-oid"
+    ;;
+  "status --porcelain")
+    ;;
+  "checkout main")
     echo "Switched to branch 'main'"
     ;;
-  "pull --rebase ")
+  "pull --rebase")
     echo "Already up to date."
     ;;
   *)
@@ -65,11 +113,25 @@ EOF
 chmod +x "$FAKE_BIN/gh" "$FAKE_BIN/git"
 
 OUTPUT_FILE="$TEST_DIR/output.txt"
+CODEX_REVIEW_LOG="$TEST_DIR/codex-review.log"
+GH_CHECKOUT_FILE="$TEST_DIR/gh-checkout"
+GH_MERGE_HEAD_FILE="$TEST_DIR/gh-merge-head"
 PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
-  bash "$TOOLKIT_ROOT/scripts/merge-pr.sh" 123 >"$OUTPUT_FILE" 2>&1
+  CODEX_REVIEW_LOG="$CODEX_REVIEW_LOG" \
+  GH_CHECKOUT_FILE="$GH_CHECKOUT_FILE" \
+  GH_MERGE_HEAD_FILE="$GH_MERGE_HEAD_FILE" \
+  bash "$MERGE_SCRIPT_DIR/merge-pr.sh" 123 >"$OUTPUT_FILE" 2>&1
 
 if grep -q 'attempt 1: mergeStateStatus=CLEAN mergeable=MERGEABLE' "$OUTPUT_FILE" \
-  && grep -q '==> Done\.' "$OUTPUT_FILE"; then
+  && grep -q '==> Refreshing origin/main for Codex review' "$OUTPUT_FILE" \
+  && grep -q '==> Checking out PR #123 head (feature/test) for Codex review' "$OUTPUT_FILE" \
+  && grep -q '==> Running Codex merge review' "$OUTPUT_FILE" \
+  && grep -q '==> Done\.' "$OUTPUT_FILE" \
+  && grep -q '^checked-out$' "$GH_CHECKOUT_FILE" \
+  && grep -q '^pr-head-oid$' "$GH_MERGE_HEAD_FILE" \
+  && grep -q '^CODEX_REVIEW_BASE=origin/main$' "$CODEX_REVIEW_LOG" \
+  && grep -q '^CODEX_REVIEW_FORCE=1$' "$CODEX_REVIEW_LOG" \
+  && grep -q '^CODEX_REVIEW_NO_AUTOFIX=1$' "$CODEX_REVIEW_LOG"; then
   echo "==> PASS: merge-pr.sh completed without jq"
   exit 0
 fi

--- a/tests/test-review-hook.sh
+++ b/tests/test-review-hook.sh
@@ -20,6 +20,12 @@ CODEX_CALLS_FILE="$TEST_DIR/codex-calls.txt"
 UNSAFE_OUTPUT="$TEST_DIR/unsafe-output.txt"
 ERRORS=0
 
+unset PRE_COMMIT
+unset PRE_COMMIT_FROM_REF PRE_COMMIT_TO_REF
+unset PRE_COMMIT_LOCAL_BRANCH PRE_COMMIT_REMOTE_BRANCH
+unset PRE_COMMIT_REMOTE_NAME PRE_COMMIT_REMOTE_URL
+unset CODEX_REVIEW_FORCE CODEX_REVIEW_NO_AUTOFIX CODEX_REVIEW_DISABLE_CACHE
+
 mkdir -p "$REPO_DIR" "$FAKE_BIN"
 git -C "$REPO_DIR" init >/dev/null 2>&1
 git -C "$REPO_DIR" config user.name "Toolkit Test"
@@ -67,6 +73,59 @@ if grep -q -- '- Anything in bootstrap/new-project.sh' "$PROMPT_FILE" \
 else
   echo "FAIL: expected multiline unsafe_paths to appear in the generated prompt" >&2
   sed -n '1,120p' "$PROMPT_FILE" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo "==> Test: review hook skips feature-branch pushes but runs default-branch pushes"
+cat > "$FAKE_BIN/codex" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'called\n' >> "$CODEX_CALLS_FILE"
+printf 'CODEX_REVIEW_CLEAN\n'
+EOF
+chmod +x "$FAKE_BIN/codex"
+: > "$CODEX_CALLS_FILE"
+
+(
+  cd "$REPO_DIR"
+  PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CODEX_CALLS_FILE="$CODEX_CALLS_FILE" \
+    PRE_COMMIT=1 \
+    PRE_COMMIT_LOCAL_BRANCH="refs/heads/feature/test" \
+    PRE_COMMIT_REMOTE_BRANCH="refs/heads/feature/test" \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    bash "$TOOLKIT_ROOT/hooks/codex-review.sh" > "$TEST_DIR/feature-push-output.txt" 2>&1
+)
+
+CODEX_CALL_COUNT="$(wc -l < "$CODEX_CALLS_FILE" | tr -d ' ')"
+if [ "$CODEX_CALL_COUNT" = "0" ] && grep -q 'skipping push to feature/test' "$TEST_DIR/feature-push-output.txt"; then
+  echo "==> PASS: feature-branch push skipped Codex"
+else
+  echo "FAIL: expected feature-branch push to skip Codex" >&2
+  echo "codex call count: $CODEX_CALL_COUNT" >&2
+  cat "$TEST_DIR/feature-push-output.txt" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+(
+  cd "$REPO_DIR"
+  PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CODEX_CALLS_FILE="$CODEX_CALLS_FILE" \
+    PRE_COMMIT=1 \
+    PRE_COMMIT_LOCAL_BRANCH="refs/heads/main" \
+    PRE_COMMIT_REMOTE_BRANCH="refs/heads/main" \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    bash "$TOOLKIT_ROOT/hooks/codex-review.sh" >/dev/null
+)
+
+CODEX_CALL_COUNT="$(wc -l < "$CODEX_CALLS_FILE" | tr -d ' ')"
+if [ "$CODEX_CALL_COUNT" = "1" ]; then
+  echo "==> PASS: default-branch push ran Codex"
+else
+  echo "FAIL: expected default-branch push to run Codex" >&2
+  echo "codex call count: $CODEX_CALL_COUNT" >&2
   ERRORS=$((ERRORS + 1))
 fi
 


### PR DESCRIPTION
## Summary
- make feature-branch pushes skip Codex review by default
- keep Codex review on direct pushes to the default branch
- run Codex from `scripts/merge-pr.sh` before squash-merge, in review-only mode
- add `CODEX_REVIEW_FORCE` and `CODEX_REVIEW_NO_AUTOFIX` controls
- update docs/templates to describe the merge/default-branch gate model

## Tests
- `bash -n hooks/codex-review.sh scripts/merge-pr.sh tests/test-review-hook.sh tests/test-merge-pr.sh`
- `bash tests/test-review-hook.sh`
- `bash tests/test-merge-pr.sh`
- `for t in tests/test-*.sh; do echo "==> $t"; bash "$t"; done`
- `pre-commit run --all-files`
- `git diff --check`
- pre-push hook on this branch: Codex default-branch push review passed quickly on feature branch; toolkit self-tests passed

## Notes
This keeps normal iteration fast while still reviewing code before it reaches `main`. Direct default-branch pushes still trigger Codex through pre-push, and `merge-pr.sh` runs the review gate before merging PRs.