### PR TITLE
Add multi-reviewer cascade (Codex, Claude, Gemini) to code review hook

### DIFF
--- a/hooks/codex-review.config.example.toml
+++ b/hooks/codex-review.config.example.toml
@@ -24,7 +24,7 @@ cache_clean_reviews = true
 # For new projects, start with false and gradually opt in as you gain confidence.
 safe_by_default = false
 
-# Paths where Codex must NEVER auto-fix — it reports findings but does not edit.
+# Paths where the reviewer must NEVER auto-fix — it reports findings but does not edit.
 # Use these for high-scrutiny areas where auto-fixes could cause damage.
 # Paths are matched as prefixes (e.g., "src/auth/" matches "src/auth/login.py").
 unsafe_paths = [
@@ -33,3 +33,18 @@ unsafe_paths = [
   # "migrations/",
   # "src/core/config.py",
 ]
+
+# --------------------------------------------------------------------------
+# Reviewer cascade (optional)
+# --------------------------------------------------------------------------
+# The [review] section configures which AI reviewers to try and in what order.
+# The hook tries each reviewer in sequence; the first one that is installed
+# and authenticated runs the review.
+#
+# Valid reviewer IDs: "codex", "claude", "gemini"
+#
+# If this section is absent, the hook defaults to ["codex"] (backward compatible).
+# Override for a single run with: TOOLKIT_REVIEWER=claude git push
+
+# [review]
+# reviewers = ["claude", "codex", "gemini"]

--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -412,7 +412,7 @@ When in doubt, STOP and emit BLOCKED."
 #   reviewer_<id>_exec PROMPT — run the review; stdout = output, exit code = success
 
 reviewer_codex_available() { command -v codex >/dev/null 2>&1; }
-reviewer_codex_auth_ok()   { return 0; }  # Codex checks auth at exec time
+reviewer_codex_auth_ok()   { codex login status >/dev/null 2>&1; }
 reviewer_codex_exec() {
   CODEX_REVIEW_IN_PROGRESS=1 codex exec --full-auto --ephemeral "$1" 2>/dev/null
 }
@@ -436,11 +436,11 @@ reviewer_gemini_auth_ok() {
   command -v gcloud >/dev/null 2>&1 && gcloud auth print-access-token >/dev/null 2>&1
 }
 reviewer_gemini_exec() {
-  local mode_flag="--non-interactive"
   if [ "$NO_AUTOFIX" != "true" ]; then
-    mode_flag="--yolo"
+    CODEX_REVIEW_IN_PROGRESS=1 gemini -p "$1" --yolo 2>/dev/null
+  else
+    CODEX_REVIEW_IN_PROGRESS=1 gemini -p "$1" 2>/dev/null
   fi
-  CODEX_REVIEW_IN_PROGRESS=1 gemini -p "$1" $mode_flag 2>/dev/null
 }
 
 # --------------------------------------------------------------------------
@@ -612,7 +612,8 @@ append_cache_file() {
 
 review_cache_key() {
   {
-    printf 'toolkit-codex-review-cache-v1\n'
+    printf 'toolkit-codex-review-cache-v2\n'
+    printf 'reviewer=%s\n' "$ACTIVE_REVIEWER"
     printf 'base=%s\n' "$BASE"
     printf 'merge_base=%s\n' "$MERGE_BASE"
     printf 'worktree_dirty_before_review=%s\n' "$WORKTREE_DIRTY_BEFORE_REVIEW"

--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -1,15 +1,21 @@
 #!/usr/bin/env bash
 #
-# hooks/codex-review.sh — non-interactive Codex review + auto-fix loop.
-# Wired into merge-pr.sh and default-branch pre-push checks.
+# hooks/codex-review.sh — non-interactive AI code review + auto-fix loop.
+# Supports multiple reviewers (Codex, Claude, Gemini) with a configurable
+# fallback cascade. Wired into merge-pr.sh and default-branch pre-push checks.
 #
 # Loop:
-#   1. Run `codex exec --full-auto` against the local diff vs the default branch
-#   2. If Codex says CODEX_REVIEW_CLEAN → push allowed.
-#   3. If Codex says CODEX_REVIEW_FIXED → it edited files. Stage + commit
+#   1. Run the selected reviewer against the local diff vs the default branch
+#   2. If reviewer says CODEX_REVIEW_CLEAN → push allowed.
+#   3. If reviewer says CODEX_REVIEW_FIXED → it edited files. Stage + commit
 #      the fixes (a new commit, NOT an amend) and loop back to step 1.
-#   4. If Codex says CODEX_REVIEW_BLOCKED → push aborts, findings printed.
+#   4. If reviewer says CODEX_REVIEW_BLOCKED → push aborts, findings printed.
 #   5. After max_iterations rounds without converging, push aborts.
+#
+# Reviewer cascade:
+#   The [review] section in .codex-review.toml lists reviewers to try in order.
+#   The first reviewer that is installed and authenticated wins.
+#   If no [review] section exists, defaults to ["codex"] (backward compatible).
 #
 # Configuration:
 #   Place a .codex-review.toml at the repo root to configure behavior.
@@ -20,14 +26,15 @@
 #   explicitly by listing safe paths or setting safe_by_default = true.
 #
 # Env overrides:
+#   TOOLKIT_REVIEWER              — force a specific reviewer (skips cascade, hard-fails if unavailable)
 #   CODEX_REVIEW_BASE             — base ref to diff against (default: origin/<default-branch>)
 #   CODEX_REVIEW_MAX_ITERATIONS   — fix loop cap (default: from config, or 3)
 #   CODEX_REVIEW_MAX_DIFF_LINES   — skip review if diff > this many lines (default: 5000)
 #   CODEX_REVIEW_CACHE_CLEAN      — cache exact-input clean reviews (default: true)
-#   CODEX_REVIEW_DISABLE_CACHE    — set to true/1 to force a fresh Codex review
+#   CODEX_REVIEW_DISABLE_CACHE    — set to true/1 to force a fresh review
 #   CODEX_REVIEW_FORCE            — set to true/1 to run even on non-default-branch pushes
 #   CODEX_REVIEW_NO_AUTOFIX       — set to true/1 for review-only mode
-#   CODEX_REVIEW_IN_PROGRESS      — internal guard to skip nested Codex hook runs
+#   CODEX_REVIEW_IN_PROGRESS      — internal guard to skip nested review runs
 #
 # To bypass entirely in an emergency: git push --no-verify
 #
@@ -52,6 +59,7 @@ MAX_DIFF_LINES="${CODEX_REVIEW_MAX_DIFF_LINES:-5000}"
 CACHE_CLEAN_REVIEWS="${CODEX_REVIEW_CACHE_CLEAN:-true}"
 NO_AUTOFIX="${CODEX_REVIEW_NO_AUTOFIX:-false}"
 UNSAFE_PATHS=""
+REVIEWER_CASCADE=()
 
 trim() {
   local value="$1"
@@ -140,6 +148,29 @@ append_unsafe_paths_csv() {
   done
 }
 
+append_reviewer() {
+  local value="$1"
+  value="$(trim "$value")"
+  value="${value%,}"
+  value="$(trim "$value")"
+  case "$value" in
+    \"*\") value="${value#\"}"; value="${value%\"}" ;;
+    \'*\') value="${value#\'}"; value="${value%\'}" ;;
+  esac
+  [ -z "$value" ] && return
+  REVIEWER_CASCADE+=("$value")
+}
+
+append_reviewers_csv() {
+  local csv="$1" item
+  local -a items=()
+  [ -n "$csv" ] || return 0
+  IFS=',' read -r -a items <<< "$csv"
+  for item in "${items[@]}"; do
+    append_reviewer "$item"
+  done
+}
+
 normalize_bool() {
   local value="$1"
   value="$(trim "$value")"
@@ -160,11 +191,24 @@ normalize_bool() {
 # We do minimal TOML parsing in bash — just key = value pairs and string arrays.
 if [ -f "$CONFIG_FILE" ]; then
   IN_UNSAFE_PATHS=false
+  IN_REVIEWERS=false
+  CURRENT_SECTION=""
   while IFS= read -r raw_line || [ -n "$raw_line" ]; do
     # Strip comments and trim whitespace
     line="$(trim "$(strip_toml_comment "$raw_line")")"
     [ -z "$line" ] && continue
 
+    # Track TOML section headers.
+    if [[ "$line" == "["*"]" ]]; then
+      IN_UNSAFE_PATHS=false
+      IN_REVIEWERS=false
+      CURRENT_SECTION="${line#\[}"
+      CURRENT_SECTION="${CURRENT_SECTION%\]}"
+      CURRENT_SECTION="$(trim "$CURRENT_SECTION")"
+      continue
+    fi
+
+    # Continue multiline arrays regardless of section.
     if [ "$IN_UNSAFE_PATHS" = true ]; then
       if [[ "$line" == *"]"* ]]; then
         append_unsafe_paths_csv "${line%%]*}"
@@ -174,7 +218,35 @@ if [ -f "$CONFIG_FILE" ]; then
       fi
       continue
     fi
+    if [ "$IN_REVIEWERS" = true ]; then
+      if [[ "$line" == *"]"* ]]; then
+        append_reviewers_csv "${line%%]*}"
+        IN_REVIEWERS=false
+      else
+        append_reviewer "$line"
+      fi
+      continue
+    fi
 
+    # Parse [review] section keys.
+    if [ "$CURRENT_SECTION" = "review" ]; then
+      case "$line" in
+        reviewers*=*)
+          array_value="$(trim "${line#*=}")"
+          array_value="${array_value#\[}"
+          if [[ "$array_value" == *"]"* ]]; then
+            append_reviewers_csv "${array_value%%]*}"
+          else
+            append_reviewers_csv "$array_value"
+            IN_REVIEWERS=true
+          fi
+          ;;
+      esac
+      continue
+    fi
+
+    # Parse [codex_review] section keys (also matches when no section header
+    # has been seen yet, for backward compatibility with existing configs).
     case "$line" in
       max_iterations*=*)
         MAX_ITERATIONS="${CODEX_REVIEW_MAX_ITERATIONS:-$(trim "${line#*=}")}"
@@ -224,6 +296,16 @@ DEFAULT_BRANCH="$(resolve_default_branch)"
 BASE="${CODEX_REVIEW_BASE:-origin/$DEFAULT_BRANCH}"
 NO_AUTOFIX="$(normalize_bool "$NO_AUTOFIX")"
 
+# Default reviewer cascade: codex-only (backward compat with existing configs).
+if [ "${#REVIEWER_CASCADE[@]}" -eq 0 ]; then
+  REVIEWER_CASCADE=("codex")
+fi
+
+# TOOLKIT_REVIEWER env var overrides the cascade with a single forced reviewer.
+if [ -n "${TOOLKIT_REVIEWER:-}" ]; then
+  REVIEWER_CASCADE=("$TOOLKIT_REVIEWER")
+fi
+
 short_ref_name() {
   local ref="$1"
   ref="${ref#refs/heads/}"
@@ -255,7 +337,7 @@ should_skip_pre_push_review() {
     return 1
   fi
 
-  echo "==> Codex review runs on pushes to $default_branch only — skipping push to $remote_branch."
+  echo "==> Review runs on pushes to $default_branch only — skipping push to $remote_branch."
   echo "    Force review with: CODEX_REVIEW_FORCE=1 git push"
   return 0
 }
@@ -322,13 +404,94 @@ When in doubt, STOP and emit BLOCKED."
 }
 
 # --------------------------------------------------------------------------
+# Reviewer adapters
+# --------------------------------------------------------------------------
+# Each reviewer exposes three functions:
+#   reviewer_<id>_available  — exit 0 if the CLI is installed
+#   reviewer_<id>_auth_ok    — exit 0 if auth is configured
+#   reviewer_<id>_exec PROMPT — run the review; stdout = output, exit code = success
+
+reviewer_codex_available() { command -v codex >/dev/null 2>&1; }
+reviewer_codex_auth_ok()   { return 0; }  # Codex checks auth at exec time
+reviewer_codex_exec() {
+  CODEX_REVIEW_IN_PROGRESS=1 codex exec --full-auto --ephemeral "$1" 2>/dev/null
+}
+
+reviewer_claude_available() { command -v claude >/dev/null 2>&1; }
+reviewer_claude_auth_ok()   { claude auth status >/dev/null 2>&1; }
+reviewer_claude_exec() {
+  local tools="Read,Grep,Glob,Bash"
+  if [ "$NO_AUTOFIX" != "true" ]; then
+    tools="Read,Grep,Glob,Bash,Edit,Write"
+  fi
+  CODEX_REVIEW_IN_PROGRESS=1 claude -p \
+    --allowedTools "$tools" \
+    --output-format text \
+    "$1" 2>/dev/null
+}
+
+reviewer_gemini_available() { command -v gemini >/dev/null 2>&1; }
+reviewer_gemini_auth_ok() {
+  [ -n "${GEMINI_API_KEY:-}" ] && return 0
+  command -v gcloud >/dev/null 2>&1 && gcloud auth print-access-token >/dev/null 2>&1
+}
+reviewer_gemini_exec() {
+  local mode_flag="--non-interactive"
+  if [ "$NO_AUTOFIX" != "true" ]; then
+    mode_flag="--yolo"
+  fi
+  CODEX_REVIEW_IN_PROGRESS=1 gemini -p "$1" $mode_flag 2>/dev/null
+}
+
+# --------------------------------------------------------------------------
+# Reviewer cascade resolver
+# --------------------------------------------------------------------------
+
+ACTIVE_REVIEWER=""
+REVIEWER_STATUS=""
+
+resolve_reviewer() {
+  local reviewer
+  ACTIVE_REVIEWER=""
+  REVIEWER_STATUS=""
+
+  for reviewer in "${REVIEWER_CASCADE[@]}"; do
+    if ! "reviewer_${reviewer}_available"; then
+      REVIEWER_STATUS="${REVIEWER_STATUS}    ${reviewer}: CLI not installed\n"
+      continue
+    fi
+    if ! "reviewer_${reviewer}_auth_ok"; then
+      REVIEWER_STATUS="${REVIEWER_STATUS}    ${reviewer}: auth check failed\n"
+      continue
+    fi
+    ACTIVE_REVIEWER="$reviewer"
+    return 0
+  done
+
+  return 1
+}
+
+run_reviewer() {
+  "reviewer_${ACTIVE_REVIEWER}_exec" "$1"
+}
+
+reviewer_label() {
+  case "$ACTIVE_REVIEWER" in
+    codex)  printf 'Codex' ;;
+    claude) printf 'Claude' ;;
+    gemini) printf 'Gemini' ;;
+    *)      printf '%s' "$ACTIVE_REVIEWER" ;;
+  esac
+}
+
+# --------------------------------------------------------------------------
 # Pre-flight checks
 # --------------------------------------------------------------------------
 
 # Feature-branch pushes should stay fast. Manual invocations and direct pushes
 # to the default branch still run the review.
 if is_truthy "${CODEX_REVIEW_IN_PROGRESS:-false}"; then
-  echo "==> Codex review already in progress — skipping nested Codex review."
+  echo "==> Review already in progress — skipping nested review."
   exit 0
 fi
 
@@ -336,12 +499,20 @@ if should_skip_pre_push_review; then
   exit 0
 fi
 
-# Graceful skip if Codex CLI not installed.
-if ! command -v codex >/dev/null 2>&1; then
-  echo "==> codex CLI not installed — skipping Codex review."
-  echo "    Install with: npm install -g @openai/codex && codex login"
+# Resolve which reviewer to use from the cascade.
+if ! resolve_reviewer; then
+  if [ -n "${TOOLKIT_REVIEWER:-}" ]; then
+    echo "ERROR: TOOLKIT_REVIEWER=$TOOLKIT_REVIEWER but that reviewer is not available:" >&2
+    printf '%b' "$REVIEWER_STATUS" >&2
+    exit 1
+  fi
+  echo "==> No reviewer available — skipping review."
+  printf '%b' "$REVIEWER_STATUS"
+  echo "    Install at least one: codex, claude, or gemini CLI."
   exit 0
 fi
+REVIEWER_LABEL="$(reviewer_label)"
+echo "==> Using reviewer: $REVIEWER_LABEL"
 
 # Fetch latest base ref for the default review target (silent on failure —
 # offline, rebasing, etc.). If CODEX_REVIEW_BASE is set, trust the caller.
@@ -351,13 +522,13 @@ fi
 
 # Find merge base so we review only this branch's commits.
 if ! MERGE_BASE="$(git merge-base "$BASE" HEAD 2>/dev/null)"; then
-  echo "==> Couldn't find merge base with $BASE — skipping Codex review."
+  echo "==> Couldn't find merge base with $BASE — skipping review."
   exit 0
 fi
 
 # Skip if no changes vs base.
 if git diff --quiet "$MERGE_BASE"..HEAD; then
-  echo "==> No changes vs $BASE — skipping Codex review."
+  echo "==> No changes vs $BASE — skipping review."
   exit 0
 fi
 
@@ -566,15 +737,13 @@ fi
 
 print_banner() {
   [ "$BANNER_PRINTED" = false ] || return 0
+  local label
+  label="$(reviewer_label)"
   printf "${C_CYAN}"
-  cat <<'BANNER'
-
-  ╔══════════════════════════════════════╗
-  ║         ⚡ TOOLKIT REVIEW ⚡        ║
-  ║        Codex merge code review       ║
-  ╚══════════════════════════════════════╝
-
-BANNER
+  printf '\n  ╔══════════════════════════════════════╗\n'
+  printf '  ║         ⚡ TOOLKIT REVIEW ⚡        ║\n'
+  printf '  ║     %s merge code review%s║\n' "$label" "$(printf '%*s' $((23 - ${#label})) '')"
+  printf '  ╚══════════════════════════════════════╝\n\n'
   printf "${C_RESET}"
   BANNER_PRINTED=true
 }
@@ -591,7 +760,7 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
   if cache_enabled; then
     REVIEW_CACHE_KEY="$(review_cache_key 2>/dev/null || true)"
     if [ -n "$REVIEW_CACHE_KEY" ] && [ -f "$(clean_review_cache_file "$REVIEW_CACHE_KEY")" ]; then
-      echo "==> Codex review previously passed for this exact diff — skipping repeat review."
+      echo "==> Review previously passed for this exact diff — skipping repeat review."
       echo "    Force a fresh review with: CODEX_REVIEW_DISABLE_CACHE=1 git push"
       exit 0
     fi
@@ -601,13 +770,13 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
   printf "  ${C_DIM}iteration ${iter}/${MAX_ITERATIONS} · ${DIFF_LINE_COUNT} lines vs ${BASE}${C_RESET}\n"
 
   set +e
-  OUTPUT="$(CODEX_REVIEW_IN_PROGRESS=1 codex exec --full-auto --ephemeral "$REVIEW_PROMPT" 2>/dev/null)"
+  OUTPUT="$(run_reviewer "$REVIEW_PROMPT")"
   EXIT=$?
   set -e
 
   if [ $EXIT -ne 0 ]; then
-    echo "==> codex exec failed with exit $EXIT — not blocking push."
-    echo "    If this keeps happening, check: codex login status, API quota, network."
+    echo "==> $REVIEWER_LABEL review failed with exit $EXIT — not blocking push."
+    echo "    If this keeps happening, check auth, API quota, and network."
     exit 0
   fi
 
@@ -633,7 +802,7 @@ PASS
 
     CODEX_REVIEW_FIXED)
       if [ "$NO_AUTOFIX" = "true" ]; then
-        echo "==> Codex emitted FIXED during review-only mode."
+        echo "==> $REVIEWER_LABEL emitted FIXED during review-only mode."
         echo "    Treating this as blocking because CODEX_REVIEW_NO_AUTOFIX=1 was set."
         echo "    Inspect the working tree before continuing."
         exit 1
@@ -641,13 +810,13 @@ PASS
 
       AUTOFIX_CHANGED_PATHS="$(changed_paths)"
       if [ -z "$AUTOFIX_CHANGED_PATHS" ]; then
-        echo "==> Codex emitted FIXED but no working-tree changes detected."
+        echo "==> $REVIEWER_LABEL emitted FIXED but no working-tree changes detected."
         echo "    Treating as ambiguous — not blocking push."
         exit 0
       fi
 
       if [ "$WORKTREE_DIRTY_BEFORE_REVIEW" = true ]; then
-        echo "==> Codex emitted FIXED, but the working tree was already dirty before review."
+        echo "==> $REVIEWER_LABEL emitted FIXED, but the working tree was already dirty before review."
         echo "    Refusing to auto-commit because that could include unrelated local changes."
         echo "    Commit or stash local changes, then push again."
         exit 1
@@ -655,7 +824,7 @@ PASS
 
       DISALLOWED_AUTOFIX_PATHS="$(disallowed_autofix_paths "$AUTOFIX_CHANGED_PATHS")"
       if [ -n "$DISALLOWED_AUTOFIX_PATHS" ]; then
-        echo "==> Codex edited paths that are not allowed by .codex-review.toml."
+        echo "==> $REVIEWER_LABEL edited paths that are not allowed by .codex-review.toml."
         echo "    Refusing to auto-commit. Review these changes manually:"
         printf '%s\n' "$DISALLOWED_AUTOFIX_PATHS" | sed 's/^/    - /'
         echo "    Inspect the working-tree diff before deciding whether to keep or discard them."
@@ -667,7 +836,7 @@ PASS
       echo ""
 
       git add -A
-      git commit -m "fix: address Codex review findings (auto, iter $iter)"
+      git commit -m "fix: address $REVIEWER_LABEL review findings (auto, iter $iter)"
       WORKTREE_DIRTY_BEFORE_REVIEW=false
       FIX_COMMITS=$((FIX_COMMITS + 1))
       echo "==> Created fix commit $(git rev-parse --short HEAD). Re-running review on new HEAD..."
@@ -678,18 +847,16 @@ PASS
     CODEX_REVIEW_BLOCKED)
       echo ""
       printf "${C_RED}"
-      cat <<'BLOCKED'
-  ╔══════════════════════════════════════╗
-  ║          🚫 PUSH BLOCKED           ║
-  ║    Codex found issues to address    ║
-  ╚══════════════════════════════════════╝
-BLOCKED
+      printf '  ╔══════════════════════════════════════╗\n'
+      printf '  ║          🚫 PUSH BLOCKED           ║\n'
+      printf '  ║  %s found issues to address%s║\n' "$REVIEWER_LABEL" "$(printf '%*s' $((25 - ${#REVIEWER_LABEL})) '')"
+      printf '  ╚══════════════════════════════════════╝\n'
       printf "${C_RESET}"
       echo ""
       printf '%s\n' "$OUTPUT" | sed 's/^/    /'
       echo ""
       if [ "$FIX_COMMITS" -gt 0 ]; then
-        echo "    Note: Codex made $FIX_COMMITS fix commit(s) earlier this run that are still in your local history."
+        echo "    Note: $REVIEWER_LABEL made $FIX_COMMITS fix commit(s) earlier this run that are still in your local history."
         echo "    To undo them: git reset --hard HEAD~$FIX_COMMITS"
       fi
       echo "    Address findings and try again. Emergency override: git push --no-verify"
@@ -697,7 +864,7 @@ BLOCKED
       ;;
 
     *)
-      echo "==> Codex output did not match the expected sentinel contract — not blocking push."
+      echo "==> $REVIEWER_LABEL output did not match the expected sentinel contract — not blocking push."
       echo "    Last line was: '$LAST_LINE'"
       echo "    Raw output (first 20 lines):"
       printf '%s\n' "$OUTPUT" | head -20 | sed 's/^/    /'
@@ -707,8 +874,8 @@ BLOCKED
 done
 
 echo ""
-echo "==> Codex review loop did not converge after $MAX_ITERATIONS iterations."
-echo "    Codex made $FIX_COMMITS fix commit(s) but kept finding new issues."
+echo "==> Review loop did not converge after $MAX_ITERATIONS iterations."
+echo "    $REVIEWER_LABEL made $FIX_COMMITS fix commit(s) but kept finding new issues."
 echo "    Push aborted. Investigate manually:"
 echo "      git log --oneline -$((MAX_ITERATIONS + 1))"
 echo "      git diff HEAD~$FIX_COMMITS..HEAD"

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -7,7 +7,7 @@
 #
 # What this does:
 #   1. Verifies the PR is open and mergeable.
-#   2. Runs Codex review as a merge gate.
+#   2. Runs AI code review as a merge gate.
 #   3. Squash-merges and deletes the remote branch.
 #   4. Checks out the default branch and pulls the updated state.
 #
@@ -43,7 +43,7 @@ truthy() {
   esac
 }
 
-run_codex_merge_review() {
+run_merge_review() {
   local current_branch default_base_ref local_head pr_head_branch pr_head_oid
 
   if ! pr_head_branch="$(gh pr view "$PR_NUMBER" --json headRefName --jq '.headRefName' 2>/dev/null)"; then
@@ -65,36 +65,36 @@ run_codex_merge_review() {
 
   REVIEWED_HEAD_OID="$pr_head_oid"
 
-  if truthy "${SKIP_CODEX_REVIEW:-false}"; then
-    echo "==> Skipping Codex merge review because SKIP_CODEX_REVIEW is set."
+  if truthy "${SKIP_REVIEW:-${SKIP_CODEX_REVIEW:-false}}"; then
+    echo "==> Skipping merge review because SKIP_REVIEW is set."
     return 0
   fi
 
   if [ ! -f "$REVIEW_SCRIPT" ]; then
-    echo "==> Codex review script not found at $REVIEW_SCRIPT — skipping review."
+    echo "==> Review script not found at $REVIEW_SCRIPT — skipping review."
     return 0
   fi
 
   default_base_ref="origin/$DEFAULT_BRANCH"
-  echo "==> Refreshing $default_base_ref for Codex review ..."
+  echo "==> Refreshing $default_base_ref for merge review ..."
   if ! git fetch origin "+refs/heads/$DEFAULT_BRANCH:refs/remotes/origin/$DEFAULT_BRANCH"; then
-    echo "ERROR: Failed to refresh $default_base_ref before Codex review." >&2
+    echo "ERROR: Failed to refresh $default_base_ref before merge review." >&2
     exit 1
   fi
   if ! git rev-parse --verify --quiet "$default_base_ref^{commit}" >/dev/null; then
-    echo "ERROR: Could not verify $default_base_ref before Codex review." >&2
+    echo "ERROR: Could not verify $default_base_ref before merge review." >&2
     exit 1
   fi
 
   if [ -n "$(git status --porcelain)" ]; then
-    echo "ERROR: Working tree has uncommitted changes; refusing to run Codex review against an ambiguous tree." >&2
+    echo "ERROR: Working tree has uncommitted changes; refusing to run review against an ambiguous tree." >&2
     exit 1
   fi
 
   current_branch="$(git rev-parse --abbrev-ref HEAD)"
   local_head="$(git rev-parse HEAD)"
   if [ "$current_branch" != "$pr_head_branch" ] || [ "$local_head" != "$pr_head_oid" ]; then
-    echo "==> Checking out PR #$PR_NUMBER head ($pr_head_branch) for Codex review ..."
+    echo "==> Checking out PR #$PR_NUMBER head ($pr_head_branch) for merge review ..."
     gh pr checkout "$PR_NUMBER" --detach
     local_head="$(git rev-parse HEAD)"
   fi
@@ -106,7 +106,7 @@ run_codex_merge_review() {
     exit 1
   fi
 
-  echo "==> Running Codex merge review ..."
+  echo "==> Running merge review ..."
   CODEX_REVIEW_BASE="$default_base_ref" \
     CODEX_REVIEW_FORCE=1 \
     CODEX_REVIEW_NO_AUTOFIX=1 \
@@ -151,8 +151,8 @@ if [ "$STATE" != "CLEAN" ] || [ "$MERGEABLE" != "MERGEABLE" ]; then
   exit 1
 fi
 
-# 3. Run Codex as the merge gate.
-run_codex_merge_review
+# 3. Run AI review as the merge gate.
+run_merge_review
 
 # 4. Squash-merge and delete the branch.
 echo "==> Squash-merging PR #$PR_NUMBER ..."

--- a/tests/test-merge-pr.sh
+++ b/tests/test-merge-pr.sh
@@ -123,9 +123,9 @@ PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
   bash "$MERGE_SCRIPT_DIR/merge-pr.sh" 123 >"$OUTPUT_FILE" 2>&1
 
 if grep -q 'attempt 1: mergeStateStatus=CLEAN mergeable=MERGEABLE' "$OUTPUT_FILE" \
-  && grep -q '==> Refreshing origin/main for Codex review' "$OUTPUT_FILE" \
-  && grep -q '==> Checking out PR #123 head (feature/test) for Codex review' "$OUTPUT_FILE" \
-  && grep -q '==> Running Codex merge review' "$OUTPUT_FILE" \
+  && grep -q '==> Refreshing origin/main for merge review' "$OUTPUT_FILE" \
+  && grep -q '==> Checking out PR #123 head (feature/test) for merge review' "$OUTPUT_FILE" \
+  && grep -q '==> Running merge review' "$OUTPUT_FILE" \
   && grep -q '==> Done\.' "$OUTPUT_FILE" \
   && grep -q '^checked-out$' "$GH_CHECKOUT_FILE" \
   && grep -q '^pr-head-oid$' "$GH_MERGE_HEAD_FILE" \

--- a/tests/test-review-hook.sh
+++ b/tests/test-review-hook.sh
@@ -50,6 +50,7 @@ EOF
 cat > "$FAKE_BIN/codex" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+if [ "${1:-}" = "login" ] && [ "${2:-}" = "status" ]; then exit 0; fi
 prompt="${@: -1}"
 printf '%s' "$prompt" > "$PROMPT_FILE"
 printf 'CODEX_REVIEW_CLEAN\n'
@@ -81,6 +82,7 @@ echo "==> Test: review hook skips feature-branch pushes but runs default-branch 
 cat > "$FAKE_BIN/codex" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+if [ "${1:-}" = "login" ] && [ "${2:-}" = "status" ]; then exit 0; fi
 printf 'called\n' >> "$CODEX_CALLS_FILE"
 printf 'CODEX_REVIEW_CLEAN\n'
 EOF
@@ -158,6 +160,7 @@ rm -rf "$(git -C "$REPO_DIR" rev-parse --absolute-git-dir)/toolkit/codex-review-
 cat > "$FAKE_BIN/codex" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+if [ "${1:-}" = "login" ] && [ "${2:-}" = "status" ]; then exit 0; fi
 printf 'called\n' >> "$CODEX_CALLS_FILE"
 printf 'CODEX_REVIEW_CLEAN\n'
 EOF
@@ -212,6 +215,7 @@ echo "==> Test: review hook preserves # inside quoted unsafe_paths"
 cat > "$FAKE_BIN/codex" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+if [ "${1:-}" = "login" ] && [ "${2:-}" = "status" ]; then exit 0; fi
 prompt="${@: -1}"
 printf '%s' "$prompt" > "$PROMPT_FILE"
 printf 'CODEX_REVIEW_CLEAN\n'
@@ -267,6 +271,7 @@ git -C "$REPO_UNSAFE" commit -m "change" >/dev/null 2>&1
 cat > "$FAKE_BIN/codex" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+if [ "${1:-}" = "login" ] && [ "${2:-}" = "status" ]; then exit 0; fi
 printf 'codex edit\n' >> bootstrap/new-project.sh
 printf 'fixed unsafe path\n'
 printf 'CODEX_REVIEW_FIXED\n'
@@ -342,6 +347,7 @@ printf 'CODEX_REVIEW_CLEAN\n'
 CLEOF
 cat > "$CASCADE_BIN/codex" <<'CXEOF'
 #!/usr/bin/env bash
+if [ "${1:-}" = "login" ] && [ "${2:-}" = "status" ]; then exit 0; fi
 printf '%s\n' "codex-called" >> "$CASCADE_CALLS"
 printf 'CODEX_REVIEW_CLEAN\n'
 CXEOF
@@ -383,6 +389,7 @@ echo "main"
 EOF
 cat > "$CASCADE_BIN/codex" <<'CXEOF'
 #!/usr/bin/env bash
+if [ "${1:-}" = "login" ] && [ "${2:-}" = "status" ]; then exit 0; fi
 printf '%s\n' "codex-called" >> "$CASCADE_CALLS"
 printf 'CODEX_REVIEW_CLEAN\n'
 CXEOF
@@ -431,6 +438,7 @@ printf 'CODEX_REVIEW_CLEAN\n'
 CLEOF
 cat > "$CASCADE_BIN/codex" <<'CXEOF'
 #!/usr/bin/env bash
+if [ "${1:-}" = "login" ] && [ "${2:-}" = "status" ]; then exit 0; fi
 printf '%s\n' "codex-called" >> "$CASCADE_CALLS"
 printf 'CODEX_REVIEW_CLEAN\n'
 CXEOF
@@ -517,6 +525,7 @@ printf 'CODEX_REVIEW_CLEAN\n'
 CLEOF
 cat > "$CASCADE_BIN/codex" <<'CXEOF'
 #!/usr/bin/env bash
+if [ "${1:-}" = "login" ] && [ "${2:-}" = "status" ]; then exit 0; fi
 printf '%s\n' "codex-called" >> "$CASCADE_CALLS"
 printf 'CODEX_REVIEW_CLEAN\n'
 CXEOF
@@ -596,6 +605,7 @@ echo "main"
 EOF
 cat > "$CASCADE_BIN/codex" <<'CXEOF'
 #!/usr/bin/env bash
+if [ "${1:-}" = "login" ] && [ "${2:-}" = "status" ]; then exit 0; fi
 printf '%s\n' "codex-called" >> "$CASCADE_CALLS"
 printf 'CODEX_REVIEW_CLEAN\n'
 CXEOF

--- a/tests/test-review-hook.sh
+++ b/tests/test-review-hook.sh
@@ -101,9 +101,9 @@ chmod +x "$FAKE_BIN/codex"
 
 CODEX_CALL_COUNT="$(wc -l < "$CODEX_CALLS_FILE" | tr -d ' ')"
 if [ "$CODEX_CALL_COUNT" = "0" ] && grep -q 'skipping push to feature/test' "$TEST_DIR/feature-push-output.txt"; then
-  echo "==> PASS: feature-branch push skipped Codex"
+  echo "==> PASS: feature-branch push skipped review"
 else
-  echo "FAIL: expected feature-branch push to skip Codex" >&2
+  echo "FAIL: expected feature-branch push to skip review" >&2
   echo "codex call count: $CODEX_CALL_COUNT" >&2
   cat "$TEST_DIR/feature-push-output.txt" >&2
   ERRORS=$((ERRORS + 1))
@@ -123,9 +123,9 @@ fi
 
 CODEX_CALL_COUNT="$(wc -l < "$CODEX_CALLS_FILE" | tr -d ' ')"
 if [ "$CODEX_CALL_COUNT" = "1" ]; then
-  echo "==> PASS: default-branch push ran Codex"
+  echo "==> PASS: default-branch push ran review"
 else
-  echo "FAIL: expected default-branch push to run Codex" >&2
+  echo "FAIL: expected default-branch push to run review" >&2
   echo "codex call count: $CODEX_CALL_COUNT" >&2
   ERRORS=$((ERRORS + 1))
 fi
@@ -144,10 +144,10 @@ echo "==> Test: review hook skips nested Codex review subprocesses"
 )
 
 CODEX_CALL_COUNT="$(wc -l < "$CODEX_CALLS_FILE" | tr -d ' ')"
-if [ "$CODEX_CALL_COUNT" = "0" ] && grep -q 'skipping nested Codex review' "$TEST_DIR/nested-review-output.txt"; then
-  echo "==> PASS: nested Codex review skipped"
+if [ "$CODEX_CALL_COUNT" = "0" ] && grep -q 'skipping nested review' "$TEST_DIR/nested-review-output.txt"; then
+  echo "==> PASS: nested review skipped"
 else
-  echo "FAIL: expected nested Codex review to skip Codex" >&2
+  echo "FAIL: expected nested review to be skipped" >&2
   echo "codex call count: $CODEX_CALL_COUNT" >&2
   cat "$TEST_DIR/nested-review-output.txt" >&2
   ERRORS=$((ERRORS + 1))
@@ -182,9 +182,9 @@ chmod +x "$FAKE_BIN/codex"
 
 CODEX_CALL_COUNT="$(wc -l < "$CODEX_CALLS_FILE" | tr -d ' ')"
 if [ "$CODEX_CALL_COUNT" = "1" ] && grep -q 'previously passed for this exact diff' "$CACHE_OUTPUT"; then
-  echo "==> PASS: clean review cache skipped the repeated Codex call"
+  echo "==> PASS: clean review cache skipped the repeated review call"
 else
-  echo "FAIL: expected clean review cache to skip the repeated Codex call" >&2
+  echo "FAIL: expected clean review cache to skip the repeated review call" >&2
   echo "codex call count: $CODEX_CALL_COUNT" >&2
   cat "$CACHE_OUTPUT" >&2
   ERRORS=$((ERRORS + 1))
@@ -293,6 +293,391 @@ if [ "$UNSAFE_EXIT" -eq 1 ] \
 else
   echo "FAIL: expected unsafe auto-fix to be blocked without creating a commit" >&2
   cat "$UNSAFE_OUTPUT" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ==========================================================================
+# Reviewer cascade tests
+# ==========================================================================
+
+CASCADE_REPO="$TEST_DIR/repo-cascade"
+CASCADE_CALLS="$TEST_DIR/cascade-calls.txt"
+CASCADE_OUTPUT="$TEST_DIR/cascade-output.txt"
+
+setup_cascade_repo() {
+  rm -rf "$CASCADE_REPO"
+  mkdir -p "$CASCADE_REPO"
+  git -C "$CASCADE_REPO" init >/dev/null 2>&1
+  git -C "$CASCADE_REPO" config user.name "Toolkit Test"
+  git -C "$CASCADE_REPO" config user.email "toolkit@example.com"
+  printf 'base\n' > "$CASCADE_REPO/example.txt"
+  git -C "$CASCADE_REPO" add example.txt
+  git -C "$CASCADE_REPO" commit -m "base" >/dev/null 2>&1
+  printf 'changed\n' >> "$CASCADE_REPO/example.txt"
+  git -C "$CASCADE_REPO" add example.txt
+  git -C "$CASCADE_REPO" commit -m "change" >/dev/null 2>&1
+}
+
+echo "==> Test: cascade selects first available reviewer"
+setup_cascade_repo
+{
+  printf '[codex_review]\nsafe_by_default = true\n'
+  printf '[review]\nreviewers = ["claude", "codex"]\n'
+} > "$CASCADE_REPO/.codex-review.toml"
+git -C "$CASCADE_REPO" add .codex-review.toml
+git -C "$CASCADE_REPO" commit -m "config" >/dev/null 2>&1
+
+CASCADE_BIN="$TEST_DIR/cascade-bin"
+rm -rf "$CASCADE_BIN"
+mkdir -p "$CASCADE_BIN"
+cat > "$CASCADE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "main"
+EOF
+cat > "$CASCADE_BIN/claude" <<'CLEOF'
+#!/usr/bin/env bash
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then exit 0; fi
+printf '%s\n' "claude-called" >> "$CASCADE_CALLS"
+printf 'CODEX_REVIEW_CLEAN\n'
+CLEOF
+cat > "$CASCADE_BIN/codex" <<'CXEOF'
+#!/usr/bin/env bash
+printf '%s\n' "codex-called" >> "$CASCADE_CALLS"
+printf 'CODEX_REVIEW_CLEAN\n'
+CXEOF
+chmod +x "$CASCADE_BIN/gh" "$CASCADE_BIN/claude" "$CASCADE_BIN/codex"
+: > "$CASCADE_CALLS"
+
+(
+  cd "$CASCADE_REPO"
+  PATH="$CASCADE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CASCADE_CALLS="$CASCADE_CALLS" \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    bash "$TOOLKIT_ROOT/hooks/codex-review.sh" > "$CASCADE_OUTPUT" 2>&1
+)
+
+if grep -q 'claude-called' "$CASCADE_CALLS" && ! grep -q 'codex-called' "$CASCADE_CALLS"; then
+  echo "==> PASS: cascade selected claude (first available)"
+else
+  echo "FAIL: expected cascade to select claude as first reviewer" >&2
+  cat "$CASCADE_CALLS" >&2
+  cat "$CASCADE_OUTPUT" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo "==> Test: cascade skips unavailable reviewer"
+setup_cascade_repo
+{
+  printf '[codex_review]\nsafe_by_default = true\n'
+  printf '[review]\nreviewers = ["claude", "codex"]\n'
+} > "$CASCADE_REPO/.codex-review.toml"
+git -C "$CASCADE_REPO" add .codex-review.toml
+git -C "$CASCADE_REPO" commit -m "config" >/dev/null 2>&1
+
+rm -rf "$CASCADE_BIN"
+mkdir -p "$CASCADE_BIN"
+cat > "$CASCADE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "main"
+EOF
+cat > "$CASCADE_BIN/codex" <<'CXEOF'
+#!/usr/bin/env bash
+printf '%s\n' "codex-called" >> "$CASCADE_CALLS"
+printf 'CODEX_REVIEW_CLEAN\n'
+CXEOF
+chmod +x "$CASCADE_BIN/gh" "$CASCADE_BIN/codex"
+: > "$CASCADE_CALLS"
+
+(
+  cd "$CASCADE_REPO"
+  PATH="$CASCADE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CASCADE_CALLS="$CASCADE_CALLS" \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    bash "$TOOLKIT_ROOT/hooks/codex-review.sh" > "$CASCADE_OUTPUT" 2>&1
+)
+
+if grep -q 'codex-called' "$CASCADE_CALLS" && grep -q 'Using reviewer: Codex' "$CASCADE_OUTPUT"; then
+  echo "==> PASS: cascade skipped claude (unavailable), used codex"
+else
+  echo "FAIL: expected cascade to skip claude and use codex" >&2
+  cat "$CASCADE_CALLS" >&2
+  cat "$CASCADE_OUTPUT" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo "==> Test: cascade skips auth-failed reviewer"
+setup_cascade_repo
+{
+  printf '[codex_review]\nsafe_by_default = true\n'
+  printf '[review]\nreviewers = ["claude", "codex"]\n'
+} > "$CASCADE_REPO/.codex-review.toml"
+git -C "$CASCADE_REPO" add .codex-review.toml
+git -C "$CASCADE_REPO" commit -m "config" >/dev/null 2>&1
+
+rm -rf "$CASCADE_BIN"
+mkdir -p "$CASCADE_BIN"
+cat > "$CASCADE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "main"
+EOF
+# claude is installed but auth fails
+cat > "$CASCADE_BIN/claude" <<'CLEOF'
+#!/usr/bin/env bash
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then exit 1; fi
+printf '%s\n' "claude-called" >> "$CASCADE_CALLS"
+printf 'CODEX_REVIEW_CLEAN\n'
+CLEOF
+cat > "$CASCADE_BIN/codex" <<'CXEOF'
+#!/usr/bin/env bash
+printf '%s\n' "codex-called" >> "$CASCADE_CALLS"
+printf 'CODEX_REVIEW_CLEAN\n'
+CXEOF
+chmod +x "$CASCADE_BIN/gh" "$CASCADE_BIN/claude" "$CASCADE_BIN/codex"
+: > "$CASCADE_CALLS"
+
+(
+  cd "$CASCADE_REPO"
+  PATH="$CASCADE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CASCADE_CALLS="$CASCADE_CALLS" \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    bash "$TOOLKIT_ROOT/hooks/codex-review.sh" > "$CASCADE_OUTPUT" 2>&1
+)
+
+if grep -q 'codex-called' "$CASCADE_CALLS" && ! grep -q 'claude-called' "$CASCADE_CALLS"; then
+  echo "==> PASS: cascade skipped claude (auth failed), used codex"
+else
+  echo "FAIL: expected cascade to skip auth-failed claude and use codex" >&2
+  cat "$CASCADE_CALLS" >&2
+  cat "$CASCADE_OUTPUT" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo "==> Test: all reviewers unavailable exits 0 with diagnostics"
+setup_cascade_repo
+{
+  printf '[codex_review]\nsafe_by_default = true\n'
+  printf '[review]\nreviewers = ["claude", "gemini"]\n'
+} > "$CASCADE_REPO/.codex-review.toml"
+git -C "$CASCADE_REPO" add .codex-review.toml
+git -C "$CASCADE_REPO" commit -m "config" >/dev/null 2>&1
+
+rm -rf "$CASCADE_BIN"
+mkdir -p "$CASCADE_BIN"
+cat > "$CASCADE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "main"
+EOF
+chmod +x "$CASCADE_BIN/gh"
+
+set +e
+(
+  cd "$CASCADE_REPO"
+  PATH="$CASCADE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    bash "$TOOLKIT_ROOT/hooks/codex-review.sh" > "$CASCADE_OUTPUT" 2>&1
+)
+ALL_UNAVAIL_EXIT=$?
+set -e
+
+if [ "$ALL_UNAVAIL_EXIT" -eq 0 ] \
+  && grep -q 'No reviewer available' "$CASCADE_OUTPUT" \
+  && grep -q 'claude: CLI not installed' "$CASCADE_OUTPUT" \
+  && grep -q 'gemini: CLI not installed' "$CASCADE_OUTPUT"; then
+  echo "==> PASS: all reviewers unavailable — exited 0 with diagnostics"
+else
+  echo "FAIL: expected exit 0 and diagnostics when all reviewers unavailable" >&2
+  echo "exit code: $ALL_UNAVAIL_EXIT" >&2
+  cat "$CASCADE_OUTPUT" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo "==> Test: TOOLKIT_REVIEWER forces a specific reviewer"
+setup_cascade_repo
+{
+  printf '[codex_review]\nsafe_by_default = true\n'
+  printf '[review]\nreviewers = ["claude", "codex"]\n'
+} > "$CASCADE_REPO/.codex-review.toml"
+git -C "$CASCADE_REPO" add .codex-review.toml
+git -C "$CASCADE_REPO" commit -m "config" >/dev/null 2>&1
+
+rm -rf "$CASCADE_BIN"
+mkdir -p "$CASCADE_BIN"
+cat > "$CASCADE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "main"
+EOF
+cat > "$CASCADE_BIN/claude" <<'CLEOF'
+#!/usr/bin/env bash
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then exit 0; fi
+printf '%s\n' "claude-called" >> "$CASCADE_CALLS"
+printf 'CODEX_REVIEW_CLEAN\n'
+CLEOF
+cat > "$CASCADE_BIN/codex" <<'CXEOF'
+#!/usr/bin/env bash
+printf '%s\n' "codex-called" >> "$CASCADE_CALLS"
+printf 'CODEX_REVIEW_CLEAN\n'
+CXEOF
+chmod +x "$CASCADE_BIN/gh" "$CASCADE_BIN/claude" "$CASCADE_BIN/codex"
+: > "$CASCADE_CALLS"
+
+(
+  cd "$CASCADE_REPO"
+  PATH="$CASCADE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CASCADE_CALLS="$CASCADE_CALLS" \
+    TOOLKIT_REVIEWER=codex \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    bash "$TOOLKIT_ROOT/hooks/codex-review.sh" > "$CASCADE_OUTPUT" 2>&1
+)
+
+if grep -q 'codex-called' "$CASCADE_CALLS" && ! grep -q 'claude-called' "$CASCADE_CALLS" \
+  && grep -q 'Using reviewer: Codex' "$CASCADE_OUTPUT"; then
+  echo "==> PASS: TOOLKIT_REVIEWER=codex forced codex despite claude being first"
+else
+  echo "FAIL: expected TOOLKIT_REVIEWER to force codex" >&2
+  cat "$CASCADE_CALLS" >&2
+  cat "$CASCADE_OUTPUT" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo "==> Test: TOOLKIT_REVIEWER hard-fails when reviewer unavailable"
+setup_cascade_repo
+{
+  printf '[codex_review]\nsafe_by_default = true\n'
+} > "$CASCADE_REPO/.codex-review.toml"
+git -C "$CASCADE_REPO" add .codex-review.toml
+git -C "$CASCADE_REPO" commit -m "config" >/dev/null 2>&1
+
+rm -rf "$CASCADE_BIN"
+mkdir -p "$CASCADE_BIN"
+cat > "$CASCADE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "main"
+EOF
+chmod +x "$CASCADE_BIN/gh"
+
+set +e
+(
+  cd "$CASCADE_REPO"
+  PATH="$CASCADE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    TOOLKIT_REVIEWER=claude \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    bash "$TOOLKIT_ROOT/hooks/codex-review.sh" > "$CASCADE_OUTPUT" 2>&1
+)
+FORCED_UNAVAIL_EXIT=$?
+set -e
+
+if [ "$FORCED_UNAVAIL_EXIT" -eq 1 ] \
+  && grep -q 'TOOLKIT_REVIEWER=claude' "$CASCADE_OUTPUT"; then
+  echo "==> PASS: TOOLKIT_REVIEWER hard-failed when reviewer unavailable"
+else
+  echo "FAIL: expected exit 1 when TOOLKIT_REVIEWER names unavailable reviewer" >&2
+  echo "exit code: $FORCED_UNAVAIL_EXIT" >&2
+  cat "$CASCADE_OUTPUT" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo "==> Test: missing [review] section defaults to codex"
+setup_cascade_repo
+{
+  printf '[codex_review]\nsafe_by_default = true\n'
+} > "$CASCADE_REPO/.codex-review.toml"
+git -C "$CASCADE_REPO" add .codex-review.toml
+git -C "$CASCADE_REPO" commit -m "config" >/dev/null 2>&1
+
+rm -rf "$CASCADE_BIN"
+mkdir -p "$CASCADE_BIN"
+cat > "$CASCADE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "main"
+EOF
+cat > "$CASCADE_BIN/codex" <<'CXEOF'
+#!/usr/bin/env bash
+printf '%s\n' "codex-called" >> "$CASCADE_CALLS"
+printf 'CODEX_REVIEW_CLEAN\n'
+CXEOF
+chmod +x "$CASCADE_BIN/gh" "$CASCADE_BIN/codex"
+: > "$CASCADE_CALLS"
+
+(
+  cd "$CASCADE_REPO"
+  PATH="$CASCADE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CASCADE_CALLS="$CASCADE_CALLS" \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    bash "$TOOLKIT_ROOT/hooks/codex-review.sh" > "$CASCADE_OUTPUT" 2>&1
+)
+
+if grep -q 'codex-called' "$CASCADE_CALLS" && grep -q 'Using reviewer: Codex' "$CASCADE_OUTPUT"; then
+  echo "==> PASS: missing [review] section defaulted to codex"
+else
+  echo "FAIL: expected missing [review] to default to codex" >&2
+  cat "$CASCADE_CALLS" >&2
+  cat "$CASCADE_OUTPUT" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo "==> Test: claude adapter restricts tools in review-only mode"
+setup_cascade_repo
+{
+  printf '[codex_review]\nsafe_by_default = true\n'
+  printf '[review]\nreviewers = ["claude"]\n'
+} > "$CASCADE_REPO/.codex-review.toml"
+git -C "$CASCADE_REPO" add .codex-review.toml
+git -C "$CASCADE_REPO" commit -m "config" >/dev/null 2>&1
+
+CLAUDE_ARGS_FILE="$TEST_DIR/claude-args.txt"
+rm -rf "$CASCADE_BIN"
+mkdir -p "$CASCADE_BIN"
+cat > "$CASCADE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "main"
+EOF
+cat > "$CASCADE_BIN/claude" <<'CLEOF'
+#!/usr/bin/env bash
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then exit 0; fi
+printf '%s\n' "$*" > "$CLAUDE_ARGS_FILE"
+printf 'CODEX_REVIEW_CLEAN\n'
+CLEOF
+chmod +x "$CASCADE_BIN/gh" "$CASCADE_BIN/claude"
+
+# Test review-only mode (no Edit/Write)
+(
+  cd "$CASCADE_REPO"
+  PATH="$CASCADE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CLAUDE_ARGS_FILE="$CLAUDE_ARGS_FILE" \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    CODEX_REVIEW_NO_AUTOFIX=1 \
+    bash "$TOOLKIT_ROOT/hooks/codex-review.sh" > "$CASCADE_OUTPUT" 2>&1
+)
+
+if grep -q 'Read,Grep,Glob,Bash' "$CLAUDE_ARGS_FILE" && ! grep -q 'Edit' "$CLAUDE_ARGS_FILE"; then
+  echo "==> PASS: claude adapter used read-only tools in review-only mode"
+else
+  echo "FAIL: expected claude to use read-only tools when NO_AUTOFIX is set" >&2
+  cat "$CLAUDE_ARGS_FILE" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# Test auto-fix mode (includes Edit/Write)
+(
+  cd "$CASCADE_REPO"
+  PATH="$CASCADE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CLAUDE_ARGS_FILE="$CLAUDE_ARGS_FILE" \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    bash "$TOOLKIT_ROOT/hooks/codex-review.sh" > "$CASCADE_OUTPUT" 2>&1
+)
+
+if grep -q 'Edit,Write' "$CLAUDE_ARGS_FILE"; then
+  echo "==> PASS: claude adapter included Edit,Write tools in auto-fix mode"
+else
+  echo "FAIL: expected claude to include Edit,Write tools when autofix enabled" >&2
+  cat "$CLAUDE_ARGS_FILE" >&2
   ERRORS=$((ERRORS + 1))
 fi
 


### PR DESCRIPTION
The review hook was hard-wired to Codex — if it wasn't installed, review
was silently skipped. This adds a reviewer abstraction layer with three
adapters and a configurable fallback cascade so at least one reviewer
always runs when available.

New [review] section in .codex-review.toml:
  reviewers = ["claude", "codex", "gemini"]

Backward compatible: missing section defaults to ["codex"].
TOOLKIT_REVIEWER env var forces a specific reviewer.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
