### PR TITLE
Add project profile runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ bash setup.sh --deps-only
 |---------|-------------|
 | `toolkit init [--no-setup]` | Add toolkit to the current project |
 | `toolkit new <dir>` | Bootstrap a new project with principles, scripts, hooks, and templates |
+| `toolkit new <dir> --type node` | Bootstrap with an explicit Node/TypeScript, Swift, Rust, Go, Python, or generic profile |
+| `toolkit detect` | Show the detected project profile for the current repo |
+| `toolkit run <task>` | Run profile-aware `lint`, `typecheck`, `build`, `test`, or `validate` |
 | `toolkit update` | Update the current project's toolkit-owned files to latest |
 | `toolkit update --dry-run` | Preview what would change |
 | `toolkit sync` | Update all registered projects at once |
@@ -58,6 +61,7 @@ When you run `toolkit new`, these files get copied into your project:
 - `CLAUDE.md` — AI coding instructions with `{{PLACEHOLDERS}}` to fill in
 - `AGENTS.md` — AI reviewer rubric with project-specific priorities
 - `.codex-review.toml` — Codex hook config (safe/unsafe paths for auto-fix)
+- `.toolkit-config` — Project profile and optional lint/test/build command overrides
 - `.pre-commit-config.yaml` — Pre-commit hooks including Codex review
 - `.gitignore` — Sensible defaults
 - `.github/pull_request_template.md` — PR checklist
@@ -65,12 +69,13 @@ When you run `toolkit new`, these files get copied into your project:
 **Toolkit-owned** (auto-updated when you run `toolkit update` or `toolkit sync`):
 - `principles/*.md` — Universal engineering principles
 - `scripts/codex-review.sh` — Codex merge/default-branch review + auto-fix loop
+- `scripts/toolkit-run.sh` — Profile-aware runner for Node/TypeScript, Swift, Rust, Python, Go, and monorepos
 - `scripts/open-pr.sh` — Push + create PR via `gh`
 - `scripts/merge-pr.sh` — Codex review + squash-merge + sync main
 - `scripts/cleanup-branches.sh` — Safe branch hygiene
-- `scripts/run-pytest-in-venv.sh` — Run pytest through `.venv` or `agent/.venv`
+- `scripts/run-pytest-in-venv.sh` — Legacy Python helper copied for Python profiles
 
-`setup.sh` installs Python dependencies into project virtualenvs. It supports `requirements.txt`, `uv.lock`, and `pyproject.toml` at the repo root and under `agent/`.
+`setup.sh` installs dependencies for the detected project profile. It supports Node package managers, SwiftPM, Cargo, Go modules, and Python `requirements.txt`/`uv.lock`/`pyproject.toml` at the repo root and under `agent/`. `toolkit run validate` uses `.toolkit-config` to run profile-aware lint/typecheck/test commands.
 
 ### Keeping projects up to date
 

--- a/bin/toolkit
+++ b/bin/toolkit
@@ -4,8 +4,9 @@
 #
 # Usage:
 #   toolkit new <project-dir>          Create a new project with toolkit files
-#   toolkit init [--no-setup] [--type python|node|swift|generic]
+#   toolkit init [--no-setup] [--type node|python|swift|rust|go|generic|auto]
 #                                      Add toolkit to the current project
+#   toolkit run <task>                  Run profile task: lint, test, build, typecheck, validate
 #   toolkit update                     Update current project to latest toolkit
 #   toolkit update --dry-run           Show what would change without applying
 #   toolkit sync                       Update all registered projects
@@ -83,12 +84,12 @@ fi
 
 cmd_new() {
   if [ "$#" -lt 1 ]; then
-    echo "Usage: toolkit new <project-dir> [--no-register] [--unsafe-paths path1,path2]" >&2
+    echo "Usage: toolkit new <project-dir> [--no-register] [--type node|python|swift|rust|go|generic|auto] [--unsafe-paths path1,path2]" >&2
     exit 1
   fi
   case "${1:-}" in
     -h|--help)
-      echo "Usage: toolkit new <project-dir> [--no-register] [--unsafe-paths path1,path2]"
+      echo "Usage: toolkit new <project-dir> [--no-register] [--type node|python|swift|rust|go|generic|auto] [--unsafe-paths path1,path2]"
       return 0
       ;;
   esac
@@ -108,12 +109,12 @@ cmd_init() {
         shift
         ;;
       -h|--help)
-        echo "Usage: toolkit init [--no-setup] [--type TYPE] [--no-register] [--unsafe-paths path1,path2]"
+        echo "Usage: toolkit init [--no-setup] [--type node|python|swift|rust|go|generic|auto] [--no-register] [--unsafe-paths path1,path2]"
         return 0
         ;;
       --type)
         if [ "$#" -lt 2 ]; then
-          echo "ERROR: --type requires a value (python, node, swift, generic)" >&2
+          echo "ERROR: --type requires a value (node, python, swift, rust, go, generic, auto)" >&2
           exit 1
         fi
         args+=("$1" "$2")
@@ -133,7 +134,7 @@ cmd_init() {
         ;;
       *)
         echo "ERROR: unknown argument '$1'" >&2
-        echo "Usage: toolkit init [--no-setup] [--no-register] [--unsafe-paths path1,path2]" >&2
+        echo "Usage: toolkit init [--no-setup] [--type node|python|swift|rust|go|generic|auto] [--no-register] [--unsafe-paths path1,path2]" >&2
         exit 1
         ;;
     esac
@@ -162,6 +163,14 @@ cmd_update() {
 
 cmd_sync() {
   exec bash "$TOOLKIT_ROOT/bootstrap/sync-all.sh" "$@"
+}
+
+cmd_run() {
+  exec bash "$TOOLKIT_ROOT/scripts/toolkit-run.sh" "$@"
+}
+
+cmd_detect() {
+  exec bash "$TOOLKIT_ROOT/scripts/toolkit-run.sh" detect
 }
 
 cmd_version() {
@@ -682,6 +691,8 @@ cmd_help() {
   echo "  ${BOLD}Project commands:${RESET}"
   printf "    ${BOLD}toolkit init${RESET} [--no-setup]      Add toolkit to the current project\n"
   printf "    ${BOLD}toolkit new${RESET} <dir>              Bootstrap a new project from scratch\n"
+  printf "    ${BOLD}toolkit detect${RESET}                 Show detected project profile\n"
+  printf "    ${BOLD}toolkit run${RESET} <task>             Run lint, typecheck, build, test, or validate\n"
   printf "    ${BOLD}toolkit update${RESET}                 Update current project to latest\n"
   printf "    ${BOLD}toolkit update${RESET} --dry-run       Preview what would change\n"
   printf "    ${BOLD}toolkit sync${RESET}                   Update all registered projects\n"
@@ -719,6 +730,8 @@ shift 2>/dev/null || true
 case "$COMMAND" in
   new)          cmd_new "$@" ;;
   init)         cmd_init "$@" ;;
+  run)          cmd_run "$@" ;;
+  detect)       cmd_detect ;;
   update)       cmd_update "$@" ;;
   sync)         cmd_sync "$@" ;;
   status)       cmd_status ;;

--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -5,6 +5,7 @@
 # Usage:
 #   new-project.sh <project-dir>
 #   new-project.sh <project-dir> --no-register   # skip adding to ~/.toolkit-projects
+#   new-project.sh <project-dir> --type node|python|swift|rust|go|generic|auto
 #   new-project.sh <project-dir> --unsafe-paths src/auth/,migrations/
 #
 # What this does:
