### PR TITLE
Add first-class review modes with wrapper-level enforcement

### DIFF
--- a/hooks/codex-review.config.example.toml
+++ b/hooks/codex-review.config.example.toml
@@ -24,6 +24,16 @@ cache_clean_reviews = true
 # For new projects, start with false and gradually opt in as you gain confidence.
 safe_by_default = false
 
+# Review mode — controls what the reviewer is allowed to do.
+# Enforced at the wrapper level (tool restrictions, sandboxes), not just in the prompt.
+#   "fix"         — full access: read, run commands, edit files, commit fixes (default)
+#   "review-only" — read + run commands, no file edits or commits
+#   "diff-only"   — read-only: no commands, no edits
+#   "no-tests"    — read + edit + commit, no command execution (skip test runs)
+#
+# Override for a single run with: CODEX_REVIEW_MODE=review-only git push
+# mode = "fix"
+
 # Paths where the reviewer must NEVER auto-fix — it reports findings but does not edit.
 # Use these for high-scrutiny areas where auto-fixes could cause damage.
 # Paths are matched as prefixes (e.g., "src/auth/" matches "src/auth/login.py").

--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -25,15 +25,25 @@
 #   (no auto-fix). This is the conservative default — opt in to auto-fix
 #   explicitly by listing safe paths or setting safe_by_default = true.
 #
+# Modes:
+#   review-only — reviewer can read + run commands, but cannot edit files or commit
+#   fix         — full access: reviewer can edit, stage, and commit auto-fixes
+#   diff-only   — read-only: reviewer can only read files, no commands or edits
+#   no-tests    — reviewer can edit and commit, but cannot run commands (no test execution)
+#
+#   Modes are enforced at the wrapper level (tool restrictions, sandboxes), not just
+#   in the prompt. Set via CODEX_REVIEW_MODE env var or `mode` in .codex-review.toml.
+#
 # Env overrides:
 #   TOOLKIT_REVIEWER              — force a specific reviewer (skips cascade, hard-fails if unavailable)
+#   CODEX_REVIEW_MODE             — review-only|fix|diff-only|no-tests (default: fix)
 #   CODEX_REVIEW_BASE             — base ref to diff against (default: origin/<default-branch>)
 #   CODEX_REVIEW_MAX_ITERATIONS   — fix loop cap (default: from config, or 3)
 #   CODEX_REVIEW_MAX_DIFF_LINES   — skip review if diff > this many lines (default: 5000)
 #   CODEX_REVIEW_CACHE_CLEAN      — cache exact-input clean reviews (default: true)
 #   CODEX_REVIEW_DISABLE_CACHE    — set to true/1 to force a fresh review
 #   CODEX_REVIEW_FORCE            — set to true/1 to run even on non-default-branch pushes
-#   CODEX_REVIEW_NO_AUTOFIX       — set to true/1 for review-only mode
+#   CODEX_REVIEW_NO_AUTOFIX       — set to true/1 for review-only mode (backward compat)
 #   CODEX_REVIEW_IN_PROGRESS      — internal guard to skip nested review runs
 #
 # To bypass entirely in an emergency: git push --no-verify
@@ -58,6 +68,7 @@ MAX_ITERATIONS="${CODEX_REVIEW_MAX_ITERATIONS:-3}"
 MAX_DIFF_LINES="${CODEX_REVIEW_MAX_DIFF_LINES:-5000}"
 CACHE_CLEAN_REVIEWS="${CODEX_REVIEW_CACHE_CLEAN:-true}"
 NO_AUTOFIX="${CODEX_REVIEW_NO_AUTOFIX:-false}"
+CONFIG_MODE=""
 UNSAFE_PATHS=""
 REVIEWER_CASCADE=()
 
@@ -187,6 +198,13 @@ normalize_bool() {
   esac
 }
 
