### PR TITLE
Add observability and repo-provided review context

### DIFF
--- a/hooks/codex-review.config.example.toml
+++ b/hooks/codex-review.config.example.toml
@@ -67,3 +67,17 @@ unsafe_paths = [
 
 # [review]
 # reviewers = ["claude", "codex", "gemini"]
+
+# --------------------------------------------------------------------------
+# Repo-provided review context (optional)
+# --------------------------------------------------------------------------
+# Place a .codex-review-context.md at the repo root (or .github/) to provide
+# additional context to the reviewer. This is appended to the prompt automatically.
+#
+# Example content:
+#   - "CI already runs linting and type-checking; do not re-run them."
+#   - "The payments module is being migrated; ignore legacy patterns in src/payments/."
+#
+# File search order:
+#   1. .codex-review-context.md
+#   2. .github/codex-review-context.md

--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -408,6 +408,18 @@ should_skip_pre_push_review() {
 }
 
 # --------------------------------------------------------------------------
+# Repo-provided review context
+# --------------------------------------------------------------------------
+
+REVIEW_CONTEXT_FILE=""
+for _candidate in "$REPO_ROOT/.codex-review-context.md" "$REPO_ROOT/.github/codex-review-context.md"; do
+  if [ -f "$_candidate" ]; then
+    REVIEW_CONTEXT_FILE="$_candidate"
+    break
+  fi
+done
+
+# --------------------------------------------------------------------------
 # Build the auto-fix policy section of the prompt from config
 # --------------------------------------------------------------------------
 
@@ -664,6 +676,9 @@ if ! resolve_reviewer; then
 fi
 REVIEWER_LABEL="$(reviewer_label)"
 echo "==> Using reviewer: $REVIEWER_LABEL"
+if [ -n "$REVIEW_CONTEXT_FILE" ]; then
+  echo "==> Review context: $(basename "$REVIEW_CONTEXT_FILE")"
+fi
 
 # Fetch latest base ref for the default review target (silent on failure —
 # offline, rebasing, etc.). If CODEX_REVIEW_BASE is set, trust the caller.
@@ -737,6 +752,15 @@ If you emit CODEX_REVIEW_FIXED, briefly describe what you fixed (one line per fi
 Do not invent new sentinels. Do not output anything after the sentinel line.
 PROMPT_EOF
 
+# Append repo-provided review context if present.
+if [ -n "$REVIEW_CONTEXT_FILE" ]; then
+  REVIEW_PROMPT="$REVIEW_PROMPT
+
+## Project review context
+
+$(cat "$REVIEW_CONTEXT_FILE")"
+fi
+
 # --------------------------------------------------------------------------
 # Clean-review cache
 # --------------------------------------------------------------------------
@@ -786,6 +810,9 @@ review_cache_key() {
     append_cache_file "CLAUDE.md" "$REPO_ROOT/CLAUDE.md"
     append_cache_file ".codex-review.toml" "$CONFIG_FILE"
     append_cache_file "codex-review.sh" "$0"
+    if [ -n "$REVIEW_CONTEXT_FILE" ]; then
+      append_cache_file "codex-review-context" "$REVIEW_CONTEXT_FILE"
+    fi
     printf '\n-- branch diff --\n'
     git diff --binary "$MERGE_BASE"..HEAD
   } | hash_stdin
@@ -891,6 +918,81 @@ $path"
 
 FIX_COMMITS=0
 BANNER_PRINTED=false
+REVIEW_START_TIME="$(date +%s)"
+REVIEW_FILES_INSPECTED="$(git diff --name-only "$MERGE_BASE"..HEAD | wc -l | tr -d ' ')"
+REVIEW_EXIT_REASON=""
+
+# --------------------------------------------------------------------------
+# Phase labels
+# --------------------------------------------------------------------------
+
+phase() {
+  printf "  ${C_DIM}[%s] %s${C_RESET}\n" "$(date +%H:%M:%S)" "$1"
+}
+
+# --------------------------------------------------------------------------
+# Worktree invariant checking
+# --------------------------------------------------------------------------
+
+WORKTREE_HEAD_BEFORE="$(git rev-parse HEAD)"
+WORKTREE_BRANCH_BEFORE="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo 'detached')"
+WORKTREE_STATUS_BEFORE="$(git status --porcelain)"
+
+check_worktree_invariants() {
+  local current_head current_branch current_status violations=""
+
+  current_head="$(git rev-parse HEAD)"
+  current_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo 'detached')"
+  current_status="$(git status --porcelain)"
+
+  if [ "$current_head" != "$WORKTREE_HEAD_BEFORE" ]; then
+    violations="${violations}    HEAD changed: $WORKTREE_HEAD_BEFORE -> $current_head\n"
+  fi
+  if [ "$current_branch" != "$WORKTREE_BRANCH_BEFORE" ]; then
+    violations="${violations}    Branch changed: $WORKTREE_BRANCH_BEFORE -> $current_branch\n"
+  fi
+  if [ "$current_status" != "$WORKTREE_STATUS_BEFORE" ]; then
+    violations="${violations}    Working tree status changed\n"
+  fi
+
+  if [ -n "$violations" ]; then
+    printf "\n  ${C_RED}WARNING: Worktree mutated during '%s' review:${C_RESET}\n" "$REVIEW_MODE"
+    printf '%b' "$violations"
+    return 1
+  fi
+  return 0
+}
+
+# --------------------------------------------------------------------------
+# Structured summary
+# --------------------------------------------------------------------------
+
+print_summary() {
+  local elapsed mins secs findings
+  elapsed=$(( $(date +%s) - REVIEW_START_TIME ))
+  mins=$((elapsed / 60))
+  secs=$((elapsed % 60))
+  findings="${REVIEW_FINDINGS_COUNT:-0}"
+
+  printf "\n  ${C_DIM}─── review summary ────────────────────────${C_RESET}\n"
+  printf "  ${C_DIM}reviewer:       %s${C_RESET}\n" "$REVIEWER_LABEL"
+  printf "  ${C_DIM}mode:           %s${C_RESET}\n" "$REVIEW_MODE"
+  printf "  ${C_DIM}files:          %s${C_RESET}\n" "$REVIEW_FILES_INSPECTED"
+  printf "  ${C_DIM}diff lines:     %s${C_RESET}\n" "$DIFF_LINE_COUNT"
+  printf "  ${C_DIM}iterations:     %s/%s${C_RESET}\n" "${iter:-0}" "$MAX_ITERATIONS"
+  printf "  ${C_DIM}fix commits:    %s${C_RESET}\n" "$FIX_COMMITS"
+  printf "  ${C_DIM}findings:       %s${C_RESET}\n" "$findings"
+  printf "  ${C_DIM}exit reason:    %s${C_RESET}\n" "$REVIEW_EXIT_REASON"
+  printf "  ${C_DIM}elapsed:        %dm%ds${C_RESET}\n" "$mins" "$secs"
+  printf "  ${C_DIM}──────────────────────────────────────────${C_RESET}\n"
+
+  if [ -n "${CODEX_REVIEW_SUMMARY_FILE:-}" ]; then
+    printf '{"reviewer":"%s","mode":"%s","files":%d,"diff_lines":%d,"iterations":%d,"fix_commits":%d,"findings":%d,"exit_reason":"%s","elapsed_seconds":%d}\n' \
+      "$REVIEWER_LABEL" "$REVIEW_MODE" "$REVIEW_FILES_INSPECTED" "$DIFF_LINE_COUNT" \
+      "${iter:-0}" "$FIX_COMMITS" "$findings" "$REVIEW_EXIT_REASON" "$elapsed" \
+      > "$CODEX_REVIEW_SUMMARY_FILE" 2>/dev/null || true
+  fi
+}
 
 # Colors (respect NO_COLOR).
 if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
@@ -914,6 +1016,7 @@ print_banner() {
 }
 
 for iter in $(seq 1 "$MAX_ITERATIONS"); do
+  phase "loading diff"
   DIFF_LINE_COUNT="$(git diff "$MERGE_BASE"..HEAD | wc -l | tr -d ' ')"
   if [ "$DIFF_LINE_COUNT" -gt "$MAX_DIFF_LINES" ]; then
     echo "==> Diff is $DIFF_LINE_COUNT lines (> $MAX_DIFF_LINES cap) — skipping review."
@@ -921,6 +1024,7 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
     exit 0
   fi
 
+  phase "checking cache"
   REVIEW_CACHE_KEY=""
   if cache_enabled; then
     REVIEW_CACHE_KEY="$(review_cache_key 2>/dev/null || true)"
@@ -933,6 +1037,7 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
 
   print_banner
   printf "  ${C_DIM}iteration ${iter}/${MAX_ITERATIONS} · ${DIFF_LINE_COUNT} lines vs ${BASE}${C_RESET}\n"
+  phase "reviewing with $REVIEWER_LABEL"
 
   set +e
   run_reviewer_with_timeout "$REVIEW_TIMEOUT"
@@ -940,19 +1045,34 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
   set -e
   OUTPUT="$(cat "$REVIEW_OUTPUT_FILE" 2>/dev/null || true)"
 
+  # Check worktree invariants in non-fix modes.
+  if ! mode_allows_fix; then
+    if ! check_worktree_invariants; then
+      REVIEW_EXIT_REASON="worktree-mutated"
+      print_summary
+      handle_error "worktree mutated in $REVIEW_MODE mode"
+    fi
+  fi
+
   if [ "$EXIT" -eq 124 ]; then
+    phase "timed out"
     echo "==> $REVIEWER_LABEL timed out after ${REVIEW_TIMEOUT}s."
+    REVIEW_EXIT_REASON="timeout"
+    print_summary
     handle_error "timeout after ${REVIEW_TIMEOUT}s"
   fi
 
   if [ $EXIT -ne 0 ]; then
     echo "==> $REVIEWER_LABEL review failed with exit $EXIT."
+    REVIEW_EXIT_REASON="error"
+    print_summary
     handle_error "reviewer exit $EXIT"
   fi
 
   LAST_LINE="$(printf '%s\n' "$OUTPUT" | tail -1 | tr -d '\r ')"
   case "$LAST_LINE" in
     CODEX_REVIEW_CLEAN)