@@ -25,7 +26,7 @@ INPUT_UNSAFE=""
 INPUT_TYPE=""
 
 usage() {
-  echo "Usage: $0 <project-dir> [--no-register] [--unsafe-paths path1,path2]"
+  echo "Usage: $0 <project-dir> [--no-register] [--type node|python|swift|rust|go|generic|auto] [--unsafe-paths path1,path2]"
 }
 
 trim() {
@@ -106,6 +107,105 @@ next_backup_path() {
   printf '%s' "$backup"
 }
 
+normalize_project_type() {
+  local value="$1"
+  value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
+
+  case "$value" in
+    ""|auto) printf 'auto' ;;
+    node|js|javascript|ts|typescript) printf 'node' ;;
+    python|py) printf 'python' ;;
+    swift) printf 'swift' ;;
+    rust|rs) printf 'rust' ;;
+    go|golang) printf 'go' ;;
+    generic) printf 'generic' ;;
+    *)
+      echo "ERROR: unknown project type '$1' (expected node, python, swift, rust, go, generic, or auto)" >&2
+      return 1
+      ;;
+  esac
+}
+
+detect_node_package_manager() {
+  local dir="$1" package_manager
+
+  if [ -f "$dir/package.json" ]; then
+    package_manager="$(sed -n 's/.*"packageManager"[[:space:]]*:[[:space:]]*"\([^@"]*\)@.*/\1/p' "$dir/package.json" | head -1)"
+    if [ -z "$package_manager" ]; then
+      package_manager="$(sed -n 's/.*"packageManager"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$dir/package.json" | head -1)"
+    fi
+    if [ -n "$package_manager" ]; then
+      printf '%s\n' "$package_manager"
+      return 0
+    fi
+  fi
+
+  if [ -f "$dir/pnpm-lock.yaml" ] || [ -f "$dir/pnpm-workspace.yaml" ]; then
+    printf 'pnpm\n'
+  elif [ -f "$dir/yarn.lock" ]; then
+    printf 'yarn\n'
+  elif [ -f "$dir/bun.lock" ] || [ -f "$dir/bun.lockb" ]; then
+    printf 'bun\n'
+  elif [ -f "$dir/package.json" ]; then
+    printf 'npm\n'
+  else
+    printf '\n'
+  fi
+}
+
+detect_project_type() {
+  local dir="$1"
+
+  if [ -f "$dir/pnpm-workspace.yaml" ]; then
+    printf 'node\n'
+  elif [ -f "$dir/package.json" ] || [ -f "$dir/tsconfig.json" ]; then
+    printf 'node\n'
+  elif [ -f "$dir/Cargo.toml" ]; then
+    printf 'rust\n'
+  elif [ -f "$dir/Package.swift" ]; then
+    printf 'swift\n'
+  elif [ -f "$dir/go.mod" ]; then
+    printf 'go\n'
+  elif [ -f "$dir/uv.lock" ] || [ -f "$dir/pyproject.toml" ] || [ -f "$dir/requirements.txt" ]; then
+    printf 'python\n'
+  else
+    printf 'generic\n'
+  fi
+}
+
+detect_monorepo() {
+  local dir="$1"
+
+  if [ -f "$dir/pnpm-workspace.yaml" ]; then
+    printf 'true\n'
+  elif [ -f "$dir/Cargo.toml" ] && grep -q '^\[workspace\]' "$dir/Cargo.toml" 2>/dev/null; then
+    printf 'true\n'
+  elif [ -f "$dir/package.json" ] && grep -q '"workspaces"' "$dir/package.json" 2>/dev/null; then
+    printf 'true\n'
+  else
+    printf 'false\n'
+  fi
+}
+
+detect_targets() {
+  local root="$1" base target_dir profile targets=""
+
+  for base in apps packages services; do
+    [ -d "$root/$base" ] || continue
+    for target_dir in "$root/$base"/*; do
+      [ -d "$target_dir" ] || continue
+      profile="$(detect_project_type "$target_dir")"
+      [ "$profile" = "generic" ] && continue
+      if [ -n "$targets" ]; then
+        targets="${targets},"
+      fi
+      targets="${targets}$(basename "$target_dir"):$base/$(basename "$target_dir"):$profile"
+    done
+  done
+
+  printf '%s\n' "$targets"
+}
+
 if [ "$#" -lt 1 ]; then
   usage >&2
   exit 1
@@ -131,8 +231,8 @@ while [ "$#" -gt 0 ]; do
     -h|--help) usage; exit 0 ;;
     --no-register) REGISTER=false; shift ;;
     --type)
-      [ "$#" -ge 2 ] || { echo "ERROR: --type requires a value (python, node, swift, generic)" >&2; exit 1; }
-      INPUT_TYPE="$2"
+      [ "$#" -ge 2 ] || { echo "ERROR: --type requires a value (node, python, swift, rust, go, generic, auto)" >&2; exit 1; }
+      INPUT_TYPE="$(normalize_project_type "$2")"
       shift 2
       ;;
     --unsafe-paths)
@@ -235,10 +335,10 @@ echo ""
 echo "==> Copying scripts (toolkit-owned, will be auto-updated):"
 mkdir -p "$PROJECT_DIR/scripts"
 copy_file_force "$TOOLKIT_ROOT/hooks/codex-review.sh" "$PROJECT_DIR/scripts/codex-review.sh"
+copy_file_force "$TOOLKIT_ROOT/scripts/toolkit-run.sh" "$PROJECT_DIR/scripts/toolkit-run.sh"
 copy_file_force "$TOOLKIT_ROOT/scripts/open-pr.sh" "$PROJECT_DIR/scripts/open-pr.sh"
 copy_file_force "$TOOLKIT_ROOT/scripts/merge-pr.sh" "$PROJECT_DIR/scripts/merge-pr.sh"
 copy_file_force "$TOOLKIT_ROOT/scripts/cleanup-branches.sh" "$PROJECT_DIR/scripts/cleanup-branches.sh"
-copy_file_force "$TOOLKIT_ROOT/scripts/run-pytest-in-venv.sh" "$PROJECT_DIR/scripts/run-pytest-in-venv.sh"
 chmod +x "$PROJECT_DIR/scripts/"*.sh
 
 # Write toolkit version.
@@ -286,8 +386,10 @@ if [ -t 0 ] && [ -f "$PROJECT_DIR/CLAUDE.md" ]; then
   read -r -p "   Test command (e.g., pnpm build, pytest tests/): " INPUT_TEST
 
   if [ -z "$INPUT_TYPE" ]; then
-    read -r -p "   Project type (python, node, swift, generic) [generic]: " INPUT_TYPE
-    INPUT_TYPE="${INPUT_TYPE:-generic}"
+    DETECTED_TYPE="$(detect_project_type "$PROJECT_DIR")"
+    read -r -p "   Project type (node, python, swift, rust, go, generic, auto) [$DETECTED_TYPE]: " INPUT_TYPE
+    INPUT_TYPE="${INPUT_TYPE:-$DETECTED_TYPE}"
+    INPUT_TYPE="$(normalize_project_type "$INPUT_TYPE")"
   fi
 
   if [ -z "$INPUT_UNSAFE" ] && [ "$CODEX_REVIEW_CONFIG_CREATED" = true ]; then
@@ -296,7 +398,15 @@ if [ -t 0 ] && [ -f "$PROJECT_DIR/CLAUDE.md" ]; then
 fi
 
 # Default project type if not set.
-INPUT_TYPE="${INPUT_TYPE:-generic}"
+INPUT_TYPE="${INPUT_TYPE:-auto}"
+INPUT_TYPE="$(normalize_project_type "$INPUT_TYPE")"
+if [ "$INPUT_TYPE" = "auto" ]; then
+  INPUT_TYPE="$(detect_project_type "$PROJECT_DIR")"
+fi
+
+PACKAGE_MANAGER="$(detect_node_package_manager "$PROJECT_DIR")"
+MONOREPO="$(detect_monorepo "$PROJECT_DIR")"
+TARGETS="$(detect_targets "$PROJECT_DIR")"
 
 if [ -n "$INPUT_NAME" ] || [ -n "$INPUT_DESC" ] || [ -n "$INPUT_TEST" ] || [ -n "$INPUT_UNSAFE" ]; then
   # Apply to CLAUDE.md / AGENTS.md.
@@ -341,29 +451,34 @@ fi
 
 # Write .toolkit-config with project type (skip if already exists).
 if [ ! -f "$PROJECT_DIR/.toolkit-config" ]; then
-  echo "project_type=$INPUT_TYPE" > "$PROJECT_DIR/.toolkit-config"
+  {
+    printf '# toolkit project profile. Commit this file so all clones use the same commands.\n'
+    printf 'project_type=%s\n' "$INPUT_TYPE"
+    if [ -n "$PACKAGE_MANAGER" ]; then
+      printf 'package_manager=%s\n' "$PACKAGE_MANAGER"
+    else
+      printf 'package_manager=auto\n'
+    fi
+    printf 'monorepo=%s\n' "$MONOREPO"
+    printf 'targets=%s\n' "$TARGETS"
+    printf 'lint_command=\n'
+    printf 'typecheck_command=\n'
+    printf 'build_command=\n'
+    printf 'test_command=%s\n' "$INPUT_TEST"
+    printf 'validate_command=\n'
+  } > "$PROJECT_DIR/.toolkit-config"
   echo "==> Wrote .toolkit-config: project_type=$INPUT_TYPE"
 else
   echo "==> .toolkit-config already exists; left unchanged."
 fi
 
-# Uncomment language-specific hooks in .pre-commit-config.yaml based on project type.
-if [ -f "$PROJECT_DIR/.pre-commit-config.yaml" ]; then
-  case "$INPUT_TYPE" in
-    python)
-      # Uncomment the Python (ruff) hooks block by stripping "# " after the base indent.
-      sed -i '' '/^  # Python (ruff):$/,/^  #$/{
-        /^  # Python (ruff):$/d
-        /^  #$/d
-        s/^  # /  /
-      }' "$PROJECT_DIR/.pre-commit-config.yaml"
-      ;;
-  esac
-fi
-
-# Remove run-pytest-in-venv.sh for non-Python projects.
-if [ "$INPUT_TYPE" != "python" ] && [ "$INPUT_TYPE" != "generic" ]; then
-  rm -f "$PROJECT_DIR/scripts/run-pytest-in-venv.sh"
+# Keep the legacy pytest helper only for Python projects. Generic ecosystem
+# tasks should go through scripts/toolkit-run.sh.
+if [ "$INPUT_TYPE" = "python" ]; then
+  echo ""
+  echo "==> Copying Python helper:"
+  copy_file_force "$TOOLKIT_ROOT/scripts/run-pytest-in-venv.sh" "$PROJECT_DIR/scripts/run-pytest-in-venv.sh"
+  chmod +x "$PROJECT_DIR/scripts/run-pytest-in-venv.sh" 2>/dev/null || true
 fi
 
 echo ""

--- a/bootstrap/update-project.sh
+++ b/bootstrap/update-project.sh
@@ -145,11 +145,12 @@ fi
 
 # Scripts
 update_file "$TOOLKIT_ROOT/hooks/codex-review.sh" "$PROJECT_DIR/scripts/codex-review.sh"
+update_file "$TOOLKIT_ROOT/scripts/toolkit-run.sh" "$PROJECT_DIR/scripts/toolkit-run.sh"
 update_file "$TOOLKIT_ROOT/scripts/open-pr.sh" "$PROJECT_DIR/scripts/open-pr.sh"
 update_file "$TOOLKIT_ROOT/scripts/merge-pr.sh" "$PROJECT_DIR/scripts/merge-pr.sh"
 update_file "$TOOLKIT_ROOT/scripts/cleanup-branches.sh" "$PROJECT_DIR/scripts/cleanup-branches.sh"
 
-if [ "$PROJECT_TYPE" = "python" ] || [ "$PROJECT_TYPE" = "generic" ]; then
+if [ "$PROJECT_TYPE" = "python" ] || [ -f "$PROJECT_DIR/scripts/run-pytest-in-venv.sh" ]; then
   update_file "$TOOLKIT_ROOT/scripts/run-pytest-in-venv.sh" "$PROJECT_DIR/scripts/run-pytest-in-venv.sh"
 fi
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -26,10 +26,10 @@ The toolkit's `.pre-commit-config.yaml` template already includes the Codex hook
 pre-commit install --install-hooks
 ```
 
-For Python test hooks, prefer the toolkit wrapper over `python3 -m pytest` so the hook uses the project's virtualenv:
+For project validation, prefer the toolkit runner so hooks use the repo's `.toolkit-config` profile instead of hardcoding an ecosystem command:
 
 ```yaml
-entry: /usr/bin/env bash scripts/run-pytest-in-venv.sh tests/
+entry: /usr/bin/env bash scripts/toolkit-run.sh validate
 ```
 
 ### 4. Configure per-project behavior

--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -651,7 +651,7 @@ run_reviewer_with_timeout() {
 
   wait "$pid" 2>/dev/null
   local rc=$?
-  kill "$watchdog" 2>/dev/null || true
+  kill_process_tree "$watchdog" TERM
   wait "$watchdog" >/dev/null 2>&1 || true
 
   # SIGTERM/SIGKILL from the watchdog means timeout; normalize to 124.

--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -599,6 +599,19 @@ reviewer_label() {
 REVIEW_OUTPUT_FILE="$(mktemp "${TMPDIR:-/tmp}/toolkit-review-output.XXXXXX")"
 trap 'rm -f "$REVIEW_OUTPUT_FILE"' EXIT
 
+kill_process_tree() {
+  local pid="$1"
+  local signal="$2"
+  local children child
+
+  children="$(ps -axo pid=,ppid= 2>/dev/null | awk -v ppid="$pid" '$2 == ppid { print $1 }' || true)"
+  for child in $children; do
+    kill_process_tree "$child" "$signal"
+  done
+
+  kill "-$signal" "$pid" 2>/dev/null || true
+}
+
 # run_reviewer_with_timeout TIMEOUT_SECS
 #   Runs the reviewer, captures output to REVIEW_OUTPUT_FILE, returns exit code.
 #   Exit 124 = timeout. Works correctly with subshells (no $() capture needed).
@@ -612,23 +625,37 @@ run_reviewer_with_timeout() {
   fi
 
   # Run reviewer in background, kill if it exceeds timeout.
-  run_reviewer "$REVIEW_PROMPT" > "$REVIEW_OUTPUT_FILE" 2>/dev/null &
+  (
+    run_reviewer "$REVIEW_PROMPT" > "$REVIEW_OUTPUT_FILE" 2>/dev/null &
+    local reviewer_pid=$!
+
+    terminate_reviewer() {
+      kill_process_tree "$reviewer_pid" TERM
+      sleep 1
+      kill_process_tree "$reviewer_pid" KILL
+      wait "$reviewer_pid" >/dev/null 2>&1 || true
+      exit 143
+    }
+
+    trap terminate_reviewer TERM INT
+    wait "$reviewer_pid"
+  ) &
   local pid=$!
   (
     sleep "$timeout_secs"
-    kill -TERM "$pid" 2>/dev/null
+    kill_process_tree "$pid" TERM
     sleep 10
-    kill -KILL "$pid" 2>/dev/null
+    kill_process_tree "$pid" KILL
   ) &
   local watchdog=$!
 
   wait "$pid" 2>/dev/null
   local rc=$?
-  kill "$watchdog" 2>/dev/null
-  wait "$watchdog" 2>/dev/null 2>&1
+  kill "$watchdog" 2>/dev/null || true
+  wait "$watchdog" >/dev/null 2>&1 || true
 
-  # SIGTERM (128+15=143) means the watchdog killed it → normalize to 124
-  if [ "$rc" -eq 143 ]; then
+  # SIGTERM/SIGKILL from the watchdog means timeout; normalize to 124.
+  if [ "$rc" -eq 143 ] || [ "$rc" -eq 137 ]; then
     return 124
   fi
   return "$rc"

--- a/scripts/toolkit-run.sh
+++ b/scripts/toolkit-run.sh
@@ -1,0 +1,486 @@
+#!/usr/bin/env bash
+#
+# scripts/toolkit-run.sh — run project profile tasks from .toolkit-config.
+#
+# Usage:
+#   bash scripts/toolkit-run.sh detect
+#   bash scripts/toolkit-run.sh lint
+#   bash scripts/toolkit-run.sh typecheck
+#   bash scripts/toolkit-run.sh build
+#   bash scripts/toolkit-run.sh test
+#   bash scripts/toolkit-run.sh validate
+#
+set -euo pipefail
+
+ACTION="${1:-validate}"
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+CONFIG_FILE="${TOOLKIT_CONFIG_FILE:-.toolkit-config}"
+
+PROJECT_TYPE=""
+PACKAGE_MANAGER=""
+MONOREPO=""
+TARGETS=""
+LINT_COMMAND=""
+TYPECHECK_COMMAND=""
+BUILD_COMMAND=""
+TEST_COMMAND=""
+VALIDATE_COMMAND=""
+
+info() { printf '==> %s\n' "$*"; }
+ok() { printf '  OK %s\n' "$*"; }
+warn() { printf '  ! %s\n' "$*" >&2; }
+
+usage() {
+  sed -n '3,12p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+load_config() {
+  local line key value
+
+  [ -f "$CONFIG_FILE" ] || return 0
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="$(trim "$line")"
+    [ -z "$line" ] && continue
+    case "$line" in \#*) continue ;; esac
+    case "$line" in *=*) ;; *) continue ;; esac
+
+    key="$(trim "${line%%=*}")"
+    value="$(trim "${line#*=}")"
+
+    case "$key" in
+      project_type|profile) PROJECT_TYPE="$value" ;;
+      package_manager) PACKAGE_MANAGER="$value" ;;
+      monorepo) MONOREPO="$value" ;;
+      targets) TARGETS="$value" ;;
+      lint_command) LINT_COMMAND="$value" ;;
+      typecheck_command) TYPECHECK_COMMAND="$value" ;;
+      build_command) BUILD_COMMAND="$value" ;;
+      test_command) TEST_COMMAND="$value" ;;
+      validate_command) VALIDATE_COMMAND="$value" ;;
+    esac
+  done < "$CONFIG_FILE"
+}
+
+detect_node_package_manager() {
+  local dir="${1:-.}" package_manager
+
+  if [ -f "$dir/package.json" ]; then
+    package_manager="$(sed -n 's/.*"packageManager"[[:space:]]*:[[:space:]]*"\([^@"]*\)@.*/\1/p' "$dir/package.json" | head -1)"
+    if [ -z "$package_manager" ]; then
+      package_manager="$(sed -n 's/.*"packageManager"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$dir/package.json" | head -1)"
+    fi
+    if [ -n "$package_manager" ]; then
+      printf '%s\n' "$package_manager"
+      return 0
+    fi
+  fi
+
+  if [ -f "$dir/pnpm-lock.yaml" ] || [ -f "$dir/pnpm-workspace.yaml" ]; then
+    printf 'pnpm\n'
+  elif [ -f "$dir/yarn.lock" ]; then
+    printf 'yarn\n'
+  elif [ -f "$dir/bun.lock" ] || [ -f "$dir/bun.lockb" ]; then
+    printf 'bun\n'
+  else
+    printf 'npm\n'
+  fi
+}
+
+detect_profile() {
+  local dir="${1:-.}"
+
+  if [ -f "$dir/pnpm-workspace.yaml" ]; then
+    printf 'node\n'
+  elif [ -f "$dir/package.json" ] || [ -f "$dir/tsconfig.json" ]; then
+    printf 'node\n'
+  elif [ -f "$dir/Cargo.toml" ]; then
+    printf 'rust\n'
+  elif [ -f "$dir/Package.swift" ]; then
+    printf 'swift\n'
+  elif [ -f "$dir/go.mod" ]; then
+    printf 'go\n'
+  elif [ -f "$dir/uv.lock" ] || [ -f "$dir/pyproject.toml" ] || [ -f "$dir/requirements.txt" ]; then
+    printf 'python\n'
+  else
+    printf 'generic\n'
+  fi
+}
+
+detect_monorepo() {
+  local dir="${1:-.}"
+
+  if [ -f "$dir/pnpm-workspace.yaml" ]; then
+    printf 'true\n'
+  elif [ -f "$dir/Cargo.toml" ] && grep -q '^\[workspace\]' "$dir/Cargo.toml" 2>/dev/null; then
+    printf 'true\n'
+  elif [ -f "$dir/package.json" ] && grep -q '"workspaces"' "$dir/package.json" 2>/dev/null; then
+    printf 'true\n'
+  else
+    printf 'false\n'
+  fi
+}
+
+detect_targets() {
+  local root="${1:-.}" base target_dir profile targets=""
+
+  for base in apps packages services; do
+    [ -d "$root/$base" ] || continue
+    for target_dir in "$root/$base"/*; do
+      [ -d "$target_dir" ] || continue
+      profile="$(detect_profile "$target_dir")"
+      [ "$profile" = "generic" ] && continue
+      if [ -n "$targets" ]; then
+        targets="${targets},"
+      fi
+      targets="${targets}$(basename "$target_dir"):$base/$(basename "$target_dir"):$profile"
+    done
+  done
+
+  printf '%s\n' "$targets"
+}
+
+has_package_script() {
+  local script="$1"
+  [ -f package.json ] || return 1
+  grep -Eq "\"$script\"[[:space:]]*:" package.json
+}
+
+run_shell_command() {
+  local command="$1"
+  info "$command"
+  bash -c "$command"
+}
+
+configured_command_for_action() {
+  case "$1" in
+    lint) printf '%s\n' "$LINT_COMMAND" ;;
+    typecheck) printf '%s\n' "$TYPECHECK_COMMAND" ;;
+    build) printf '%s\n' "$BUILD_COMMAND" ;;
+    test) printf '%s\n' "$TEST_COMMAND" ;;
+    validate) printf '%s\n' "$VALIDATE_COMMAND" ;;
+    *) printf '\n' ;;
+  esac
+}
+
+run_node_script() {
+  local script="$1" package_manager command
+
+  has_package_script "$script" || return 1
+
+  package_manager="${PACKAGE_MANAGER:-auto}"
+  if [ "$package_manager" = "auto" ] || [ -z "$package_manager" ]; then
+    package_manager="$(detect_node_package_manager ".")"
+  fi
+
+  case "$package_manager" in
+    pnpm) command="pnpm $script" ;;
+    yarn) command="yarn $script" ;;
+    bun) command="bun run $script" ;;
+    npm|*) command="npm run $script" ;;
+  esac
+
+  run_shell_command "$command"
+}
+
+find_python_bin() {
+  local candidate
+
+  for candidate in ".venv/bin/python" "agent/.venv/bin/python"; do
+    if [ -x "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  if command -v python3 >/dev/null 2>&1; then
+    command -v python3
+    return 0
+  fi
+  if command -v python >/dev/null 2>&1; then
+    command -v python
+    return 0
+  fi
+
+  return 1
+}
+
+run_node_action() {
+  local action="$1"
+
+  case "$action" in
+    lint|typecheck|build|test)
+      if run_node_script "$action"; then
+        return 0
+      fi
+      ok "no package.json '$action' script; skipped"
+      ;;
+    *)
+      warn "unknown Node action: $action"
+      return 1
+      ;;
+  esac
+}
+
+run_python_action() {
+  local action="$1" python_bin
+
+  case "$action" in
+    lint)
+      if command -v ruff >/dev/null 2>&1; then
+        run_shell_command "ruff check ."
+      else
+        ok "ruff not installed; skipped"
+      fi
+      ;;
+    typecheck)
+      if command -v pyright >/dev/null 2>&1; then
+        run_shell_command "pyright"
+      elif command -v mypy >/dev/null 2>&1; then
+        run_shell_command "mypy ."
+      else
+        ok "pyright/mypy not installed; skipped"
+      fi
+      ;;
+    build)
+      ok "no default Python build command; set build_command in .toolkit-config"
+      ;;
+    test)
+      if python_bin="$(find_python_bin)"; then
+        run_shell_command "$python_bin -m pytest"
+      else
+        ok "python not found; skipped"
+      fi
+      ;;
+    *)
+      warn "unknown Python action: $action"
+      return 1
+      ;;
+  esac
+}
+
+run_rust_action() {
+  local action="$1"
+
+  if ! command -v cargo >/dev/null 2>&1; then
+    ok "cargo not installed; skipped"
+    return 0
+  fi
+
+  case "$action" in
+    lint)
+      if cargo fmt --version >/dev/null 2>&1; then
+        run_shell_command "cargo fmt -- --check"
+      else
+        ok "cargo fmt not installed; skipped"
+      fi
+      if cargo clippy --version >/dev/null 2>&1; then
+        run_shell_command "cargo clippy --all-targets --all-features -- -D warnings"
+      else
+        ok "cargo clippy not installed; skipped"
+      fi
+      ;;
+    typecheck) run_shell_command "cargo check --all-targets --all-features" ;;
+    build) run_shell_command "cargo build --all" ;;
+    test) run_shell_command "cargo test --all" ;;
+    *)
+      warn "unknown Rust action: $action"
+      return 1
+      ;;
+  esac
+}
+
+run_swift_action() {
+  local action="$1"
+
+  if ! command -v swift >/dev/null 2>&1; then
+    ok "swift not installed; skipped"
+    return 0
+  fi
+
+  case "$action" in
+    lint)
+      if command -v swift-format >/dev/null 2>&1; then
+        run_shell_command "swift-format lint -r ."
+      else
+        ok "swift-format not installed; skipped"
+      fi
+      ;;
+    typecheck|build) run_shell_command "swift build" ;;
+    test) run_shell_command "swift test" ;;
+    *)
+      warn "unknown Swift action: $action"
+      return 1
+      ;;
+  esac
+}
+
+run_go_action() {
+  local action="$1"
+
+  if ! command -v go >/dev/null 2>&1; then
+    ok "go not installed; skipped"
+    return 0
+  fi
+
+  case "$action" in
+    lint) run_shell_command "go vet ./..." ;;
+    typecheck|build) run_shell_command "go build ./..." ;;
+    test) run_shell_command "go test ./..." ;;
+    *)
+      warn "unknown Go action: $action"
+      return 1
+      ;;
+  esac
+}
+
+run_profile_action() {
+  local profile="$1" action="$2"
+
+  case "$profile" in
+    node|typescript|ts) run_node_action "$action" ;;
+    python) run_python_action "$action" ;;
+    rust) run_rust_action "$action" ;;
+    swift) run_swift_action "$action" ;;
+    go) run_go_action "$action" ;;
+    generic|"")
+      ok "generic project has no default '$action' command; set ${action}_command in .toolkit-config"
+      ;;
+    *)
+      warn "unknown project_type '$profile' for action '$action'"
+      return 1
+      ;;
+  esac
+}
+
+run_targets_action() {
+  local action="$1" entry name path profile
+  local -a target_entries=()
+
+  [ -n "$TARGETS" ] || return 1
+
+  IFS=',' read -r -a target_entries <<< "$TARGETS"
+  for entry in "${target_entries[@]}"; do
+    entry="$(trim "$entry")"
+    [ -z "$entry" ] && continue
+    name="${entry%%:*}"
+    path="${entry#*:}"
+    profile="${path#*:}"
+    path="${path%%:*}"
+    if [ "$path" = "$profile" ]; then
+      profile="auto"
+    fi
+    if [ "$profile" = "auto" ] || [ -z "$profile" ]; then
+      profile="$(detect_profile "$path")"
+    fi
+
+    if [ ! -d "$path" ]; then
+      warn "target '$name' path not found: $path"
+      continue
+    fi
+
+    info "target $name ($profile) — $action"
+    (cd "$path" && run_profile_action "$profile" "$action")
+  done
+}
+
+run_action() {
+  local action="$1" configured profile
+
+  configured="$(configured_command_for_action "$action")"
+  if [ -n "$configured" ]; then
+    run_shell_command "$configured"
+    return 0
+  fi
+
+  if run_targets_action "$action"; then
+    return 0
+  fi
+
+  profile="${PROJECT_TYPE:-auto}"
+  if [ "$profile" = "auto" ] || [ -z "$profile" ]; then
+    profile="$(detect_profile ".")"
+  fi
+  if [ "$profile" = "generic" ] && [ "$(detect_profile ".")" != "generic" ]; then
+    profile="$(detect_profile ".")"
+  fi
+
+  run_profile_action "$profile" "$action"
+}
+
+run_validate() {
+  local configured
+
+  configured="$(configured_command_for_action validate)"
+  if [ -n "$configured" ]; then
+    run_shell_command "$configured"
+    return 0
+  fi
+
+  run_action lint
+  run_action typecheck
+  run_action test
+}
+
+print_detection() {
+  local profile package_manager monorepo targets
+
+  profile="${PROJECT_TYPE:-auto}"
+  [ "$profile" = "auto" ] || [ -n "$profile" ] || profile="auto"
+  if [ "$profile" = "auto" ]; then
+    profile="$(detect_profile ".")"
+  fi
+  if [ "$profile" = "generic" ] && [ "$(detect_profile ".")" != "generic" ]; then
+    profile="$(detect_profile ".")"
+  fi
+
+  package_manager="${PACKAGE_MANAGER:-auto}"
+  if [ "$package_manager" = "auto" ] || [ -z "$package_manager" ]; then
+    if [ "$profile" = "node" ]; then
+      package_manager="$(detect_node_package_manager ".")"
+    else
+      package_manager=""
+    fi
+  fi
+
+  monorepo="${MONOREPO:-auto}"
+  if [ "$monorepo" = "auto" ] || [ -z "$monorepo" ]; then
+    monorepo="$(detect_monorepo ".")"
+  fi
+
+  targets="${TARGETS:-}"
+  if [ -z "$targets" ]; then
+    targets="$(detect_targets ".")"
+  fi
+
+  printf 'project_type=%s\n' "$profile"
+  [ -n "$package_manager" ] && printf 'package_manager=%s\n' "$package_manager"
+  printf 'monorepo=%s\n' "$monorepo"
+  if [ -n "$targets" ]; then
+    printf 'targets=%s\n' "$targets"
+  fi
+}
+
+load_config
+
+case "$ACTION" in
+  -h|--help) usage ;;
+  detect) print_detection ;;
+  lint|typecheck|build|test) run_action "$ACTION" ;;
+  validate) run_validate ;;
+  *)
+    echo "ERROR: unknown toolkit-run action '$ACTION'" >&2
+    usage >&2
+    exit 1
+    ;;
+esac

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -34,8 +34,8 @@
 # Reinstall dependencies without rerunning the full machine setup
 bash setup.sh --deps-only
 
-# Before any push — replace with your project's test command
-{{TEST_COMMAND — e.g., scripts/run-pytest-in-venv.sh tests/ -v --timeout=60 -x}}
+# Before any push — uses .toolkit-config profile defaults and command overrides
+bash scripts/toolkit-run.sh validate
 ```
 
 Fix failing tests before pushing.

--- a/templates/gitignore
+++ b/templates/gitignore
@@ -36,5 +36,4 @@ out/
 
 # Toolkit
 .toolkit-version
-.toolkit-config
 *.bak

--- a/templates/pre-commit-config.yaml
+++ b/templates/pre-commit-config.yaml
@@ -67,25 +67,15 @@ repos:
         always_run: true
         pass_filenames: false
 
-  # ── Project-specific hooks ─────────────────────────────────────────────
-  # Add language-specific linters and test runners below.
-  # `toolkit init` will uncomment relevant hooks for your project type.
-  #
-  # Python (ruff):
-  # - repo: https://github.com/astral-sh/ruff-pre-commit
-  #   rev: v0.8.6
-  #   hooks:
-  #     - id: ruff
-  #       args: ['--fix']
-  #     - id: ruff-format
-  #
-  # Tests (pre-push):
-  # - repo: local
-  #   hooks:
-  #     - id: tests
-  #       name: Run tests
-  #       entry: /usr/bin/env bash -c 'your-test-command-here'
-  #       language: system
-  #       stages: [pre-push]
-  #       always_run: true
-  #       pass_filenames: false
+  # ── Project profile checks ─────────────────────────────────────────────
+  # scripts/toolkit-run.sh reads .toolkit-config and dispatches to the
+  # appropriate Node/TypeScript, Swift, Rust, Python, Go, or monorepo commands.
+  - repo: local
+    hooks:
+      - id: toolkit-validate
+        name: Toolkit project validation
+        entry: /usr/bin/env bash scripts/toolkit-run.sh validate
+        language: system
+        stages: [pre-push]
+        always_run: true
+        pass_filenames: false

--- a/templates/setup.sh
+++ b/templates/setup.sh
@@ -241,65 +241,259 @@ install_uv_project() {
   fi
 }
 
+CONFIG_PROJECT_TYPE=""
+CONFIG_PACKAGE_MANAGER=""
+CONFIG_TARGETS=""
+
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+load_toolkit_config() {
+  local line key value
+
+  [ -f ".toolkit-config" ] || return 0
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="$(trim "$line")"
+    [ -z "$line" ] && continue
+    case "$line" in \#*) continue ;; esac
+    case "$line" in *=*) ;; *) continue ;; esac
+
+    key="$(trim "${line%%=*}")"
+    value="$(trim "${line#*=}")"
+    case "$key" in
+      project_type|profile) CONFIG_PROJECT_TYPE="$value" ;;
+      package_manager) CONFIG_PACKAGE_MANAGER="$value" ;;
+      targets) CONFIG_TARGETS="$value" ;;
+    esac
+  done < ".toolkit-config"
+}
+
+detect_node_package_manager() {
+  local dir="${1:-.}" package_manager
+
+  if [ -f "$dir/package.json" ]; then
+    package_manager="$(sed -n 's/.*"packageManager"[[:space:]]*:[[:space:]]*"\([^@"]*\)@.*/\1/p' "$dir/package.json" | head -1)"
+    if [ -z "$package_manager" ]; then
+      package_manager="$(sed -n 's/.*"packageManager"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$dir/package.json" | head -1)"
+    fi
+    if [ -n "$package_manager" ]; then
+      printf '%s\n' "$package_manager"
+      return 0
+    fi
+  fi
+
+  if [ -f "$dir/pnpm-lock.yaml" ] || [ -f "$dir/pnpm-workspace.yaml" ]; then
+    printf 'pnpm\n'
+  elif [ -f "$dir/yarn.lock" ]; then
+    printf 'yarn\n'
+  elif [ -f "$dir/bun.lock" ] || [ -f "$dir/bun.lockb" ]; then
+    printf 'bun\n'
+  else
+    printf 'npm\n'
+  fi
+}
+
+detect_profile() {
+  local dir="${1:-.}"
+
+  if [ -f "$dir/pnpm-workspace.yaml" ]; then
+    printf 'node\n'
+  elif [ -f "$dir/package.json" ] || [ -f "$dir/tsconfig.json" ]; then
+    printf 'node\n'
+  elif [ -f "$dir/Cargo.toml" ]; then
+    printf 'rust\n'
+  elif [ -f "$dir/Package.swift" ]; then
+    printf 'swift\n'
+  elif [ -f "$dir/go.mod" ]; then
+    printf 'go\n'
+  elif [ -f "$dir/uv.lock" ] || [ -f "$dir/pyproject.toml" ] || [ -f "$dir/requirements.txt" ]; then
+    printf 'python\n'
+  else
+    printf 'generic\n'
+  fi
+}
+
+install_node_dependencies() {
+  local label="$1"
+  local project_dir="$2"
+  local package_manager="$3"
+
+  [ -f "$project_dir/package.json" ] || [ -f "$project_dir/pnpm-workspace.yaml" ] || return 1
+
+  if [ "$package_manager" = "auto" ] || [ -z "$package_manager" ]; then
+    package_manager="$(detect_node_package_manager "$project_dir")"
+  fi
+
+  if { [ "$package_manager" = "pnpm" ] || [ "$package_manager" = "yarn" ]; } && command -v corepack >/dev/null 2>&1; then
+    corepack enable 2>/dev/null || true
+  fi
+
+  case "$package_manager" in
+    pnpm)
+      if command -v pnpm >/dev/null 2>&1; then
+        (cd "$project_dir" && pnpm install) 2>&1 | tail -1 | while read -r line; do ok "$label dependencies installed: $line"; done
+      else
+        warn "$label uses pnpm, but pnpm is not installed. Run: corepack enable or brew install pnpm"
+      fi
+      ;;
+    yarn)
+      if command -v yarn >/dev/null 2>&1; then
+        (cd "$project_dir" && yarn install) 2>&1 | tail -1 | while read -r line; do ok "$label dependencies installed: $line"; done
+      else
+        warn "$label uses yarn, but yarn is not installed. Run: corepack enable"
+      fi
+      ;;
+    bun)
+      if command -v bun >/dev/null 2>&1; then
+        (cd "$project_dir" && bun install) 2>&1 | tail -1 | while read -r line; do ok "$label dependencies installed: $line"; done
+      else
+        warn "$label uses bun, but bun is not installed."
+      fi
+      ;;
+    npm|*)
+      if command -v npm >/dev/null 2>&1; then
+        (cd "$project_dir" && npm install) 2>&1 | tail -1 | while read -r line; do ok "$label dependencies installed: $line"; done
+      else
+        warn "$label uses npm, but npm is not installed. Install Node.js/npm first."
+      fi
+      ;;
+  esac
+
+  return 0
+}
+
+install_python_dependencies() {
+  local label="$1"
+  local project_dir="$2"
+
+  if [ -f "$project_dir/uv.lock" ]; then
+    install_uv_project "$label" "$project_dir"
+  elif [ -f "$project_dir/pyproject.toml" ] && [ ! -f "$project_dir/requirements.txt" ]; then
+    install_uv_project "$label" "$project_dir"
+  elif [ -f "$project_dir/requirements.txt" ]; then
+    if [ "$project_dir" = "." ]; then
+      install_python_requirements "$label" "$project_dir/requirements.txt" ".venv"
+    else
+      install_python_requirements "$label" "$project_dir/requirements.txt" "$project_dir/.venv"
+    fi
+  else
+    return 1
+  fi
+
+  return 0
+}
+
+install_rust_dependencies() {
+  local label="$1"
+  local project_dir="$2"
+
+  [ -f "$project_dir/Cargo.toml" ] || return 1
+  if command -v cargo >/dev/null 2>&1; then
+    (cd "$project_dir" && cargo fetch) 2>&1 | tail -1 | while read -r line; do ok "$label crates fetched: $line"; done
+  else
+    warn "$label is Rust, but cargo is not installed."
+  fi
+  return 0
+}
+
+install_swift_dependencies() {
+  local label="$1"
+  local project_dir="$2"
+
+  [ -f "$project_dir/Package.swift" ] || return 1
+  if command -v swift >/dev/null 2>&1; then
+    (cd "$project_dir" && swift package resolve) 2>&1 | tail -1 | while read -r line; do ok "$label packages resolved: $line"; done
+  else
+    warn "$label is Swift, but swift is not installed."
+  fi
+  return 0
+}
+
+install_go_dependencies() {
+  local label="$1"
+  local project_dir="$2"
+
+  [ -f "$project_dir/go.mod" ] || return 1
+  if command -v go >/dev/null 2>&1; then
+    (cd "$project_dir" && go mod download) 2>&1 && ok "$label modules downloaded"
+  else
+    warn "$label is Go, but go is not installed."
+  fi
+  return 0
+}
+
+install_profile_dependencies() {
+  local label="$1"
+  local project_dir="$2"
+  local profile="$3"
+
+  if [ "$profile" = "auto" ] || [ -z "$profile" ]; then
+    profile="$(detect_profile "$project_dir")"
+  fi
+
+  case "$profile" in
+    node|typescript|ts) install_node_dependencies "$label" "$project_dir" "$CONFIG_PACKAGE_MANAGER" ;;
+    python) install_python_dependencies "$label" "$project_dir" ;;
+    rust) install_rust_dependencies "$label" "$project_dir" ;;
+    swift) install_swift_dependencies "$label" "$project_dir" ;;
+    go) install_go_dependencies "$label" "$project_dir" ;;
+    generic|"") return 1 ;;
+    *) warn "Unknown project_type '$profile' in .toolkit-config"; return 1 ;;
+  esac
+}
+
+install_configured_targets() {
+  local entry name path profile
+  local -a target_entries=()
+
+  [ -n "$CONFIG_TARGETS" ] || return 1
+
+  IFS=',' read -r -a target_entries <<< "$CONFIG_TARGETS"
+  for entry in "${target_entries[@]}"; do
+    entry="$(trim "$entry")"
+    [ -z "$entry" ] && continue
+    name="${entry%%:*}"
+    path="${entry#*:}"
+    profile="${path#*:}"
+    path="${path%%:*}"
+    if [ "$path" = "$profile" ]; then
+      profile="auto"
+    fi
+    if [ ! -d "$path" ]; then
+      warn "target '$name' path not found: $path"
+      continue
+    fi
+    install_profile_dependencies "$name" "$path" "$profile" || true
+  done
+}
+
+load_toolkit_config
+
 DEPS_FOUND=false