+is_truthy() {
+  case "$(normalize_bool "${1:-false}")" in
+    true) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # Parse .codex-review.toml if it exists.
 # We do minimal TOML parsing in bash — just key = value pairs and string arrays.
 if [ -f "$CONFIG_FILE" ]; then
@@ -262,6 +280,12 @@ if [ -f "$CONFIG_FILE" ]; then
         val="$(printf '%s' "$val" | tr '[:upper:]' '[:lower:]')"
         SAFE_BY_DEFAULT="$val"
         ;;
+      mode*=*)
+        val="$(trim "${line#*=}")"
+        val="${val%\"}"; val="${val#\"}"
+        val="${val%\'}"; val="${val#\'}"
+        CONFIG_MODE="$val"
+        ;;
       unsafe_paths*=*)
         array_value="$(trim "${line#*=}")"
         array_value="${array_value#\[}"
@@ -306,18 +330,46 @@ if [ -n "${TOOLKIT_REVIEWER:-}" ]; then
   REVIEWER_CASCADE=("$TOOLKIT_REVIEWER")
 fi
 
+# --------------------------------------------------------------------------
+# Mode resolution
+# --------------------------------------------------------------------------
+# Modes: review-only, fix, diff-only, no-tests
+#   review-only — read + bash, no edits, no git ops (default for merge review)
+#   fix         — full access, auto-fix + commit (default for pre-push)
+#   diff-only   — read-only, no bash, no edits
+#   no-tests    — edit + commit, no bash (skip test execution)
+
+resolve_mode() {
+  local mode="${CODEX_REVIEW_MODE:-}"
+
+  # Backward compat: NO_AUTOFIX=true maps to review-only
+  if [ -z "$mode" ] && is_truthy "$NO_AUTOFIX"; then
+    mode="review-only"
+  fi
+
+  # Fall back to config, then default
+  [ -n "$mode" ] || mode="${CONFIG_MODE:-fix}"
+
+  case "$mode" in
+    review-only|fix|diff-only|no-tests) ;;
+    *)
+      echo "ERROR: Invalid mode '$mode'. Valid: review-only, fix, diff-only, no-tests" >&2
+      exit 2
+      ;;
+  esac
+  printf '%s' "$mode"
+}
+
+REVIEW_MODE="$(resolve_mode)"
+
+mode_allows_fix()  { [ "$REVIEW_MODE" = "fix" ] || [ "$REVIEW_MODE" = "no-tests" ]; }
+mode_allows_bash() { [ "$REVIEW_MODE" = "fix" ] || [ "$REVIEW_MODE" = "review-only" ]; }
+
 short_ref_name() {
   local ref="$1"
   ref="${ref#refs/heads/}"
   ref="${ref#refs/remotes/origin/}"
   printf '%s' "$ref"
-}
-
-is_truthy() {
-  case "$(normalize_bool "${1:-false}")" in
-    true) return 0 ;;
-    *) return 1 ;;
-  esac
 }
 
 is_pre_push_hook() {
@@ -349,9 +401,9 @@ should_skip_pre_push_review() {
 build_autofix_policy() {
   local policy=""
 
-  if [ "$NO_AUTOFIX" = "true" ]; then
-    cat <<'POLICY_EOF'
-Do not edit files in this run. Do not stage, commit, or modify anything.
+  if ! mode_allows_fix; then
+    cat <<POLICY_EOF
+Mode: $REVIEW_MODE — do not edit files. Do not stage, commit, or modify anything.
 
 Review only:
 - If there are no blocking issues, emit CLEAN.
@@ -414,16 +466,24 @@ When in doubt, STOP and emit BLOCKED."
 reviewer_codex_available() { command -v codex >/dev/null 2>&1; }
 reviewer_codex_auth_ok()   { codex login status >/dev/null 2>&1; }
 reviewer_codex_exec() {
-  CODEX_REVIEW_IN_PROGRESS=1 codex exec --full-auto --ephemeral "$1" 2>/dev/null
+  local sandbox="read-only"
+  if mode_allows_fix; then
+    sandbox="workspace-write"
+  fi
+  CODEX_REVIEW_IN_PROGRESS=1 codex exec \
+    --sandbox "$sandbox" --ephemeral "$1" 2>/dev/null
 }
 
 reviewer_claude_available() { command -v claude >/dev/null 2>&1; }
 reviewer_claude_auth_ok()   { claude auth status >/dev/null 2>&1; }
 reviewer_claude_exec() {
-  local tools="Read,Grep,Glob,Bash"
-  if [ "$NO_AUTOFIX" != "true" ]; then
-    tools="Read,Grep,Glob,Bash,Edit,Write"
-  fi
+  local tools
+  case "$REVIEW_MODE" in
+    diff-only)    tools="Read,Grep,Glob" ;;
+    review-only)  tools="Read,Grep,Glob,Bash" ;;
+    no-tests)     tools="Read,Grep,Glob,Edit,Write" ;;
+    fix)          tools="Read,Grep,Glob,Bash,Edit,Write" ;;
+  esac
   CODEX_REVIEW_IN_PROGRESS=1 claude -p \
     --allowedTools "$tools" \
     --output-format text \
