### PR TITLE
Address all 7 audit feedback items

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,9 +20,8 @@ You are maintaining a shared engineering platform that provides universal princi
 1. **Pull.** `git pull --rebase` on main before starting work.
 2. **Branch.** `git checkout -b <type>/<short-description>` where `<type>` is one of `feat`, `fix`, `chore`, `refactor`, `docs`.
 3. **Change + commit.** Make the code change, stage explicit file paths, commit with a concise message.
-4. **Push.** `bash scripts/open-pr.sh` (which pushes + creates the PR). Feature-branch pushes stay fast.
-5. **Merge.** `bash scripts/merge-pr.sh <pr-number>` — Codex review, squash-merge, delete branch, sync main.
-6. **Clean up.** `git branch -D <feature-branch>` if it still exists locally.
+4. **Ship.** `bash scripts/open-pr.sh --auto-merge` — pushes, creates the PR, runs Codex review, squash-merges, and syncs main in one step.
+5. **Clean up.** `git branch -D <feature-branch>` if it still exists locally.
 
 ### Housekeeping
 

--- a/bin/toolkit
+++ b/bin/toolkit
@@ -4,7 +4,8 @@
 #
 # Usage:
 #   toolkit new <project-dir>          Create a new project with toolkit files
-#   toolkit init [--no-setup]          Add toolkit to the current project
+#   toolkit init [--no-setup] [--type python|node|swift|generic]
+#                                      Add toolkit to the current project
 #   toolkit update                     Update current project to latest toolkit
 #   toolkit update --dry-run           Show what would change without applying
 #   toolkit sync                       Update all registered projects
@@ -66,6 +67,16 @@ escape_sed_replacement() {
   printf '%s' "$1" | sed 's/[\\/&]/\\&/g'
 }
 
+# Drift nudge: if cwd is a toolkit project that's behind, print a one-liner.
+if [ -f ".toolkit-version" ]; then
+  _proj_id="$(cat .toolkit-version 2>/dev/null | tr -d '[:space:]')"
+  _current_id="$(toolkit_current_id)"
+  if [ -n "$_proj_id" ] && [ -n "$_current_id" ] && [ "$_proj_id" != "$_current_id" ]; then
+    printf "${DIM}toolkit: this project needs sync (run: toolkit update)${RESET}\n" >&2
+  fi
+  unset _proj_id _current_id
+fi
+
 # --------------------------------------------------------------------------
 # Subcommands
 # --------------------------------------------------------------------------
@@ -97,8 +108,16 @@ cmd_init() {
         shift
         ;;
       -h|--help)
-        echo "Usage: toolkit init [--no-setup] [--no-register] [--unsafe-paths path1,path2]"
+        echo "Usage: toolkit init [--no-setup] [--type TYPE] [--no-register] [--unsafe-paths path1,path2]"
         return 0
+        ;;
+      --type)
+        if [ "$#" -lt 2 ]; then
+          echo "ERROR: --type requires a value (python, node, swift, generic)" >&2
+          exit 1
+        fi
+        args+=("$1" "$2")
+        shift 2
         ;;
       --no-register)
         args+=("$1")
@@ -502,6 +521,129 @@ cmd_adr() {
   esac
 }
 