-
-if [ -f "pnpm-lock.yaml" ]; then
+ROOT_PROFILE="${CONFIG_PROJECT_TYPE:-auto}"
+if [ "$ROOT_PROFILE" = "generic" ] && [ "$(detect_profile ".")" != "generic" ]; then
+  ROOT_PROFILE="$(detect_profile ".")"
+fi
+if install_profile_dependencies "Project" "." "$ROOT_PROFILE"; then
   DEPS_FOUND=true
-  if command -v pnpm >/dev/null 2>&1; then
-    pnpm install 2>&1 | tail -1 | while read -r line; do ok "$line"; done
-  else
-    warn "pnpm-lock.yaml found, but pnpm is not installed. Run: brew install pnpm"
-  fi
-elif [ -f "package-lock.json" ]; then
-  DEPS_FOUND=true
-  if command -v npm >/dev/null 2>&1; then
-    npm install 2>&1 | tail -1 | while read -r line; do ok "$line"; done
-  else
-    warn "package-lock.json found, but npm is not installed. Install Node.js/npm first."
-  fi
-elif [ -f "package.json" ]; then
-  DEPS_FOUND=true
-  if command -v pnpm >/dev/null 2>&1; then
-    pnpm install 2>&1 | tail -1 | while read -r line; do ok "$line"; done
-  elif command -v npm >/dev/null 2>&1; then
-    npm install 2>&1 | tail -1 | while read -r line; do ok "$line"; done
-  else
-    warn "package.json found, but neither pnpm nor npm is installed."
-  fi
 fi
 