+      phase "done — clean"
       echo ""
       printf "${C_GREEN}"
       cat <<'PASS'
@@ -965,7 +1085,8 @@ PASS
       if [ "$FIX_COMMITS" -gt 0 ]; then
         printf "  ${C_DIM}($FIX_COMMITS auto-fix commit(s) applied)${C_RESET}\n"
       fi
-      echo ""
+      REVIEW_EXIT_REASON="clean"
+      print_summary
       write_clean_review_cache "$REVIEW_CACHE_KEY" "$DIFF_LINE_COUNT"
       exit 0
       ;;
@@ -1001,6 +1122,7 @@ PASS
         exit 1
       fi
 
+      phase "applying fixes"
       printf "\n  ${C_YELLOW}🔧 Auto-fixing...${C_RESET}\n\n"
       git diff --stat
       echo ""
@@ -1015,6 +1137,8 @@ PASS
       ;;
 
     CODEX_REVIEW_BLOCKED)
+      phase "done — blocked"
+      REVIEW_FINDINGS_COUNT="$(printf '%s\n' "$OUTPUT" | grep -c '^- ' || true)"
       echo ""
       printf "${C_RED}"
       printf '  ╔══════════════════════════════════════╗\n'
@@ -1030,6 +1154,8 @@ PASS
         echo "    To undo them: git reset --hard HEAD~$FIX_COMMITS"
       fi
       echo "    Address findings and try again. Emergency override: git push --no-verify"