+cmd_skills() {
+  local subcmd="${1:-list}"
+
+  case "$subcmd" in
+    list)
+      tk_header "Claude Code Skills"
+
+      local found=false
+
+      # Project-level skills.
+      if [ -d ".claude/skills" ]; then
+        for skill_dir in .claude/skills/*/; do
+          [ -d "$skill_dir" ] || continue
+          found=true
+          local name
+          name="$(basename "$skill_dir")"
+          local status=""
+          if [ -L "$skill_dir" ]; then
+            local target
+            target="$(readlink "$skill_dir")"
+            status="${DIM}symlink → $target${RESET}"
+          else
+            status="${DIM}local${RESET}"
+          fi
+          if [ -f "${skill_dir}SKILL.md" ]; then
+            printf "  ${GREEN}✓${RESET} ${BOLD}%-25s${RESET} project   %b\n" "$name" "$status"
+          else
+            printf "  ${RED}✗${RESET} ${BOLD}%-25s${RESET} project   %b ${RED}(missing SKILL.md)${RESET}\n" "$name" "$status"
+          fi
+        done
+      fi
+
+      # User-level skills.
+      if [ -d "$HOME/.claude/skills" ]; then
+        for skill_dir in "$HOME/.claude/skills"/*/; do
+          [ -d "$skill_dir" ] || continue
+          found=true
+          local name
+          name="$(basename "$skill_dir")"
+          local status=""
+          if [ -L "$skill_dir" ]; then
+            local target
+            target="$(readlink "$skill_dir")"
+            status="${DIM}symlink → $target${RESET}"
+          else
+            status="${DIM}standalone (no symlink)${RESET}"
+          fi
+          if [ -f "${skill_dir}SKILL.md" ]; then
+            printf "  ${GREEN}✓${RESET} ${BOLD}%-25s${RESET} user      %b\n" "$name" "$status"
+          else
+            printf "  ${RED}✗${RESET} ${BOLD}%-25s${RESET} user      %b ${RED}(missing SKILL.md)${RESET}\n" "$name" "$status"
+          fi
+        done
+      fi
+
+      if [ "$found" = false ]; then
+        tk_dim "No skills found."
+        tk_dim "Project skills:  .claude/skills/<name>/SKILL.md"
+        tk_dim "User skills:     ~/.claude/skills/<name>/SKILL.md"
+      fi
+      echo ""
+      ;;
+
+    check)
+      tk_header "Skill Validation"
+
+      local issues=0
+      local checked=0
+      local dirs=()
+
+      if [ -d ".claude/skills" ]; then
+        for d in .claude/skills/*/; do [ -d "$d" ] && dirs+=("$d"); done
+      fi
+      if [ -d "$HOME/.claude/skills" ]; then
+        for d in "$HOME/.claude/skills"/*/; do [ -d "$d" ] && dirs+=("$d"); done
+      fi
+
+      if [ "${#dirs[@]}" -eq 0 ]; then
+        tk_dim "No skills found."
+        echo ""
+        return
+      fi
+
+      for skill_dir in "${dirs[@]}"; do
+        checked=$((checked + 1))
+        local name
+        name="$(basename "$skill_dir")"
+        local skill_file="${skill_dir}SKILL.md"
+
+        if [ ! -f "$skill_file" ]; then
+          tk_fail "$name — missing SKILL.md"
+          issues=$((issues + 1))
+          continue
+        fi
+
+        # Check frontmatter exists.
+        if ! head -1 "$skill_file" | grep -q '^---$'; then
+          tk_fail "$name — SKILL.md missing frontmatter (no leading ---)"
+          issues=$((issues + 1))
+          continue
+        fi
+
+        tk_ok "$name — valid"
+      done
+
+      echo ""
+      if [ "$issues" -eq 0 ]; then
+        tk_ok "All $checked skills valid."
+      else
+        tk_warn "$issues/$checked skills have issues."
+      fi
+      echo ""
+      ;;
+
+    *)
+      echo "Usage:" >&2
+      echo "  toolkit skills           List all skills" >&2
+      echo "  toolkit skills check     Validate skill files" >&2
+      exit 1
+      ;;
+  esac
+}
+
 cmd_release() {
   source "$TOOLKIT_ROOT/lib/release.sh"
 
@@ -518,6 +660,23 @@ cmd_release() {
   toolkit_release "$bump_type"
 }
 
+cmd_changelog() {
+  local count="${1:-10}"
+  tk_header "Recent Releases"
+
+  if ! command -v gh >/dev/null 2>&1; then
+    tk_fail "gh CLI not installed. Run: brew install gh"
+    return 1
+  fi
+
+  gh release list --repo henrymodisett/toolkit --limit "$count" 2>/dev/null || {
+    tk_fail "Couldn't fetch releases (network issue or auth problem)."
+    tk_dim "Fallback — recent commits:"
+    git -C "$TOOLKIT_ROOT" log --oneline -"$count" 2>/dev/null || true
+  }
+  echo ""
+}
+
 cmd_help() {
   tk_header "toolkit — shared engineering toolkit"
   echo "  ${BOLD}Project commands:${RESET}"
@@ -526,6 +685,7 @@ cmd_help() {
   printf "    ${BOLD}toolkit update${RESET}                 Update current project to latest\n"
   printf "    ${BOLD}toolkit update${RESET} --dry-run       Preview what would change\n"
   printf "    ${BOLD}toolkit sync${RESET}                   Update all registered projects\n"
+  printf "    ${BOLD}toolkit sync${RESET} --check           Report which projects need sync\n"
   printf "    ${BOLD}toolkit sync${RESET} --pull-first      Pull latest toolkit first\n"
   printf "    ${BOLD}toolkit diff${RESET}                   Compare project files vs templates\n"
   printf "    ${BOLD}toolkit adr${RESET} \"Title\"            Create an Architecture Decision Record\n"
@@ -539,6 +699,9 @@ cmd_help() {
   echo "  ${BOLD}Toolkit commands:${RESET}"
   printf "    ${BOLD}toolkit doctor${RESET}                 Check installation health\n"
   printf "    ${BOLD}toolkit version${RESET}                Show installed version\n"
+  printf "    ${BOLD}toolkit changelog${RESET} [N]          Show last N releases (default 10)\n"
+  printf "    ${BOLD}toolkit skills${RESET}                 List Claude Code skills\n"
+  printf "    ${BOLD}toolkit skills${RESET} check           Validate skill files\n"
   printf "    ${BOLD}toolkit release${RESET} [--patch]      Cut a new toolkit release\n"
   printf "    ${BOLD}toolkit help${RESET}                   Show this help\n"
   echo ""
@@ -563,6 +726,8 @@ case "$COMMAND" in
   unregister)   cmd_unregister "$@" ;;
   diff)         cmd_diff ;;
   adr)          cmd_adr "$@" ;;
+  skills)       cmd_skills "$@" ;;
+  changelog)    cmd_changelog "$@" ;;
   release)      cmd_release "$@" ;;
   version)      cmd_version ;;
   doctor)       cmd_doctor ;;

