### PR TITLE
Prevent nested Codex review runs

### DIFF
--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -27,6 +27,7 @@
 #   CODEX_REVIEW_DISABLE_CACHE    — set to true/1 to force a fresh Codex review
 #   CODEX_REVIEW_FORCE            — set to true/1 to run even on non-default-branch pushes
 #   CODEX_REVIEW_NO_AUTOFIX       — set to true/1 for review-only mode
+#   CODEX_REVIEW_IN_PROGRESS      — internal guard to skip nested Codex hook runs
 #
 # To bypass entirely in an emergency: git push --no-verify
 #
@@ -326,6 +327,11 @@ When in doubt, STOP and emit BLOCKED."
 
 # Feature-branch pushes should stay fast. Manual invocations and direct pushes
 # to the default branch still run the review.
+if is_truthy "${CODEX_REVIEW_IN_PROGRESS:-false}"; then
+  echo "==> Codex review already in progress — skipping nested Codex review."
+  exit 0
+fi
+
 if should_skip_pre_push_review; then
   exit 0
 fi
@@ -595,7 +601,7 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
   printf "  ${C_DIM}iteration ${iter}/${MAX_ITERATIONS} · ${DIFF_LINE_COUNT} lines vs ${BASE}${C_RESET}\n"
 
   set +e
-  OUTPUT="$(codex exec --full-auto --ephemeral "$REVIEW_PROMPT" 2>/dev/null)"
+  OUTPUT="$(CODEX_REVIEW_IN_PROGRESS=1 codex exec --full-auto --ephemeral "$REVIEW_PROMPT" 2>/dev/null)"
   EXIT=$?
   set -e
 

--- a/tests/test-review-hook.sh
+++ b/tests/test-review-hook.sh
@@ -25,6 +25,7 @@ unset PRE_COMMIT_FROM_REF PRE_COMMIT_TO_REF
 unset PRE_COMMIT_LOCAL_BRANCH PRE_COMMIT_REMOTE_BRANCH
 unset PRE_COMMIT_REMOTE_NAME PRE_COMMIT_REMOTE_URL
 unset CODEX_REVIEW_FORCE CODEX_REVIEW_NO_AUTOFIX CODEX_REVIEW_DISABLE_CACHE
+unset CODEX_REVIEW_IN_PROGRESS
 
 mkdir -p "$REPO_DIR" "$FAKE_BIN"
 git -C "$REPO_DIR" init >/dev/null 2>&1
@@ -129,8 +130,31 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
+echo "==> Test: review hook skips nested Codex review subprocesses"
+: > "$CODEX_CALLS_FILE"
+
+(
+  cd "$REPO_DIR"
+  PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CODEX_CALLS_FILE="$CODEX_CALLS_FILE" \
+    CODEX_REVIEW_IN_PROGRESS=1 \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    bash "$TOOLKIT_ROOT/hooks/codex-review.sh" > "$TEST_DIR/nested-review-output.txt" 2>&1
+)
+
+CODEX_CALL_COUNT="$(wc -l < "$CODEX_CALLS_FILE" | tr -d ' ')"
+if [ "$CODEX_CALL_COUNT" = "0" ] && grep -q 'skipping nested Codex review' "$TEST_DIR/nested-review-output.txt"; then
+  echo "==> PASS: nested Codex review skipped"
+else
+  echo "FAIL: expected nested Codex review to skip Codex" >&2
+  echo "codex call count: $CODEX_CALL_COUNT" >&2
+  cat "$TEST_DIR/nested-review-output.txt" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
 echo "==> Test: review hook caches exact clean reviews"
-rm -rf "$(cd "$REPO_DIR" && git rev-parse --git-path toolkit/codex-review-clean)"
+rm -rf "$(git -C "$REPO_DIR" rev-parse --absolute-git-dir)/toolkit/codex-review-clean"
 cat > "$FAKE_BIN/codex" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