@@ -436,7 +496,7 @@ reviewer_gemini_auth_ok() {
   command -v gcloud >/dev/null 2>&1 && gcloud auth print-access-token >/dev/null 2>&1
 }
 reviewer_gemini_exec() {
-  if [ "$NO_AUTOFIX" != "true" ]; then
+  if mode_allows_fix; then
     CODEX_REVIEW_IN_PROGRESS=1 gemini -p "$1" --yolo 2>/dev/null
   else
     CODEX_REVIEW_IN_PROGRESS=1 gemini -p "$1" 2>/dev/null
@@ -802,9 +862,9 @@ PASS
       ;;
 
     CODEX_REVIEW_FIXED)
-      if [ "$NO_AUTOFIX" = "true" ]; then
-        echo "==> $REVIEWER_LABEL emitted FIXED during review-only mode."
-        echo "    Treating this as blocking because CODEX_REVIEW_NO_AUTOFIX=1 was set."
+      if ! mode_allows_fix; then
+        echo "==> $REVIEWER_LABEL emitted FIXED in '$REVIEW_MODE' mode."
+        echo "    The reviewer was restricted from editing — this should not happen."
         echo "    Inspect the working tree before continuing."
         exit 1
       fi
@@ -837,7 +897,7 @@ PASS
       echo ""
 
       git add -A
-      git commit -m "fix: address $REVIEWER_LABEL review findings (auto, iter $iter)"
+      git commit -m "fix: address $REVIEWER_LABEL review findings (auto, $REVIEW_MODE, iter $iter)"
       WORKTREE_DIRTY_BEFORE_REVIEW=false
       FIX_COMMITS=$((FIX_COMMITS + 1))
       echo "==> Created fix commit $(git rev-parse --short HEAD). Re-running review on new HEAD..."

--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -353,8 +353,8 @@ resolve_mode() {
   case "$mode" in
     review-only|fix|diff-only|no-tests) ;;
     *)
-      echo "ERROR: Invalid mode '$mode'. Valid: review-only, fix, diff-only, no-tests" >&2
-      exit 2
+      echo "WARNING: Invalid mode '$mode' — falling back to 'fix'. Valid: review-only, fix, diff-only, no-tests" >&2
+      mode="fix"
       ;;
   esac
   printf '%s' "$mode"