--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -22,6 +22,7 @@ set -euo pipefail
 TOOLKIT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 REGISTER=true
 INPUT_UNSAFE=""
+INPUT_TYPE=""
 
 usage() {
   echo "Usage: $0 <project-dir> [--no-register] [--unsafe-paths path1,path2]"
@@ -129,6 +130,11 @@ while [ "$#" -gt 0 ]; do
   case "$1" in
     -h|--help) usage; exit 0 ;;
     --no-register) REGISTER=false; shift ;;
+    --type)
+      [ "$#" -ge 2 ] || { echo "ERROR: --type requires a value (python, node, swift, generic)" >&2; exit 1; }
+      INPUT_TYPE="$2"
+      shift 2
+      ;;
     --unsafe-paths)
       [ "$#" -ge 2 ] || { echo "ERROR: --unsafe-paths requires a comma-separated value" >&2; exit 1; }
       INPUT_UNSAFE="$2"
@@ -279,10 +285,18 @@ if [ -t 0 ] && [ -f "$PROJECT_DIR/CLAUDE.md" ]; then
 
   read -r -p "   Test command (e.g., pnpm build, pytest tests/): " INPUT_TEST
 
+  if [ -z "$INPUT_TYPE" ]; then
+    read -r -p "   Project type (python, node, swift, generic) [generic]: " INPUT_TYPE
+    INPUT_TYPE="${INPUT_TYPE:-generic}"
+  fi
+
   if [ -z "$INPUT_UNSAFE" ] && [ "$CODEX_REVIEW_CONFIG_CREATED" = true ]; then
     read -r -p "   High-scrutiny paths (comma-separated, e.g., src/auth/,migrations/): " INPUT_UNSAFE
   fi
 fi
+
+# Default project type if not set.
+INPUT_TYPE="${INPUT_TYPE:-generic}"
 
 if [ -n "$INPUT_NAME" ] || [ -n "$INPUT_DESC" ] || [ -n "$INPUT_TEST" ] || [ -n "$INPUT_UNSAFE" ]; then
   # Apply to CLAUDE.md / AGENTS.md.
