### PR TITLE
feat: add migrate-from-toolkit subcommand

### DIFF
--- a/bin/touchstone
+++ b/bin/touchstone
@@ -164,6 +164,10 @@ cmd_update() {
   exec bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh" "$@"
 }
 
+cmd_migrate_from_toolkit() {
+  exec bash "$TOUCHSTONE_ROOT/bootstrap/migrate-from-toolkit.sh" "$@"
+}
+
 cmd_sync() {
   exec bash "$TOUCHSTONE_ROOT/bootstrap/sync-all.sh" "$@"
 }
@@ -706,6 +710,7 @@ cmd_help() {
   printf "    ${BOLD}touchstone update${RESET}                 Create a branch + commit for touchstone updates\n"
   printf "    ${BOLD}touchstone update${RESET} --dry-run       Preview what would change\n"
   printf "    ${BOLD}touchstone update${RESET} --check         Report whether this project needs update\n"
+  printf "    ${BOLD}touchstone migrate-from-toolkit${RESET}   One-shot rename of legacy .toolkit-* files (pre-1.0.0 projects)\n"
   printf "    ${BOLD}touchstone sync${RESET}                   Update all registered projects\n"
   printf "    ${BOLD}touchstone sync${RESET} --check           Report which projects need sync\n"
   printf "    ${BOLD}touchstone sync${RESET} --pull-first      Pull latest touchstone first\n"
@@ -744,6 +749,7 @@ case "$COMMAND" in
   run)          cmd_run "$@" ;;
   detect)       cmd_detect ;;
   update)       cmd_update "$@" ;;
+  migrate-from-toolkit) cmd_migrate_from_toolkit "$@" ;;
   sync)         cmd_sync "$@" ;;
   status)       cmd_status ;;
   list|ls)      cmd_list ;;