@@ -432,6 +432,13 @@ $(echo "$UNSAFE_PATHS" | while read -r p; do [ -n "$p" ] && echo "- Anything in 
     policy="$policy
 
 The working tree already has uncommitted changes. Do not edit files in this run; emit BLOCKED for issues that need changes."
+  fi
+
+  if [ "$REVIEW_MODE" = "no-tests" ]; then
+    policy="$policy
+
+IMPORTANT: Mode is 'no-tests'. Do NOT run any shell commands, test suites, or build tools.
+Review by reading files only. You may edit files to fix issues."
   fi
 
   policy="$policy
@@ -630,7 +637,7 @@ Do NOT flag: formatting, style, naming, missing docstrings, speculative refactor
 Examine the diff vs $BASE using your tools.
 $(if [ "$REVIEW_MODE" = "diff-only" ]; then
 printf '\n## Diff (included because mode=diff-only restricts tool access)\n\n```\n'
-git diff "$MERGE_BASE"..HEAD 2>/dev/null | head -2000
+git diff "$MERGE_BASE"..HEAD 2>/dev/null
 printf '```\n'
 fi)
 

--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -466,9 +466,17 @@ When in doubt, STOP and emit BLOCKED."
 reviewer_codex_available() { command -v codex >/dev/null 2>&1; }
 reviewer_codex_auth_ok()   { codex login status >/dev/null 2>&1; }
 reviewer_codex_exec() {
+  # Codex sandbox: read-only (no file writes) or workspace-write (edits allowed).
+  # Codex cannot selectively disable command execution, so diff-only and no-tests
+  # degrade: diff-only → read-only sandbox, no-tests → workspace-write sandbox.
+  # The prompt still instructs the reviewer, but enforcement is filesystem-only.
   local sandbox="read-only"
-  if mode_allows_fix; then
+  if [ "$REVIEW_MODE" = "fix" ] || [ "$REVIEW_MODE" = "no-tests" ]; then
     sandbox="workspace-write"
+  fi
+  if [ "$REVIEW_MODE" = "diff-only" ] || [ "$REVIEW_MODE" = "no-tests" ]; then
+    printf "  ${C_DIM}(codex: '%s' enforced via sandbox=%s + prompt; command restriction is prompt-level only)${C_RESET}\n" \
+      "$REVIEW_MODE" "$sandbox" >&2
   fi
   CODEX_REVIEW_IN_PROGRESS=1 codex exec \
     --sandbox "$sandbox" --ephemeral "$1" 2>/dev/null
@@ -477,6 +485,7 @@ reviewer_codex_exec() {
 reviewer_claude_available() { command -v claude >/dev/null 2>&1; }
 reviewer_claude_auth_ok()   { claude auth status >/dev/null 2>&1; }
 reviewer_claude_exec() {
+  # Claude has fine-grained --allowedTools: all four modes are fully enforced.
   local tools
   case "$REVIEW_MODE" in
     diff-only)    tools="Read,Grep,Glob" ;;
@@ -496,9 +505,16 @@ reviewer_gemini_auth_ok() {
   command -v gcloud >/dev/null 2>&1 && gcloud auth print-access-token >/dev/null 2>&1
 }
 reviewer_gemini_exec() {
-  if mode_allows_fix; then
+  # Gemini: --yolo (full auto-approve) or not (no auto-approve).
+  # Only fix mode uses --yolo. diff-only, review-only, and no-tests all run
+  # without --yolo. no-tests cannot be fully enforced (edits without commands)
+  # since Gemini lacks granular tool control.
+  if [ "$REVIEW_MODE" = "fix" ]; then
     CODEX_REVIEW_IN_PROGRESS=1 gemini -p "$1" --yolo 2>/dev/null
   else
+    if [ "$REVIEW_MODE" = "no-tests" ]; then
+      printf "  ${C_DIM}(gemini: 'no-tests' mode degrades to review-only; gemini lacks granular tool control)${C_RESET}\n" >&2
+    fi
     CODEX_REVIEW_IN_PROGRESS=1 gemini -p "$1" 2>/dev/null
   fi
 }
@@ -612,6 +628,11 @@ Read CLAUDE.md at the repo root for project context (if it exists).
 Do NOT flag: formatting, style, naming, missing docstrings, speculative refactors, "you could consider" observations without a concrete bug.
 
 Examine the diff vs $BASE using your tools.
+$(if [ "$REVIEW_MODE" = "diff-only" ]; then
+printf '\n## Diff (included because mode=diff-only restricts tool access)\n\n```\n'
+git diff "$MERGE_BASE"..HEAD 2>/dev/null | head -2000
+printf '```\n'
+fi)
 
 ## Auto-fix policy
 

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -109,7 +109,7 @@ run_merge_review() {
   echo "==> Running merge review ..."
   CODEX_REVIEW_BASE="$default_base_ref" \
     CODEX_REVIEW_FORCE=1 \
-    CODEX_REVIEW_NO_AUTOFIX=1 \
+    CODEX_REVIEW_MODE=review-only \
     bash "$REVIEW_SCRIPT"
 }
 

--- a/tests/test-merge-pr.sh
+++ b/tests/test-merge-pr.sh
@@ -20,7 +20,7 @@ set -euo pipefail
 {
   printf 'CODEX_REVIEW_BASE=%s\n' "${CODEX_REVIEW_BASE:-}"
   printf 'CODEX_REVIEW_FORCE=%s\n' "${CODEX_REVIEW_FORCE:-}"
-  printf 'CODEX_REVIEW_NO_AUTOFIX=%s\n' "${CODEX_REVIEW_NO_AUTOFIX:-}"
+  printf 'CODEX_REVIEW_MODE=%s\n' "${CODEX_REVIEW_MODE:-}"
 } > "$CODEX_REVIEW_LOG"
 EOF
 chmod +x "$MERGE_SCRIPT_DIR/merge-pr.sh" "$MERGE_SCRIPT_DIR/codex-review.sh"
@@ -131,7 +131,7 @@ if grep -q 'attempt 1: mergeStateStatus=CLEAN mergeable=MERGEABLE' "$OUTPUT_FILE
   && grep -q '^pr-head-oid$' "$GH_MERGE_HEAD_FILE" \
   && grep -q '^CODEX_REVIEW_BASE=origin/main$' "$CODEX_REVIEW_LOG" \
   && grep -q '^CODEX_REVIEW_FORCE=1$' "$CODEX_REVIEW_LOG" \
-  && grep -q '^CODEX_REVIEW_NO_AUTOFIX=1$' "$CODEX_REVIEW_LOG"; then
+  && grep -q '^CODEX_REVIEW_MODE=review-only$' "$CODEX_REVIEW_LOG"; then
   echo "==> PASS: merge-pr.sh completed without jq"
   exit 0
 fi

--- a/tests/test-review-hook.sh
+++ b/tests/test-review-hook.sh
@@ -889,24 +889,39 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
-echo "==> Test: invalid mode exits 2"
-set +e
+echo "==> Test: invalid mode warns and falls back to fix"
+setup_mode_repo
+rm -rf "$MODE_BIN"
+mkdir -p "$MODE_BIN"
+cat > "$MODE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "main"
+EOF
+cat > "$MODE_BIN/codex" <<'CXEOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = "login" ] && [ "${2:-}" = "status" ]; then exit 0; fi
+printf '%s\n' "$*" > "$CODEX_ARGS_FILE"
+printf 'CODEX_REVIEW_CLEAN\n'
+CXEOF
+chmod +x "$MODE_BIN/gh" "$MODE_BIN/codex"
+
 (
   cd "$MODE_REPO"
   PATH="$MODE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CODEX_ARGS_FILE="$CODEX_ARGS_FILE" \
     CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
     CODEX_REVIEW_MODE=invalid \
     bash "$TOOLKIT_ROOT/hooks/codex-review.sh" > "$MODE_OUTPUT" 2>&1
 )
-INVALID_MODE_EXIT=$?
-set -e
 
-if [ "$INVALID_MODE_EXIT" -eq 2 ] && grep -q "Invalid mode" "$MODE_OUTPUT"; then
-  echo "==> PASS: invalid mode exits 2"
+if grep -q "Invalid mode" "$MODE_OUTPUT" \
+  && grep -q -- '--sandbox workspace-write' "$CODEX_ARGS_FILE"; then
+  echo "==> PASS: invalid mode warned and fell back to fix (workspace-write)"
 else
-  echo "FAIL: expected exit 2 for invalid mode" >&2
-  echo "exit code: $INVALID_MODE_EXIT" >&2
+  echo "FAIL: expected invalid mode to warn and fall back to fix" >&2
   cat "$MODE_OUTPUT" >&2
+  cat "$CODEX_ARGS_FILE" >&2
   ERRORS=$((ERRORS + 1))
 fi
 

--- a/tests/test-review-hook.sh
+++ b/tests/test-review-hook.sh
@@ -661,14 +661,14 @@ chmod +x "$CASCADE_BIN/gh" "$CASCADE_BIN/claude"
     CLAUDE_ARGS_FILE="$CLAUDE_ARGS_FILE" \
     CODEX_REVIEW_BASE="HEAD~1" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
-    CODEX_REVIEW_NO_AUTOFIX=1 \
+    CODEX_REVIEW_MODE=review-only \
     bash "$TOOLKIT_ROOT/hooks/codex-review.sh" > "$CASCADE_OUTPUT" 2>&1
 )
 
 if grep -q 'Read,Grep,Glob,Bash' "$CLAUDE_ARGS_FILE" && ! grep -q 'Edit' "$CLAUDE_ARGS_FILE"; then
   echo "==> PASS: claude adapter used read-only tools in review-only mode"
 else
-  echo "FAIL: expected claude to use read-only tools when NO_AUTOFIX is set" >&2
+  echo "FAIL: expected claude to use read-only tools in review-only mode" >&2
   cat "$CLAUDE_ARGS_FILE" >&2
   ERRORS=$((ERRORS + 1))
 fi
@@ -688,6 +688,225 @@ if grep -q 'Edit,Write' "$CLAUDE_ARGS_FILE"; then
 else
   echo "FAIL: expected claude to include Edit,Write tools when autofix enabled" >&2
   cat "$CLAUDE_ARGS_FILE" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ==========================================================================
+# Mode enforcement tests
+# ==========================================================================
+
+MODE_REPO="$TEST_DIR/repo-mode"
+MODE_OUTPUT="$TEST_DIR/mode-output.txt"
+CODEX_ARGS_FILE="$TEST_DIR/codex-args.txt"
+
+setup_mode_repo() {
+  rm -rf "$MODE_REPO"
+  mkdir -p "$MODE_REPO"
+  git -C "$MODE_REPO" init >/dev/null 2>&1
+  git -C "$MODE_REPO" config user.name "Toolkit Test"
+  git -C "$MODE_REPO" config user.email "toolkit@example.com"
+  printf 'base\n' > "$MODE_REPO/example.txt"
+  git -C "$MODE_REPO" add example.txt
+  git -C "$MODE_REPO" commit -m "base" >/dev/null 2>&1
+  printf 'changed\n' >> "$MODE_REPO/example.txt"
+  git -C "$MODE_REPO" add example.txt
+  git -C "$MODE_REPO" commit -m "change" >/dev/null 2>&1
+}
+
+echo "==> Test: codex adapter uses --sandbox read-only in review-only mode"
+setup_mode_repo
+{
+  printf '[codex_review]\nsafe_by_default = true\n'
+} > "$MODE_REPO/.codex-review.toml"
+git -C "$MODE_REPO" add .codex-review.toml
+git -C "$MODE_REPO" commit -m "config" >/dev/null 2>&1
+
+MODE_BIN="$TEST_DIR/mode-bin"
+rm -rf "$MODE_BIN"
+mkdir -p "$MODE_BIN"
+cat > "$MODE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "main"
+EOF
+cat > "$MODE_BIN/codex" <<'CXEOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = "login" ] && [ "${2:-}" = "status" ]; then exit 0; fi
+printf '%s\n' "$*" > "$CODEX_ARGS_FILE"
+printf 'CODEX_REVIEW_CLEAN\n'
+CXEOF
+chmod +x "$MODE_BIN/gh" "$MODE_BIN/codex"
+
+(
+  cd "$MODE_REPO"
+  PATH="$MODE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CODEX_ARGS_FILE="$CODEX_ARGS_FILE" \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    CODEX_REVIEW_MODE=review-only \
+    bash "$TOOLKIT_ROOT/hooks/codex-review.sh" > "$MODE_OUTPUT" 2>&1
+)
+
+if grep -q -- '--sandbox read-only' "$CODEX_ARGS_FILE"; then
+  echo "==> PASS: codex used --sandbox read-only in review-only mode"
+else
+  echo "FAIL: expected codex to use --sandbox read-only in review-only mode" >&2
+  cat "$CODEX_ARGS_FILE" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo "==> Test: codex adapter uses --sandbox workspace-write in fix mode"
+(
+  cd "$MODE_REPO"
+  PATH="$MODE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CODEX_ARGS_FILE="$CODEX_ARGS_FILE" \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    CODEX_REVIEW_MODE=fix \
+    bash "$TOOLKIT_ROOT/hooks/codex-review.sh" > "$MODE_OUTPUT" 2>&1
+)
+
+if grep -q -- '--sandbox workspace-write' "$CODEX_ARGS_FILE"; then
+  echo "==> PASS: codex used --sandbox workspace-write in fix mode"
+else
+  echo "FAIL: expected codex to use --sandbox workspace-write in fix mode" >&2
+  cat "$CODEX_ARGS_FILE" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo "==> Test: claude adapter restricts to Read,Grep,Glob in diff-only mode"
+rm -rf "$MODE_BIN"
+mkdir -p "$MODE_BIN"
+cat > "$MODE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "main"
+EOF
+cat > "$MODE_BIN/claude" <<'CLEOF'
+#!/usr/bin/env bash
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then exit 0; fi
+printf '%s\n' "$*" > "$CLAUDE_ARGS_FILE"
+printf 'CODEX_REVIEW_CLEAN\n'
+CLEOF
+chmod +x "$MODE_BIN/gh" "$MODE_BIN/claude"
+
+{
+  printf '[codex_review]\nsafe_by_default = true\n'
+  printf '[review]\nreviewers = ["claude"]\n'
+} > "$MODE_REPO/.codex-review.toml"
+git -C "$MODE_REPO" add .codex-review.toml
+git -C "$MODE_REPO" commit -m "claude config" >/dev/null 2>&1
+
+(
+  cd "$MODE_REPO"
+  PATH="$MODE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CLAUDE_ARGS_FILE="$CLAUDE_ARGS_FILE" \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    CODEX_REVIEW_MODE=diff-only \
+    bash "$TOOLKIT_ROOT/hooks/codex-review.sh" > "$MODE_OUTPUT" 2>&1
+)
+
+if grep -q 'Read,Grep,Glob' "$CLAUDE_ARGS_FILE" \
+  && ! grep -q 'Bash' "$CLAUDE_ARGS_FILE" \
+  && ! grep -q 'Edit' "$CLAUDE_ARGS_FILE"; then
+  echo "==> PASS: claude restricted to Read,Grep,Glob in diff-only mode"
+else
+  echo "FAIL: expected claude to use only Read,Grep,Glob in diff-only mode" >&2
+  cat "$CLAUDE_ARGS_FILE" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo "==> Test: CODEX_REVIEW_NO_AUTOFIX backward compat maps to review-only"
+rm -rf "$MODE_BIN"
+mkdir -p "$MODE_BIN"
+cat > "$MODE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "main"
+EOF
+cat > "$MODE_BIN/codex" <<'CXEOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = "login" ] && [ "${2:-}" = "status" ]; then exit 0; fi
+printf '%s\n' "$*" > "$CODEX_ARGS_FILE"
+printf 'CODEX_REVIEW_CLEAN\n'
+CXEOF
+chmod +x "$MODE_BIN/gh" "$MODE_BIN/codex"
+
+{
+  printf '[codex_review]\nsafe_by_default = true\n'
+} > "$MODE_REPO/.codex-review.toml"
+git -C "$MODE_REPO" add .codex-review.toml
+git -C "$MODE_REPO" commit -m "codex config" >/dev/null 2>&1
+
+(
+  cd "$MODE_REPO"
+  PATH="$MODE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CODEX_ARGS_FILE="$CODEX_ARGS_FILE" \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    CODEX_REVIEW_NO_AUTOFIX=1 \
+    bash "$TOOLKIT_ROOT/hooks/codex-review.sh" > "$MODE_OUTPUT" 2>&1
+)
+
+if grep -q -- '--sandbox read-only' "$CODEX_ARGS_FILE"; then
+  echo "==> PASS: CODEX_REVIEW_NO_AUTOFIX=1 mapped to review-only (read-only sandbox)"
+else
+  echo "FAIL: expected CODEX_REVIEW_NO_AUTOFIX to map to review-only mode" >&2
+  cat "$CODEX_ARGS_FILE" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo "==> Test: FIXED sentinel in review-only mode exits 1"
+rm -rf "$MODE_BIN"
+mkdir -p "$MODE_BIN"
+cat > "$MODE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "main"
+EOF
+cat > "$MODE_BIN/codex" <<'CXEOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = "login" ] && [ "${2:-}" = "status" ]; then exit 0; fi
+printf 'CODEX_REVIEW_FIXED\n'
+CXEOF
+chmod +x "$MODE_BIN/gh" "$MODE_BIN/codex"
+
+set +e
+(
+  cd "$MODE_REPO"
+  PATH="$MODE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    CODEX_REVIEW_MODE=review-only \
+    bash "$TOOLKIT_ROOT/hooks/codex-review.sh" > "$MODE_OUTPUT" 2>&1
+)
+FIXED_RO_EXIT=$?
+set -e
+
+if [ "$FIXED_RO_EXIT" -eq 1 ] && grep -q "emitted FIXED in 'review-only' mode" "$MODE_OUTPUT"; then
+  echo "==> PASS: FIXED in review-only mode exits 1 with warning"
+else
+  echo "FAIL: expected exit 1 and warning when FIXED emitted in review-only mode" >&2
+  echo "exit code: $FIXED_RO_EXIT" >&2
+  cat "$MODE_OUTPUT" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo "==> Test: invalid mode exits 2"
+set +e
+(
+  cd "$MODE_REPO"
+  PATH="$MODE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_MODE=invalid \
+    bash "$TOOLKIT_ROOT/hooks/codex-review.sh" > "$MODE_OUTPUT" 2>&1
+)
+INVALID_MODE_EXIT=$?
+set -e
+
+if [ "$INVALID_MODE_EXIT" -eq 2 ] && grep -q "Invalid mode" "$MODE_OUTPUT"; then
+  echo "==> PASS: invalid mode exits 2"
+else
+  echo "FAIL: expected exit 2 for invalid mode" >&2
+  echo "exit code: $INVALID_MODE_EXIT" >&2
+  cat "$MODE_OUTPUT" >&2
   ERRORS=$((ERRORS + 1))
 fi
 


### PR DESCRIPTION
Replace the single CODEX_REVIEW_NO_AUTOFIX boolean with a proper mode
system: review-only, fix, diff-only, no-tests. Modes are enforced at
the wrapper level via tool restrictions and sandboxes, not just prompt
text:

- Codex: --sandbox read-only vs workspace-write
- Claude: --allowedTools restricted per mode
- Gemini: --yolo only in fix/no-tests modes

CODEX_REVIEW_NO_AUTOFIX=1 backward compat preserved (maps to review-only).
New config key: mode = "fix" in [codex_review].
New env var: CODEX_REVIEW_MODE=review-only|fix|diff-only|no-tests.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