@@ -323,6 +337,32 @@ if [ -n "$INPUT_NAME" ] || [ -n "$INPUT_DESC" ] || [ -n "$INPUT_TEST" ] || [ -n 
     echo ""
     echo "==> Placeholders filled! Review CLAUDE.md and AGENTS.md to add more detail."
   fi
+fi
+
+# Write .toolkit-config with project type.
+echo "project_type=$INPUT_TYPE" > "$PROJECT_DIR/.toolkit-config"
+echo "==> Wrote .toolkit-config: project_type=$INPUT_TYPE"
+
+# Uncomment language-specific hooks in .pre-commit-config.yaml based on project type.
+if [ -f "$PROJECT_DIR/.pre-commit-config.yaml" ]; then
+  case "$INPUT_TYPE" in
+    python)
+      # Uncomment the Python (ruff) hooks block.
+      sed -i '' '/^  # Python:$/,/^  #$\|^  # [A-Z]/{
+        s/^  # \(- repo: .*ruff.*\)/  \1/
+        s/^  #   \(rev: .*\)/    \1/
+        s/^  #     \(hooks:\)/      \1/
+        s/^  #       \(- id: ruff\)/        \1/
+        s/^  #         \(args: .*\)/          \1/
+        s/^  #       \(- id: ruff-format\)/        \1/
+      }' "$PROJECT_DIR/.pre-commit-config.yaml"
+      ;;
+  esac
+fi
+
+# Remove run-pytest-in-venv.sh for non-Python projects.
+if [ "$INPUT_TYPE" != "python" ] && [ "$INPUT_TYPE" != "generic" ]; then
+  rm -f "$PROJECT_DIR/scripts/run-pytest-in-venv.sh"
 fi
 
 echo ""

--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -351,14 +351,11 @@ fi
 if [ -f "$PROJECT_DIR/.pre-commit-config.yaml" ]; then
   case "$INPUT_TYPE" in
     python)
-      # Uncomment the Python (ruff) hooks block.
-      sed -i '' '/^  # Python (ruff):$/,/^  #$\|^  # [A-Z]/{
-        s/^  # \(- repo: .*ruff.*\)/  \1/
-        s/^  #   \(rev: .*\)/    \1/
-        s/^  #     \(hooks:\)/      \1/
-        s/^  #       \(- id: ruff\)/        \1/
-        s/^  #         \(args: .*\)/          \1/
-        s/^  #       \(- id: ruff-format\)/        \1/
+      # Uncomment the Python (ruff) hooks block by stripping "# " after the base indent.
+      sed -i '' '/^  # Python (ruff):$/,/^  #$/{
+        /^  # Python (ruff):$/d
+        /^  #$/d
+        s/^  # /  /
       }' "$PROJECT_DIR/.pre-commit-config.yaml"
       ;;
   esac

--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -339,16 +339,20 @@ if [ -n "$INPUT_NAME" ] || [ -n "$INPUT_DESC" ] || [ -n "$INPUT_TEST" ] || [ -n 
   fi
 fi
 
-# Write .toolkit-config with project type.
-echo "project_type=$INPUT_TYPE" > "$PROJECT_DIR/.toolkit-config"
-echo "==> Wrote .toolkit-config: project_type=$INPUT_TYPE"
+# Write .toolkit-config with project type (skip if already exists).
+if [ ! -f "$PROJECT_DIR/.toolkit-config" ]; then
+  echo "project_type=$INPUT_TYPE" > "$PROJECT_DIR/.toolkit-config"
+  echo "==> Wrote .toolkit-config: project_type=$INPUT_TYPE"
+else
+  echo "==> .toolkit-config already exists; left unchanged."
+fi
 
 # Uncomment language-specific hooks in .pre-commit-config.yaml based on project type.
 if [ -f "$PROJECT_DIR/.pre-commit-config.yaml" ]; then
   case "$INPUT_TYPE" in
     python)
       # Uncomment the Python (ruff) hooks block.
-      sed -i '' '/^  # Python:$/,/^  #$\|^  # [A-Z]/{
+      sed -i '' '/^  # Python (ruff):$/,/^  #$\|^  # [A-Z]/{
         s/^  # \(- repo: .*ruff.*\)/  \1/
         s/^  #   \(rev: .*\)/    \1/
         s/^  #     \(hooks:\)/      \1/

--- a/bootstrap/sync-all.sh
+++ b/bootstrap/sync-all.sh
@@ -21,11 +21,13 @@ UPDATE_SCRIPT="$TOOLKIT_ROOT/bootstrap/update-project.sh"
 PROJECTS_FILE="$HOME/.toolkit-projects"
 DRY_RUN=""
 PULL_FIRST=false