--- a/bootstrap/migrate-from-toolkit.sh
+++ b/bootstrap/migrate-from-toolkit.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# bootstrap/migrate-from-toolkit.sh — one-shot migration of legacy .toolkit-*
+# dotfiles to their .touchstone-* equivalents for projects bootstrapped before
+# the v1.0.0 toolkit -> touchstone rename.
+#
+# Behavior:
+#   1. Refuses to run if not a git repo or working tree is dirty.
+#   2. Renames .toolkit-{version,manifest,config} -> .touchstone-{version,manifest,config}
+#      using `git mv` so history follows.
+#   3. Rewrites path references inside .touchstone-manifest
+#      (`.toolkit-*` -> `.touchstone-*`, `toolkit-run.sh` -> `touchstone-run.sh`).
+#   4. Commits as "chore: migrate from toolkit to touchstone" on the current branch.
+#   5. Idempotent: if no legacy files remain, exits 0 with a clear message.
+#
+# This script is a backwards-compat shim for the rename and can be deleted
+# once every downstream project has migrated. It intentionally does NOT run
+# `touchstone update` afterward — the user runs that as a separate step.
+#
+set -euo pipefail
+
+PROJECT_DIR="$(pwd)"
+
+LEGACY_PAIRS=(
+  ".toolkit-version:.touchstone-version"
+  ".toolkit-manifest:.touchstone-manifest"
+  ".toolkit-config:.touchstone-config"
+)
+
+require_git_repo() {
+  if ! git -C "$PROJECT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "ERROR: touchstone migrate-from-toolkit requires a git repository." >&2
+    exit 1
+  fi
+}
+
+require_clean_tree() {
+  if [ -n "$(git -C "$PROJECT_DIR" status --porcelain)" ]; then
+    echo "ERROR: Working tree is dirty. Commit, stash, or revert first." >&2
+    exit 1
+  fi
+}
+
+detect_legacy_state() {
+  local pair old new conflict=0 legacy=0
+  for pair in "${LEGACY_PAIRS[@]}"; do
+    old="${pair%%:*}"
+    new="${pair##*:}"
+    if [ -f "$PROJECT_DIR/$old" ] && [ -f "$PROJECT_DIR/$new" ]; then
+      echo "ERROR: Both $old and $new exist in $PROJECT_DIR." >&2
+      echo "       Manual cleanup required: pick one and delete the other." >&2
+      conflict=1
+    fi
+    if [ -f "$PROJECT_DIR/$old" ]; then
+      legacy=1
+    fi
+  done
+  [ "$conflict" -eq 0 ] || exit 1
+  [ "$legacy" -eq 1 ]
+}
+
+rename_legacy_files() {
+  local pair old new
+  for pair in "${LEGACY_PAIRS[@]}"; do
+    old="${pair%%:*}"
+    new="${pair##*:}"
+    if [ -f "$PROJECT_DIR/$old" ]; then
+      git -C "$PROJECT_DIR" mv "$old" "$new"
+      echo "    renamed $old -> $new"
+    fi
+  done
+}
+
+rewrite_manifest_paths() {
+  local manifest="$PROJECT_DIR/.touchstone-manifest"
+  [ -f "$manifest" ] || return 0
+  if ! grep -qE '\.toolkit-|toolkit-run\.sh' "$manifest"; then
+    return 0
+  fi
+  # sed -i.bak is portable across BSD/GNU; we remove the backup ourselves.
+  sed -i.bak \
+    -e 's/\.toolkit-/\.touchstone-/g' \
+    -e 's/toolkit-run\.sh/touchstone-run.sh/g' \
+    "$manifest"
+  rm -f "$manifest.bak"
+  git -C "$PROJECT_DIR" add .touchstone-manifest
+  echo "    updated .touchstone-manifest path references"
+}
+
+main() {
+  require_git_repo
+
+  if ! detect_legacy_state; then
+    echo "==> No legacy .toolkit-* files found. Nothing to migrate."
+    exit 0
+  fi
+
+  require_clean_tree
+
+  echo "==> Migrating legacy .toolkit-* files in $PROJECT_DIR"
+  rename_legacy_files
+  rewrite_manifest_paths
+
+  git -C "$PROJECT_DIR" commit -m "chore: migrate from toolkit to touchstone
+
+Renames legacy .toolkit-* dotfiles to .touchstone-* to match the v1.0.0
+rename. Path references inside .touchstone-manifest are rewritten.
+Run \`touchstone update\` next to pick up any newer touchstone-owned files." >/dev/null
+
+  echo "==> Committed migration. Next: touchstone update"
+}
+
+main "$@"

--- a/bootstrap/update-project.sh
+++ b/bootstrap/update-project.sh
@@ -46,8 +46,15 @@ done
 
 # Verify we're in a project with .touchstone-version.
 if [ ! -f "$PROJECT_DIR/.touchstone-version" ]; then
+  if [ -f "$PROJECT_DIR/.toolkit-version" ]; then
+    echo "ERROR: Legacy .toolkit-version found in $PROJECT_DIR" >&2
+    echo "       This project was bootstrapped before the toolkit -> touchstone rename." >&2
+    echo "       Run: touchstone migrate-from-toolkit" >&2
+    echo "       Then re-run: touchstone update" >&2
+    exit 1
+  fi
   echo "ERROR: No .touchstone-version file found in $PROJECT_DIR" >&2
-  echo "       This project hasn't been bootstrapped with the Touchstone." >&2
+  echo "       This project hasn't been bootstrapped with Touchstone." >&2
   echo "       Run: $(dirname "$0")/new-project.sh $PROJECT_DIR" >&2
   exit 1
 fi

--- a/tests/test-migrate.sh
+++ b/tests/test-migrate.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+#
+# tests/test-migrate.sh — verify `touchstone migrate-from-toolkit` renames
+# legacy .toolkit-* dotfiles to .touchstone-* equivalents and commits the
+# result.
+#
+set -euo pipefail
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_DIR="$(mktemp -d -t touchstone-test-migrate.XXXXXX)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+ERRORS=0
+
+fail() {
+  echo "FAIL: $1" >&2
+  ERRORS=$((ERRORS + 1))
+}
+
+make_project() {
+  local project_dir="$1"
+  mkdir -p "$project_dir"
+  (
+    cd "$project_dir"
+    git init -q -b main
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    echo "placeholder" > README.md
+    git add README.md
+    git commit -q -m "initial"
+  )
+}
+
+write_legacy_state() {
+  local project_dir="$1"
+  (
+    cd "$project_dir"
+    printf 'abc123\n' > .toolkit-version
+    cat > .toolkit-manifest <<'EOF'
+# Managed by toolkit. These paths may be updated by `toolkit update`.
+.toolkit-manifest
+.toolkit-version
+scripts/toolkit-run.sh
+EOF
+    printf 'project_type=python\n' > .toolkit-config
+    git add .toolkit-version .toolkit-manifest .toolkit-config
+    git commit -q -m "add legacy toolkit files"
+  )
+}
+
+run_migrate() {
+  local project_dir="$1"
+  (
+    cd "$project_dir"
+    TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" migrate-from-toolkit
+  )
+}
+
+# ------------------------------------------------------------------
+# Test 1: happy path — all three legacy files get renamed + committed
+# ------------------------------------------------------------------
+echo "==> Test 1: migrates legacy files and commits"
+
+PROJECT_DIR="$TEST_DIR/project1"
+make_project "$PROJECT_DIR"
+write_legacy_state "$PROJECT_DIR"
+run_migrate "$PROJECT_DIR" >/dev/null
+
+for f in .touchstone-version .touchstone-manifest .touchstone-config; do
+  [ -f "$PROJECT_DIR/$f" ] || fail "$f should exist after migrate"
+done
+for f in .toolkit-version .toolkit-manifest .toolkit-config; do
+  [ ! -f "$PROJECT_DIR/$f" ] || fail "$f should be gone after migrate"
+done
+
+if ! grep -q '\.touchstone-version' "$PROJECT_DIR/.touchstone-manifest" \
+  || ! grep -q 'touchstone-run.sh' "$PROJECT_DIR/.touchstone-manifest"; then
+  fail "manifest path references should be rewritten"
+fi
+if grep -qE '\.toolkit-|toolkit-run\.sh' "$PROJECT_DIR/.touchstone-manifest"; then
+  fail "manifest should not contain any toolkit-* references"
+fi
+
+HEAD_MSG="$(git -C "$PROJECT_DIR" log -1 --format=%s)"
+if [ "$HEAD_MSG" != "chore: migrate from toolkit to touchstone" ]; then
+  fail "expected migration commit on HEAD, got: $HEAD_MSG"
+fi
+
+if [ -n "$(git -C "$PROJECT_DIR" status --porcelain)" ]; then
+  fail "working tree should be clean after migrate"
+fi
+
+# ------------------------------------------------------------------
+# Test 2: idempotent — running on already-migrated repo is a no-op
+# ------------------------------------------------------------------
+echo "==> Test 2: no-op when no legacy files exist"
+
+run_migrate "$PROJECT_DIR" >/dev/null
+
+# Should still only have the one migration commit (no new commit created).
+COMMIT_COUNT_AFTER="$(git -C "$PROJECT_DIR" rev-list --count HEAD)"
+if [ "$COMMIT_COUNT_AFTER" != "3" ]; then
+  fail "expected 3 commits (initial + legacy + migrate), got $COMMIT_COUNT_AFTER"
+fi
+
+# ------------------------------------------------------------------
+# Test 3: refuses to run with dirty tree
+# ------------------------------------------------------------------
+echo "==> Test 3: refuses when working tree is dirty"
+
+PROJECT_DIR2="$TEST_DIR/project2"
+make_project "$PROJECT_DIR2"
+write_legacy_state "$PROJECT_DIR2"
+echo "dirty" > "$PROJECT_DIR2/uncommitted.txt"
+
+set +e
+run_migrate "$PROJECT_DIR2" 2>/dev/null
+RC=$?
+set -e
+
+if [ "$RC" -eq 0 ]; then
+  fail "expected non-zero exit when tree is dirty"
+fi
+if [ ! -f "$PROJECT_DIR2/.toolkit-version" ]; then
+  fail ".toolkit-version should still exist (no rename on dirty refusal)"
+fi
+
+# ------------------------------------------------------------------
+# Test 4: conflict — both .toolkit-* and .touchstone-* present is rejected
+# ------------------------------------------------------------------
+echo "==> Test 4: refuses when both legacy and new files coexist"
+
+PROJECT_DIR3="$TEST_DIR/project3"
+make_project "$PROJECT_DIR3"
+(
+  cd "$PROJECT_DIR3"
+  printf 'legacy\n' > .toolkit-version
+  printf 'newer\n'  > .touchstone-version
+  git add .toolkit-version .touchstone-version
+  git commit -q -m "conflicting state"
+)
+
+set +e
+run_migrate "$PROJECT_DIR3" 2>/dev/null
+RC=$?
+set -e
+
+if [ "$RC" -eq 0 ]; then
+  fail "expected non-zero exit when both versions exist"
+fi
+
+# ------------------------------------------------------------------
+# Test 5: `touchstone update` directs user to migrate when legacy detected
+# ------------------------------------------------------------------
+echo "==> Test 5: update prints migration hint for legacy projects"
+
+PROJECT_DIR4="$TEST_DIR/project4"
+make_project "$PROJECT_DIR4"
+write_legacy_state "$PROJECT_DIR4"
+
+set +e
+UPDATE_OUT="$(cd "$PROJECT_DIR4" && TOUCHSTONE_NO_AUTO_UPDATE=1 \
+  "$TOUCHSTONE_ROOT/bin/touchstone" update 2>&1)"
+RC=$?
+set -e
+
+if [ "$RC" -eq 0 ]; then
+  fail "expected update to fail on legacy project"
+fi
+if ! grep -q 'migrate-from-toolkit' <<< "$UPDATE_OUT"; then
+  fail "expected update error to mention 'migrate-from-toolkit', got:\n$UPDATE_OUT"
+fi
+
+# ------------------------------------------------------------------
+if [ "$ERRORS" -eq 0 ]; then
+  echo ""
+  echo "==> PASS: all migrate assertions passed"
+  exit 0
+else
+  echo ""
+  echo "==> FAIL: $ERRORS assertion(s) failed"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds `touchstone migrate-from-toolkit`, a one-shot subcommand that renames legacy `.toolkit-*` dotfiles to `.touchstone-*` and rewrites path references inside the manifest. For projects bootstrapped before the v1.0.0 rename.

`touchstone update` now detects the legacy state and directs the user to `migrate-from-toolkit` (clear error, no magic).

## Why this way, not auto-magic inside `update`

Considered auto-migrating inside `touchstone update`. Rejected: the migration is genuinely a one-time precondition that creates dirty state before `update`'s own clean-tree check. Hacking around that check for a one-shot event invited brittle logic. An explicit subcommand is scoped, discoverable (shows in help), testable in isolation, and easily deletable in v2.0.0.

## Test plan

- [x] 5 tests in `tests/test-migrate.sh`: happy path, idempotence, dirty-tree refusal, conflict refusal, update-emits-hint
- [x] All 6 self-tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)