-if [ -f "uv.lock" ]; then
+# Backward-compatible nested Python agent support.
+if install_python_dependencies "agent Python" "agent"; then
   DEPS_FOUND=true
-  install_uv_project "Python" "."
-elif [ -f "pyproject.toml" ] && [ ! -f "requirements.txt" ]; then
-  DEPS_FOUND=true
-  install_uv_project "Python" "."
-elif [ -f "requirements.txt" ]; then
-  DEPS_FOUND=true
-  install_python_requirements "Python" "requirements.txt" ".venv"
 fi
 
-if [ -f "agent/uv.lock" ]; then
+if [ "$DEPS_FOUND" = false ] && install_configured_targets; then
   DEPS_FOUND=true
-  install_uv_project "agent Python" "agent"
-elif [ -f "agent/pyproject.toml" ] && [ ! -f "agent/requirements.txt" ]; then
-  DEPS_FOUND=true
-  install_uv_project "agent Python" "agent"
-elif [ -f "agent/requirements.txt" ]; then
-  DEPS_FOUND=true
-  install_python_requirements "agent Python" "agent/requirements.txt" "agent/.venv"
 fi
 
 if [ "$DEPS_FOUND" = false ]; then
-  if [ -f "Cargo.toml" ]; then
-    ok "Rust project — run: cargo build"
-  elif [ -f "Package.swift" ]; then
-    ok "Swift project — run: swift build"
-  elif [ -f "go.mod" ]; then
-    go mod download 2>&1 && ok "Go modules downloaded"
-  else
-    ok "No recognized dependency file — skipping"
-  fi
+  ok "No recognized dependency file — skipping"
 fi
 
 # --------------------------------------------------------------------------

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -24,6 +24,13 @@ assert_exists() {
   fi
 }
 