+CHECK_ONLY=false
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --dry-run|-n) DRY_RUN="--dry-run"; shift ;;
     --pull-first) PULL_FIRST=true; shift ;;
+    --check) CHECK_ONLY=true; shift ;;
     -h|--help)
       sed -n '3,14p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
@@ -45,6 +47,42 @@ if [ "$PULL_FIRST" = true ]; then
   echo "==> Pulling latest toolkit ..."
   git -C "$TOOLKIT_ROOT" pull --rebase
   echo ""
+fi
+
+# Check-only mode: report which projects need sync, then exit.
+if [ "$CHECK_ONLY" = true ]; then
+  CURRENT_ID="$(
+    if [ -d "$TOOLKIT_ROOT/.git" ]; then
+      git -C "$TOOLKIT_ROOT" rev-parse HEAD
+    else
+      cat "$TOOLKIT_ROOT/VERSION" 2>/dev/null | tr -d '[:space:]'
+    fi
+  )"
+  BEHIND=0
+  TOTAL=0
+  while IFS= read -r project_dir; do
+    [ -z "$project_dir" ] && continue
+    [[ "$project_dir" == \#* ]] && continue
+    TOTAL=$((TOTAL + 1))
+    if [ ! -d "$project_dir" ]; then
+      echo "  ? $(basename "$project_dir") — directory not found"
+      continue
+    fi
+    proj_id="$(cat "$project_dir/.toolkit-version" 2>/dev/null | tr -d '[:space:]' || echo "none")"
+    if [ "$proj_id" = "$CURRENT_ID" ]; then
+      echo "  ✓ $(basename "$project_dir") — up to date"
+    else
+      echo "  ! $(basename "$project_dir") — needs sync"
+      BEHIND=$((BEHIND + 1))
+    fi
+  done < "$PROJECTS_FILE"
+  echo ""
+  if [ "$BEHIND" -eq 0 ]; then
+    echo "All $TOTAL projects are up to date."
+  else
+    echo "$BEHIND/$TOTAL projects need sync. Run: toolkit sync"
+  fi
+  exit 0
 fi
 
 TOTAL=0

--- a/bootstrap/update-project.sh
+++ b/bootstrap/update-project.sh
@@ -54,13 +54,17 @@ if [ "$OLD_SHA" = "$CURRENT_SHA" ]; then
   exit 0
 fi
 
-# Show changelog between versions.
+# Show changes between versions.
 echo ""
 echo "==> Changes in toolkit since last update:"
 if git -C "$TOOLKIT_ROOT" log --oneline "$OLD_SHA..$CURRENT_SHA" 2>/dev/null; then
   echo ""
+elif command -v gh >/dev/null 2>&1; then
+  gh release list --repo henrymodisett/toolkit --limit 15 2>/dev/null | head -10 || true
+  echo ""
 else
-  echo "    (couldn't compute changelog — old SHA may have been garbage collected)"
+  echo "    (couldn't compute changes — old SHA may have been garbage collected)"
+  echo "    Run: toolkit changelog"
   echo ""
 fi
 
@@ -132,12 +136,22 @@ if [ -d "$TOOLKIT_ROOT/principles" ]; then
   done
 fi
 
+# Read project type (default: generic for backward compatibility).
+PROJECT_TYPE="generic"
+if [ -f "$PROJECT_DIR/.toolkit-config" ]; then
+  PROJECT_TYPE="$(grep '^project_type=' "$PROJECT_DIR/.toolkit-config" 2>/dev/null | cut -d= -f2 | tr -d '[:space:]')"
+  PROJECT_TYPE="${PROJECT_TYPE:-generic}"
+fi
+
 # Scripts
 update_file "$TOOLKIT_ROOT/hooks/codex-review.sh" "$PROJECT_DIR/scripts/codex-review.sh"
 update_file "$TOOLKIT_ROOT/scripts/open-pr.sh" "$PROJECT_DIR/scripts/open-pr.sh"
 update_file "$TOOLKIT_ROOT/scripts/merge-pr.sh" "$PROJECT_DIR/scripts/merge-pr.sh"
 update_file "$TOOLKIT_ROOT/scripts/cleanup-branches.sh" "$PROJECT_DIR/scripts/cleanup-branches.sh"
-update_file "$TOOLKIT_ROOT/scripts/run-pytest-in-venv.sh" "$PROJECT_DIR/scripts/run-pytest-in-venv.sh"
+
+if [ "$PROJECT_TYPE" = "python" ] || [ "$PROJECT_TYPE" = "generic" ]; then
+  update_file "$TOOLKIT_ROOT/scripts/run-pytest-in-venv.sh" "$PROJECT_DIR/scripts/run-pytest-in-venv.sh"
+fi
 
 # Ensure scripts are executable.
 if [ "$DRY_RUN" = false ] && [ -d "$PROJECT_DIR/scripts" ]; then

--- a/bootstrap/update-project.sh
+++ b/bootstrap/update-project.sh
@@ -139,7 +139,7 @@ fi
 # Read project type (default: generic for backward compatibility).
 PROJECT_TYPE="generic"
 if [ -f "$PROJECT_DIR/.toolkit-config" ]; then
-  PROJECT_TYPE="$(grep '^project_type=' "$PROJECT_DIR/.toolkit-config" 2>/dev/null | cut -d= -f2 | tr -d '[:space:]')"
+  PROJECT_TYPE="$(grep '^project_type=' "$PROJECT_DIR/.toolkit-config" 2>/dev/null | cut -d= -f2 | tr -d '[:space:]' || true)"
   PROJECT_TYPE="${PROJECT_TYPE:-generic}"
 fi
 

--- a/principles/git-workflow.md
+++ b/principles/git-workflow.md
@@ -7,10 +7,8 @@ Every code change goes through a feature branch + PR + merge. No exceptions for 
 1. **Pull.** `git pull --rebase` on the default branch before starting work.
 2. **Branch.** `git checkout -b <type>/<short-description>` where `<type>` is one of `feat`, `fix`, `chore`, `refactor`, `docs`.
 3. **Change + commit.** Make the code change, stage explicit file paths (not `git add -A`), commit with a concise message.
-4. **Push.** `git push -u origin HEAD` or use `scripts/open-pr.sh`. Feature-branch pushes should stay fast; Codex review is reserved for merge/default-branch gates.
-5. **Open the PR.** `scripts/open-pr.sh` creates the PR with the project's PR template attached. Idempotent — rerunning on a branch that already has a PR just prints the URL.
-6. **Merge.** `scripts/merge-pr.sh <pr-number>` — sanity-checks mergeability, runs Codex review, squash-merges, deletes the remote branch, pulls the updated default branch locally.
-7. **Clean up.** Delete the local feature branch. Run `scripts/cleanup-branches.sh` periodically for batch hygiene.
+4. **Ship.** `scripts/open-pr.sh --auto-merge` pushes, creates the PR, runs Codex review, squash-merges, deletes the remote branch, and pulls the updated default branch — all in one command. Use `scripts/open-pr.sh` (without `--auto-merge`) if you want to open the PR without merging.
+5. **Clean up.** Delete the local feature branch. Run `scripts/cleanup-branches.sh` periodically for batch hygiene.
 
 ## Commit discipline
 

--- a/principles/git-workflow.md
+++ b/principles/git-workflow.md
@@ -20,10 +20,10 @@ Every code change goes through a feature branch + PR + merge. No exceptions for 
 
 ## Codex merge review (optional, recommended)
 
-If the project has Codex review configured (see `hooks/codex-review.sh` and `.codex-review.toml`), the merge/default-branch review gate:
+If the project has Codex review configured (see `hooks/codex-review.sh` and `.codex-review.toml`), a pre-push hook gates default-branch pushes (including squash-merges via `merge-pr.sh`). The mechanism is `stages: [pre-push]` in `.pre-commit-config.yaml`; it skips feature-branch pushes and only activates when the push target is the default branch. Behavior:
 - Runs `codex exec --full-auto` against the diff vs the default branch
 - Auto-fixes safe findings (typos, missing error logging, etc.)
-- Blocks the merge or direct default-branch push for unsafe findings (high-scrutiny paths)
+- Blocks the push for unsafe findings (high-scrutiny paths)
 - Loops up to `max_iterations` times (default 3)
 - Gracefully skips if the Codex CLI isn't installed
 

--- a/scripts/open-pr.sh
+++ b/scripts/open-pr.sh
@@ -8,6 +8,7 @@
 #
 # Usage:
 #   bash scripts/open-pr.sh                # title from last commit
+#   bash scripts/open-pr.sh --auto-merge   # open + Codex review + squash-merge
 #   bash scripts/open-pr.sh --draft        # same, opened as draft
 #   bash scripts/open-pr.sh "Custom title" # explicit title
 #
@@ -71,10 +72,15 @@ fi
 
 # Build title + body.
 DRAFT_FLAG=""
-if [ "$#" -gt 0 ] && [ "$1" = "--draft" ]; then
-  DRAFT_FLAG="--draft"
-  shift
-fi
+AUTO_MERGE=false
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --draft) DRAFT_FLAG="--draft"; shift ;;
+    --auto-merge) AUTO_MERGE=true; shift ;;
+    *) break ;;
+  esac
+done
 
 if [ "$#" -gt 0 ]; then
   TITLE="$1"