+      REVIEW_EXIT_REASON="blocked"
+      print_summary
       exit 1
       ;;
 
@@ -1038,6 +1164,8 @@ PASS
       echo "    Last line was: '$LAST_LINE'"
       echo "    Raw output (first 20 lines):"
       printf '%s\n' "$OUTPUT" | head -20 | sed 's/^/    /'
+      REVIEW_EXIT_REASON="malformed-sentinel"
+      print_summary
       handle_error "malformed sentinel"
       ;;
   esac
@@ -1052,4 +1180,6 @@ echo "      git diff HEAD~$FIX_COMMITS..HEAD"
 echo ""
 echo "    To undo all auto-fix commits: git reset --hard HEAD~$FIX_COMMITS"
 echo "    Emergency override: git push --no-verify"
+REVIEW_EXIT_REASON="max-iterations"
+print_summary
 exit 1

--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -735,6 +735,10 @@ fi)
 ## Auto-fix policy
 
 $AUTOFIX_POLICY
+$(if [ -n "$REVIEW_CONTEXT_FILE" ]; then
+printf '\n## Project review context\n\n'
+cat "$REVIEW_CONTEXT_FILE"
+fi)
 
 ## Output contract — strict
 
@@ -751,15 +755,6 @@ If you emit CODEX_REVIEW_FIXED, briefly describe what you fixed (one line per fi
 
 Do not invent new sentinels. Do not output anything after the sentinel line.
 PROMPT_EOF
-
-# Append repo-provided review context if present.
-if [ -n "$REVIEW_CONTEXT_FILE" ]; then
-  REVIEW_PROMPT="$REVIEW_PROMPT
-
-## Project review context
-
-$(cat "$REVIEW_CONTEXT_FILE")"
-fi
 
 # --------------------------------------------------------------------------
 # Clean-review cache
@@ -1046,11 +1041,14 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
   OUTPUT="$(cat "$REVIEW_OUTPUT_FILE" 2>/dev/null || true)"
 
   # Check worktree invariants in non-fix modes.
+  # This is a hard failure regardless of on_error policy — a reviewer that
+  # mutates the worktree in review-only mode is a safety violation.
   if ! mode_allows_fix; then
     if ! check_worktree_invariants; then
       REVIEW_EXIT_REASON="worktree-mutated"
       print_summary
-      handle_error "worktree mutated in $REVIEW_MODE mode"
+      echo "==> ERROR: Worktree was mutated in '$REVIEW_MODE' mode — blocking push." >&2
+      exit 1
     fi
   fi
 

--- a/tests/test-review-hook.sh
+++ b/tests/test-review-hook.sh
@@ -1077,6 +1077,178 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
+# ==========================================================================
+# Repo-provided context tests
+# ==========================================================================
+
+CTX_REPO="$TEST_DIR/repo-ctx"
+CTX_OUTPUT="$TEST_DIR/ctx-output.txt"
+CTX_PROMPT="$TEST_DIR/ctx-prompt.txt"
+
+setup_ctx_repo() {
+  rm -rf "$CTX_REPO"
+  mkdir -p "$CTX_REPO"
+  git -C "$CTX_REPO" init >/dev/null 2>&1
+  git -C "$CTX_REPO" config user.name "Toolkit Test"
+  git -C "$CTX_REPO" config user.email "toolkit@example.com"
+  printf 'base\n' > "$CTX_REPO/example.txt"
+  git -C "$CTX_REPO" add example.txt
+  git -C "$CTX_REPO" commit -m "base" >/dev/null 2>&1
+  printf 'changed\n' >> "$CTX_REPO/example.txt"
+  git -C "$CTX_REPO" add example.txt
+  git -C "$CTX_REPO" commit -m "change" >/dev/null 2>&1
+}
+
+CTX_BIN="$TEST_DIR/ctx-bin"
+
+setup_ctx_bin() {
+  rm -rf "$CTX_BIN"
+  mkdir -p "$CTX_BIN"
+  cat > "$CTX_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "main"
+EOF
+  cat > "$CTX_BIN/codex" <<'CXEOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = "login" ] && [ "${2:-}" = "status" ]; then exit 0; fi
+prompt="${@: -1}"
+printf '%s' "$prompt" > "$CTX_PROMPT"
+printf 'CODEX_REVIEW_CLEAN\n'
+CXEOF
+  chmod +x "$CTX_BIN/gh" "$CTX_BIN/codex"
+}
+
+echo "==> Test: context file at repo root is appended to prompt"
+setup_ctx_repo
+setup_ctx_bin
+printf 'UNIQUE_CTX_MARKER_12345\n' > "$CTX_REPO/.codex-review-context.md"
+git -C "$CTX_REPO" add .codex-review-context.md
+git -C "$CTX_REPO" commit -m "add context" >/dev/null 2>&1
+
+(
+  cd "$CTX_REPO"
+  PATH="$CTX_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CTX_PROMPT="$CTX_PROMPT" \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    bash "$TOOLKIT_ROOT/hooks/codex-review.sh" > "$CTX_OUTPUT" 2>&1
+)
+
+if grep -q 'UNIQUE_CTX_MARKER_12345' "$CTX_PROMPT" \
+  && grep -q 'Review context' "$CTX_OUTPUT"; then
+  echo "==> PASS: context file appended to prompt"
+else
+  echo "FAIL: expected context file content in prompt" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo "==> Test: context file under .github/ is discovered"
+setup_ctx_repo
+setup_ctx_bin
+mkdir -p "$CTX_REPO/.github"
+printf 'GITHUB_CTX_MARKER_67890\n' > "$CTX_REPO/.github/codex-review-context.md"
+git -C "$CTX_REPO" add .github/codex-review-context.md
+git -C "$CTX_REPO" commit -m "add github context" >/dev/null 2>&1
+
+(
+  cd "$CTX_REPO"
+  PATH="$CTX_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CTX_PROMPT="$CTX_PROMPT" \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    bash "$TOOLKIT_ROOT/hooks/codex-review.sh" > "$CTX_OUTPUT" 2>&1
+)
+
+if grep -q 'GITHUB_CTX_MARKER_67890' "$CTX_PROMPT"; then
+  echo "==> PASS: .github/ context file discovered"
+else
+  echo "FAIL: expected .github/ context file in prompt" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo "==> Test: no context file = no error"
+setup_ctx_repo
+setup_ctx_bin
+(
+  cd "$CTX_REPO"
+  PATH="$CTX_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CTX_PROMPT="$CTX_PROMPT" \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    bash "$TOOLKIT_ROOT/hooks/codex-review.sh" > "$CTX_OUTPUT" 2>&1
+)
+
+if ! grep -q 'Review context' "$CTX_OUTPUT" \
+  && ! grep -q 'Project review context' "$CTX_PROMPT"; then
+  echo "==> PASS: no context file, no error"
+else
+  echo "FAIL: expected no context section when file is missing" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ==========================================================================
+# Observability tests (phase labels, summary)
+# ==========================================================================
+
+echo "==> Test: phase labels appear in output"
+setup_ctx_repo
+setup_ctx_bin
+(
+  cd "$CTX_REPO"
+  PATH="$CTX_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CTX_PROMPT="$CTX_PROMPT" \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    bash "$TOOLKIT_ROOT/hooks/codex-review.sh" > "$CTX_OUTPUT" 2>&1
+)
+
+if grep -q 'loading diff' "$CTX_OUTPUT" \
+  && grep -q 'checking cache' "$CTX_OUTPUT" \
+  && grep -q 'reviewing with' "$CTX_OUTPUT" \
+  && grep -q 'done — clean' "$CTX_OUTPUT"; then
+  echo "==> PASS: phase labels appear in output"
+else
+  echo "FAIL: expected phase labels in output" >&2
+  cat "$CTX_OUTPUT" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo "==> Test: summary block appears at end"
+if grep -q 'review summary' "$CTX_OUTPUT" \
+  && grep -q 'exit reason:.*clean' "$CTX_OUTPUT" \
+  && grep -q 'elapsed:' "$CTX_OUTPUT"; then
+  echo "==> PASS: summary block appears at end"
+else
+  echo "FAIL: expected summary block in output" >&2
+  cat "$CTX_OUTPUT" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo "==> Test: JSON summary file written when env var set"
+setup_ctx_repo
+setup_ctx_bin
+JSON_SUMMARY="$TEST_DIR/review-summary.json"
+rm -f "$JSON_SUMMARY"
+(
+  cd "$CTX_REPO"
+  PATH="$CTX_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CTX_PROMPT="$CTX_PROMPT" \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    CODEX_REVIEW_SUMMARY_FILE="$JSON_SUMMARY" \
+    bash "$TOOLKIT_ROOT/hooks/codex-review.sh" > "$CTX_OUTPUT" 2>&1
+)
+
+if [ -f "$JSON_SUMMARY" ] \
+  && grep -q '"exit_reason":"clean"' "$JSON_SUMMARY" \
+  && grep -q '"reviewer":"Codex"' "$JSON_SUMMARY"; then
+  echo "==> PASS: JSON summary file written"
+else
+  echo "FAIL: expected JSON summary file" >&2
+  cat "$JSON_SUMMARY" 2>/dev/null >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
 if [ "$ERRORS" -eq 0 ]; then
   echo "==> PASS: all review hook assertions passed"
   exit 0


### PR DESCRIPTION
Observability:
- Phase labels with timestamps: loading diff, checking cache,
  reviewing with <Reviewer>, applying fixes, done — clean/blocked
- Worktree invariant checking: records HEAD/branch/status before review,
  verifies unchanged after non-fix mode runs
- Structured summary block at every exit: reviewer, mode, files,
  diff lines, iterations, fix commits, findings, exit reason, elapsed
- Optional JSON summary to file via CODEX_REVIEW_SUMMARY_FILE env var

Repo-provided context:
- Auto-discovers .codex-review-context.md (or .github/) and appends
  to the review prompt. Included in cache key for invalidation.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