+assert_not_exists() {
+  if [ -e "$1" ]; then
+    echo "FAIL: expected $1 to NOT exist" >&2
+    ERRORS=$((ERRORS + 1))
+  fi
+}
+
 assert_executable() {
   if [ ! -x "$1" ]; then
     echo "FAIL: expected $1 to be executable" >&2
@@ -43,6 +50,8 @@ PROJECT_WITH_UNSAFE="$TEST_DIR/test-project-unsafe"
 PROJECT_EXISTING="$TEST_DIR/test-project-existing"
 PROJECT_EXISTING_CONFIG="$TEST_DIR/test-project-existing-config"
 PROJECT_INIT_EXISTING_SETUP="$TEST_DIR/test-project-init-existing-setup"
+PROJECT_NODE="$TEST_DIR/test-project-node"
+PROJECT_PYTHON="$TEST_DIR/test-project-python"
 
 # Git repo
 assert_exists "$PROJECT/.git"
@@ -65,16 +74,24 @@ assert_exists "$PROJECT/principles/README.md"
 
 # Scripts
 assert_exists "$PROJECT/scripts/codex-review.sh"
+assert_exists "$PROJECT/scripts/toolkit-run.sh"
 assert_exists "$PROJECT/scripts/open-pr.sh"
 assert_exists "$PROJECT/scripts/merge-pr.sh"
 assert_exists "$PROJECT/scripts/cleanup-branches.sh"
-assert_exists "$PROJECT/scripts/run-pytest-in-venv.sh"
+assert_not_exists "$PROJECT/scripts/run-pytest-in-venv.sh"
 assert_executable "$PROJECT/scripts/codex-review.sh"
+assert_executable "$PROJECT/scripts/toolkit-run.sh"
 assert_executable "$PROJECT/scripts/open-pr.sh"
 assert_executable "$PROJECT/scripts/merge-pr.sh"
 assert_executable "$PROJECT/scripts/cleanup-branches.sh"
-assert_executable "$PROJECT/scripts/run-pytest-in-venv.sh"
 assert_contains "$PROJECT/.pre-commit-config.yaml" 'codex-review.sh'
+assert_contains "$PROJECT/.pre-commit-config.yaml" 'toolkit-run.sh validate'
+assert_contains "$PROJECT/.toolkit-config" '^project_type=generic$'
+assert_contains "$PROJECT/.toolkit-config" '^lint_command=$'
+if grep -q '^\.toolkit-config$' "$PROJECT/.gitignore"; then
+  echo "FAIL: expected .toolkit-config to be commit-friendly, not ignored" >&2
+  ERRORS=$((ERRORS + 1))
+fi
 
 # Toolkit version
 assert_exists "$PROJECT/.toolkit-version"
@@ -86,6 +103,7 @@ assert_contains "$PROJECT/CLAUDE.md" "@principles/"
 # Help flags should print usage instead of bootstrapping a project named --help.
 if (cd "$TEST_DIR" && bash "$TOOLKIT_ROOT/bootstrap/new-project.sh" --help) >"$TEST_DIR/new-project-help.txt" 2>&1; then
   assert_contains "$TEST_DIR/new-project-help.txt" 'unsafe-paths'
+  assert_contains "$TEST_DIR/new-project-help.txt" 'node|python|swift|rust|go|generic|auto'
 else
   echo "FAIL: expected new-project.sh --help to succeed" >&2
   ERRORS=$((ERRORS + 1))
@@ -97,6 +115,7 @@ fi
 
 if TOOLKIT_NO_AUTO_UPDATE=1 "$TOOLKIT_ROOT/bin/toolkit" init --help >"$TEST_DIR/toolkit-init-help.txt" 2>&1; then
   assert_contains "$TEST_DIR/toolkit-init-help.txt" 'Usage: toolkit init'
+  assert_contains "$TEST_DIR/toolkit-init-help.txt" 'node|python|swift|rust|go|generic|auto'
 else
   echo "FAIL: expected toolkit init --help to succeed" >&2
   ERRORS=$((ERRORS + 1))
@@ -108,6 +127,18 @@ assert_exists "$PROJECT_WITH_UNSAFE/.codex-review.toml"
 assert_contains "$PROJECT_WITH_UNSAFE/.codex-review.toml" '"src/auth/",'
 assert_contains "$PROJECT_WITH_UNSAFE/.codex-review.toml" '"migrations/",'
 assert_contains "$PROJECT_WITH_UNSAFE/.codex-review.toml" '^unsafe_paths = \[$'
+
+# Ecosystem profiles should configure shared runner behavior without making
+# Python the default for every project.
+bash "$TOOLKIT_ROOT/bootstrap/new-project.sh" "$PROJECT_NODE" --no-register --type node
+assert_exists "$PROJECT_NODE/scripts/toolkit-run.sh"
+assert_not_exists "$PROJECT_NODE/scripts/run-pytest-in-venv.sh"
+assert_contains "$PROJECT_NODE/.toolkit-config" '^project_type=node$'
+
+bash "$TOOLKIT_ROOT/bootstrap/new-project.sh" "$PROJECT_PYTHON" --no-register --type python
+assert_exists "$PROJECT_PYTHON/scripts/toolkit-run.sh"
+assert_exists "$PROJECT_PYTHON/scripts/run-pytest-in-venv.sh"
+assert_contains "$PROJECT_PYTHON/.toolkit-config" '^project_type=python$'
 
 # Bootstrap into an existing directory should back up toolkit-owned files before replacing them.
 mkdir -p "$PROJECT_EXISTING/principles" "$PROJECT_EXISTING/scripts"
@@ -253,6 +284,87 @@ FAKECODEX
 chmod +x "$SETUP_VERSION_FAKE_BIN/"*
 (cd "$SETUP_VERSION_PROJECT" && PATH="$SETUP_VERSION_FAKE_BIN:$PATH" bash setup.sh) >"$TEST_DIR/setup-version-output.txt"
 assert_contains "$TEST_DIR/setup-version-output.txt" 'toolkit v9.9.9'
+
+# toolkit-run.sh should provide ecosystem-neutral task dispatch.
+RUNNER_FAKE_BIN="$TEST_DIR/runner-fake-bin"
+RUNNER_LOG="$TEST_DIR/runner.log"
+mkdir -p "$RUNNER_FAKE_BIN"
+
+cat > "$RUNNER_FAKE_BIN/pnpm" <<'FAKEPNPM'
+#!/usr/bin/env bash
+printf 'pnpm|%s|%s\n' "$PWD" "$*" >> "$RUNNER_LOG"
+FAKEPNPM
+cat > "$RUNNER_FAKE_BIN/npm" <<'FAKENPM'
+#!/usr/bin/env bash
+printf 'npm|%s|%s\n' "$PWD" "$*" >> "$RUNNER_LOG"
+FAKENPM
+cat > "$RUNNER_FAKE_BIN/swift" <<'FAKESWIFT'
+#!/usr/bin/env bash
+printf 'swift|%s|%s\n' "$PWD" "$*" >> "$RUNNER_LOG"
+FAKESWIFT
+cat > "$RUNNER_FAKE_BIN/cargo" <<'FAKECARGO'
+#!/usr/bin/env bash
+printf 'cargo|%s|%s\n' "$PWD" "$*" >> "$RUNNER_LOG"
+FAKECARGO
+chmod +x "$RUNNER_FAKE_BIN/"*
+
+printf '{"packageManager":"pnpm@9.0.0","scripts":{"lint":"echo lint","typecheck":"echo typecheck","test":"echo test"}}\n' > "$PROJECT_NODE/package.json"
+: > "$RUNNER_LOG"
+(cd "$PROJECT_NODE" && PATH="$RUNNER_FAKE_BIN:$PATH" RUNNER_LOG="$RUNNER_LOG" bash scripts/toolkit-run.sh validate) >/dev/null
+assert_contains "$RUNNER_LOG" 'pnpm|.*/test-project-node|lint'
+assert_contains "$RUNNER_LOG" 'pnpm|.*/test-project-node|typecheck'
+assert_contains "$RUNNER_LOG" 'pnpm|.*/test-project-node|test'
+
+SWIFT_PROJECT="$TEST_DIR/swift-runner"
+mkdir -p "$SWIFT_PROJECT/scripts"
+cp "$TOOLKIT_ROOT/scripts/toolkit-run.sh" "$SWIFT_PROJECT/scripts/toolkit-run.sh"
+printf 'project_type=swift\n' > "$SWIFT_PROJECT/.toolkit-config"
+printf '// swift package\n' > "$SWIFT_PROJECT/Package.swift"
+: > "$RUNNER_LOG"
+(cd "$SWIFT_PROJECT" && PATH="$RUNNER_FAKE_BIN:$PATH" RUNNER_LOG="$RUNNER_LOG" bash scripts/toolkit-run.sh validate) >/dev/null
+assert_contains "$RUNNER_LOG" 'swift|.*/swift-runner|build'
+assert_contains "$RUNNER_LOG" 'swift|.*/swift-runner|test'
+
+RUST_PROJECT="$TEST_DIR/rust-runner"
+mkdir -p "$RUST_PROJECT/scripts"
+cp "$TOOLKIT_ROOT/scripts/toolkit-run.sh" "$RUST_PROJECT/scripts/toolkit-run.sh"
+printf 'project_type=rust\n' > "$RUST_PROJECT/.toolkit-config"
+printf '[package]\nname = "demo"\nversion = "0.0.0"\n' > "$RUST_PROJECT/Cargo.toml"
+: > "$RUNNER_LOG"
+(cd "$RUST_PROJECT" && PATH="$RUNNER_FAKE_BIN:$PATH" RUNNER_LOG="$RUNNER_LOG" bash scripts/toolkit-run.sh validate) >/dev/null
+assert_contains "$RUNNER_LOG" 'cargo|.*/rust-runner|fmt -- --check'
+assert_contains "$RUNNER_LOG" 'cargo|.*/rust-runner|clippy --all-targets --all-features -- -D warnings'
+assert_contains "$RUNNER_LOG" 'cargo|.*/rust-runner|check --all-targets --all-features'
+assert_contains "$RUNNER_LOG" 'cargo|.*/rust-runner|test --all'
+
+MONOREPO_PROJECT="$TEST_DIR/monorepo-runner"
+mkdir -p "$MONOREPO_PROJECT/scripts" "$MONOREPO_PROJECT/apps/web" "$MONOREPO_PROJECT/services/api"
+cp "$TOOLKIT_ROOT/scripts/toolkit-run.sh" "$MONOREPO_PROJECT/scripts/toolkit-run.sh"
+{
+  printf 'project_type=generic\n'
+  printf 'targets=web:apps/web:node,api:services/api:rust\n'
+} > "$MONOREPO_PROJECT/.toolkit-config"
+printf '{"scripts":{"test":"echo test"}}\n' > "$MONOREPO_PROJECT/apps/web/package.json"
+printf '[package]\nname = "api"\nversion = "0.0.0"\n' > "$MONOREPO_PROJECT/services/api/Cargo.toml"
+: > "$RUNNER_LOG"
+(cd "$MONOREPO_PROJECT" && PATH="$RUNNER_FAKE_BIN:$PATH" RUNNER_LOG="$RUNNER_LOG" bash scripts/toolkit-run.sh test) >/dev/null
+assert_contains "$RUNNER_LOG" 'npm|.*/monorepo-runner/apps/web|run test'
+assert_contains "$RUNNER_LOG" 'cargo|.*/monorepo-runner/services/api|test --all'
+
+# setup.sh --deps-only should also use the project profile layer for non-Python ecosystems.
+: > "$RUNNER_LOG"
+(cd "$PROJECT_NODE" && PATH="$RUNNER_FAKE_BIN:$PATH" RUNNER_LOG="$RUNNER_LOG" bash setup.sh --deps-only) >/dev/null
+assert_contains "$RUNNER_LOG" 'pnpm|.*/test-project-node|install'
+
+cp "$TOOLKIT_ROOT/templates/setup.sh" "$SWIFT_PROJECT/setup.sh"
+: > "$RUNNER_LOG"
+(cd "$SWIFT_PROJECT" && PATH="$RUNNER_FAKE_BIN:$PATH" RUNNER_LOG="$RUNNER_LOG" bash setup.sh --deps-only) >/dev/null
+assert_contains "$RUNNER_LOG" 'swift|.*/swift-runner|package resolve'
+
+cp "$TOOLKIT_ROOT/templates/setup.sh" "$RUST_PROJECT/setup.sh"
+: > "$RUNNER_LOG"
+(cd "$RUST_PROJECT" && PATH="$RUNNER_FAKE_BIN:$PATH" RUNNER_LOG="$RUNNER_LOG" bash setup.sh --deps-only) >/dev/null
+assert_contains "$RUNNER_LOG" 'cargo|.*/rust-runner|fetch'
 
 echo ""
 if [ "$ERRORS" -eq 0 ]; then

--- a/tests/test-review-hook.sh
+++ b/tests/test-review-hook.sh
@@ -931,6 +931,8 @@ fi
 
 TIMEOUT_REPO="$TEST_DIR/repo-timeout"
 TIMEOUT_OUTPUT="$TEST_DIR/timeout-output.txt"
+TIMEOUT_PID_FILE="$TEST_DIR/timeout-reviewer.pid"
+TIMEOUT_CHILD_PID_FILE="$TEST_DIR/timeout-reviewer-child.pid"
 
 setup_timeout_repo() {
   rm -rf "$TIMEOUT_REPO"
@@ -958,14 +960,21 @@ EOF
 cat > "$TIMEOUT_BIN/codex" <<'CXEOF'
 #!/usr/bin/env bash
 if [ "${1:-}" = "login" ] && [ "${2:-}" = "status" ]; then exit 0; fi
-sleep 999
+sleep 999 &
+child_pid=$!
+printf '%s\n' "$$" > "$TIMEOUT_PID_FILE"
+printf '%s\n' "$child_pid" > "$TIMEOUT_CHILD_PID_FILE"
+wait "$child_pid"
 CXEOF
 chmod +x "$TIMEOUT_BIN/gh" "$TIMEOUT_BIN/codex"
+rm -f "$TIMEOUT_PID_FILE" "$TIMEOUT_CHILD_PID_FILE"
 
 set +e
 (
   cd "$TIMEOUT_REPO"
   PATH="$TIMEOUT_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    TIMEOUT_PID_FILE="$TIMEOUT_PID_FILE" \
+    TIMEOUT_CHILD_PID_FILE="$TIMEOUT_CHILD_PID_FILE" \
     CODEX_REVIEW_BASE="HEAD~1" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
     CODEX_REVIEW_TIMEOUT=2 \
@@ -979,6 +988,25 @@ if [ "$TIMEOUT_EXIT" -eq 0 ] && grep -q 'timed out after 2s' "$TIMEOUT_OUTPUT"; 
 else
   echo "FAIL: expected timeout to kill reviewer and exit 0" >&2
   echo "exit code: $TIMEOUT_EXIT" >&2
+  cat "$TIMEOUT_OUTPUT" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+process_still_active() {
+  local pid="$1"
+  local stat
+
+  stat="$(ps -p "$pid" -o stat= 2>/dev/null | awk '{print $1}' || true)"
+  [ -n "$stat" ] && [[ "$stat" != Z* ]]
+}
+
+if [ -s "$TIMEOUT_PID_FILE" ] \
+  && [ -s "$TIMEOUT_CHILD_PID_FILE" ] \
+  && ! process_still_active "$(cat "$TIMEOUT_PID_FILE")" \
+  && ! process_still_active "$(cat "$TIMEOUT_CHILD_PID_FILE")"; then
+  echo "==> PASS: timeout cleaned up reviewer process tree"
+else
+  echo "FAIL: expected timeout to clean up reviewer process tree" >&2
   cat "$TIMEOUT_OUTPUT" >&2
   ERRORS=$((ERRORS + 1))
 fi

--- a/tests/test-review-hook.sh
+++ b/tests/test-review-hook.sh
@@ -948,6 +948,58 @@ setup_timeout_repo() {
   git -C "$TIMEOUT_REPO" commit -m "change" >/dev/null 2>&1
 }
 
+sleep_command_active() {
+  local seconds="$1"
+
+  ps -axo stat=,command= 2>/dev/null | awk -v command="sleep $seconds" '
+    $1 !~ /^Z/ {
+      $1 = ""
+      sub(/^[[:space:]]+/, "")
+      if ($0 == command) {
+        found = 1
+      }
+    }
+    END { exit(found ? 0 : 1) }
+  '
+}
+
+echo "==> Test: clean review cancels timeout watchdog"
+setup_timeout_repo
+TIMEOUT_BIN="$TEST_DIR/timeout-bin"
+rm -rf "$TIMEOUT_BIN"
+mkdir -p "$TIMEOUT_BIN"
+cat > "$TIMEOUT_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "main"
+EOF
+cat > "$TIMEOUT_BIN/codex" <<'CXEOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = "login" ] && [ "${2:-}" = "status" ]; then exit 0; fi
+printf 'CODEX_REVIEW_CLEAN\n'
+CXEOF
+chmod +x "$TIMEOUT_BIN/gh" "$TIMEOUT_BIN/codex"
+
+set +e
+(
+  cd "$TIMEOUT_REPO"
+  PATH="$TIMEOUT_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    CODEX_REVIEW_TIMEOUT=13 \
+    bash "$TOOLKIT_ROOT/hooks/codex-review.sh" > "$TIMEOUT_OUTPUT" 2>&1
+)
+CLEAN_TIMEOUT_EXIT=$?
+set -e
+
+if [ "$CLEAN_TIMEOUT_EXIT" -eq 0 ] && ! sleep_command_active 13; then
+  echo "==> PASS: clean review canceled timeout watchdog"
+else
+  echo "FAIL: expected clean review to cancel timeout watchdog" >&2
+  echo "exit code: $CLEAN_TIMEOUT_EXIT" >&2
+  cat "$TIMEOUT_OUTPUT" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
 echo "==> Test: timeout kills reviewer and exits per on_error"
 setup_timeout_repo
 TIMEOUT_BIN="$TEST_DIR/timeout-bin"

--- a/tests/test-update.sh
+++ b/tests/test-update.sh
@@ -69,7 +69,7 @@ echo "--- Step 3: Modify a toolkit-owned file, then update ---"
 
 # Simulate local modification to a toolkit-owned file.
 echo "# locally modified" >> "$PROJECT/principles/engineering-principles.md"
-rm "$PROJECT/scripts/run-pytest-in-venv.sh"
+rm "$PROJECT/scripts/toolkit-run.sh"
 
 # Fake a new toolkit version by writing a different SHA so update thinks
 # there's something new. We write a fake old SHA to .toolkit-version.
@@ -79,7 +79,7 @@ echo "0000000000000000000000000000000000000000" > "$PROJECT/.toolkit-version"
 
 # Verify .bak was created.
 assert_exists "$PROJECT/principles/engineering-principles.md.bak"
-assert_exists "$PROJECT/scripts/run-pytest-in-venv.sh"
+assert_exists "$PROJECT/scripts/toolkit-run.sh"
 assert_contains "$TEST_DIR/update-output-2.txt" 'toolkit diff'
 assert_contains "$TEST_DIR/update-output-2.txt" '.codex-review.toml'
 


### PR DESCRIPTION
## Summary
- add `.toolkit-config` project profiles and `scripts/toolkit-run.sh` for Node/TS, Swift, Rust, Go, Python, generic projects, and simple monorepo target detection
- wire `toolkit detect` / `toolkit run <task>` plus profile-aware bootstrap, update, setup, docs, and tests
- fix `codex-review.sh` timeout cleanup so reviewer process trees and watchdog sleeps do not wedge pre-push self-tests

## Tests
- `bash tests/test-review-hook.sh`
- `bash -c 'set -e; for test in tests/test-*.sh; do /usr/bin/env bash "$test"; done'`
- `bash -n hooks/codex-review.sh tests/test-review-hook.sh`
- `shellcheck --severity=warning hooks/codex-review.sh tests/test-review-hook.sh`
- normal `git push` pre-push hooks passed on `feat/project-profiles`