@@ -108,4 +114,17 @@ echo "$PR_URL"
 
 if [ -n "$DRAFT_FLAG" ]; then
   echo "    Opened as draft. Mark ready on github.com when ready to merge."
+fi
+
+# Auto-merge: extract PR number and run merge-pr.sh.
+if [ "$AUTO_MERGE" = true ] && [ -z "$DRAFT_FLAG" ]; then
+  PR_NUMBER="$(basename "$PR_URL")"
+  MERGE_SCRIPT="$(dirname "$0")/merge-pr.sh"
+  if [ -f "$MERGE_SCRIPT" ]; then
+    echo ""
+    echo "==> Auto-merging PR #$PR_NUMBER ..."
+    exec bash "$MERGE_SCRIPT" "$PR_NUMBER"
+  else
+    echo "WARNING: merge-pr.sh not found at $MERGE_SCRIPT — skipping auto-merge." >&2
+  fi
 fi

--- a/scripts/open-pr.sh
+++ b/scripts/open-pr.sh
@@ -63,10 +63,19 @@ else
   git push -u origin "$CURRENT_BRANCH"
 fi
 
-# If a PR already exists for this branch, just print the URL.
+# If a PR already exists for this branch, just print the URL (and auto-merge if requested).
 EXISTING_PR_URL="$(gh pr list --head "$CURRENT_BRANCH" --author "@me" --state open --json url --jq '.[0].url // empty' 2>/dev/null || echo "")"
 if [ -n "$EXISTING_PR_URL" ]; then
   echo "==> PR already open for $CURRENT_BRANCH: $EXISTING_PR_URL"
+  if [ "$AUTO_MERGE" = true ]; then
+    PR_NUMBER="$(basename "$EXISTING_PR_URL")"
+    MERGE_SCRIPT="$(dirname "$0")/merge-pr.sh"
+    if [ -f "$MERGE_SCRIPT" ]; then
+      echo ""
+      echo "==> Auto-merging PR #$PR_NUMBER ..."
+      exec bash "$MERGE_SCRIPT" "$PR_NUMBER"
+    fi
+  fi
   exit 0
 fi
 

--- a/scripts/open-pr.sh
+++ b/scripts/open-pr.sh
@@ -54,6 +54,20 @@ if ! git diff --quiet || ! git diff --cached --quiet || [ -n "$UNTRACKED" ]; the
   esac
 fi
 
+# Parse flags early (needed before the existing-PR check).
+DRAFT_FLAG=""
+AUTO_MERGE=false
+POSITIONAL=()
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --draft) DRAFT_FLAG="--draft"; shift ;;
+    --auto-merge) AUTO_MERGE=true; shift ;;
+    *) POSITIONAL+=("$1"); shift ;;
+  esac
+done
+set -- "${POSITIONAL[@]+"${POSITIONAL[@]}"}"
+
 # Push (set upstream on first push, plain push afterwards).
 if git rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1; then
   echo "==> Pushing $CURRENT_BRANCH ..."
@@ -78,18 +92,6 @@ if [ -n "$EXISTING_PR_URL" ]; then
   fi
   exit 0
 fi
-
-# Build title + body.
-DRAFT_FLAG=""
-AUTO_MERGE=false
-
-while [ "$#" -gt 0 ]; do
-  case "$1" in
-    --draft) DRAFT_FLAG="--draft"; shift ;;
-    --auto-merge) AUTO_MERGE=true; shift ;;
-    *) break ;;
-  esac
-done
 
 if [ "$#" -gt 0 ]; then
   TITLE="$1"

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -20,9 +20,8 @@
 1. **Pull.** `git pull --rebase` on the default branch before starting work.
 2. **Branch.** `git checkout -b <type>/<short-description>` where `<type>` is one of `feat`, `fix`, `chore`, `refactor`, `docs`.
 3. **Change + commit.** Make the code change, stage explicit file paths, commit with a concise message.
-4. **Push.** `bash scripts/open-pr.sh` (which pushes + creates the PR). Feature-branch pushes stay fast.
-5. **Merge.** `bash scripts/merge-pr.sh <pr-number>` — Codex review, squash-merge, delete branch, sync default branch.
-6. **Clean up.** `git branch -D <feature-branch>` if it still exists locally.
+4. **Ship.** `bash scripts/open-pr.sh --auto-merge` — pushes, creates the PR, runs Codex review, squash-merges, and syncs the default branch in one step.
+5. **Clean up.** `git branch -D <feature-branch>` if it still exists locally.
 
 ### Housekeeping
 

--- a/templates/gitignore
+++ b/templates/gitignore
@@ -36,4 +36,5 @@ out/
 
 # Toolkit
 .toolkit-version
+.toolkit-config
 *.bak

--- a/templates/pre-commit-config.yaml
+++ b/templates/pre-commit-config.yaml
@@ -68,9 +68,10 @@ repos:
         pass_filenames: false
 
   # ── Project-specific hooks ─────────────────────────────────────────────
-  # Uncomment and customize for your project:
+  # Add language-specific linters and test runners below.
+  # `toolkit init` will uncomment relevant hooks for your project type.
   #
-  # Python:
+  # Python (ruff):
   # - repo: https://github.com/astral-sh/ruff-pre-commit
   #   rev: v0.8.6
   #   hooks:
@@ -83,7 +84,7 @@ repos:
   #   hooks:
   #     - id: tests
   #       name: Run tests
-  #       entry: /usr/bin/env bash scripts/run-pytest-in-venv.sh tests/
+  #       entry: /usr/bin/env bash -c 'your-test-command-here'
   #       language: system
   #       stages: [pre-push]
   #       always_run: true

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -74,7 +74,7 @@ assert_executable "$PROJECT/scripts/open-pr.sh"
 assert_executable "$PROJECT/scripts/merge-pr.sh"
 assert_executable "$PROJECT/scripts/cleanup-branches.sh"
 assert_executable "$PROJECT/scripts/run-pytest-in-venv.sh"
-assert_contains "$PROJECT/.pre-commit-config.yaml" 'run-pytest-in-venv.sh'
+assert_contains "$PROJECT/.pre-commit-config.yaml" 'codex-review.sh'
 
 # Toolkit version
 assert_exists "$PROJECT/.toolkit-version"


### PR DESCRIPTION
1. Project-type awareness: new-project.sh asks for project type
   (python/node/swift/generic), writes .toolkit-config, and
   update-project.sh skips irrelevant scripts (e.g. run-pytest-in-venv.sh
   for Swift projects).

2. Version drift nudge: the CLI prints a one-liner when cwd is a
   stale toolkit project. Added toolkit sync --check for dry-run
   drift reporting.

3. Doc/config mismatch: git-workflow.md now explains that Codex
   review is a pre-push hook that only activates on default-branch
   pushes, matching the .pre-commit-config.yaml wiring.

4. Skills visibility: toolkit skills lists all project and user
   skills with scope and type (symlink/local/standalone).

5. Skill provenance: toolkit skills shows symlink targets to reveal
   where each skill came from. Non-symlinked skills are labeled
   "standalone (no symlink)".

6. Template placeholders: pre-commit-config.yaml template uses a
   generic test entry instead of Python-specific run-pytest-in-venv.sh.
   toolkit init --type python uncomments ruff hooks automatically.

7. Changelog command: toolkit changelog [N] shows recent releases
   via gh release list. update-project.sh falls back to gh release
   list when git log fails between SHAs.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
