### PR TITLE
feat(init): repair/upgrade existing touchstoned repos + per-project doctor

### DIFF
--- a/bin/touchstone
+++ b/bin/touchstone
@@ -147,16 +147,50 @@ cmd_init() {
     setup_existed=true
   fi
 
-  bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$(pwd)" "${args[@]}"
+  # State detection: fresh | current | outdated | legacy-toolkit. Determines
+  # whether init bootstraps, reconciles, or delegates to the update flow.
+  local project_dir installed_id current_id init_state="fresh"
+  project_dir="$(pwd)"
 
-  if [ "$run_setup" = true ] && [ -f "$(pwd)/setup.sh" ]; then
+  if [ -f "$project_dir/.toolkit-version" ] && [ ! -f "$project_dir/.touchstone-version" ]; then
+    init_state="legacy-toolkit"
+  elif [ -f "$project_dir/.touchstone-version" ]; then
+    installed_id="$(cat "$project_dir/.touchstone-version" 2>/dev/null | tr -d '[:space:]' || echo "")"
+    current_id="$(touchstone_current_id)"
+    if [ "$installed_id" = "$current_id" ]; then
+      init_state="current"
+    else
+      init_state="outdated"
+    fi
+  fi
+
+  case "$init_state" in
+    legacy-toolkit)
+      tk_fail "Legacy .toolkit-version found in $project_dir"
+      tk_dim "Run: touchstone migrate-from-toolkit"
+      tk_dim "Then re-run: touchstone init"
+      return 1
+      ;;
+    outdated)
+      tk_header "Touchstone init — upgrading"
+      tk_dim "  installed: ${installed_id:0:12}"
+      tk_dim "  current:   ${current_id:0:12}"
+      tk_info "Delegating to 'touchstone update' (branch + commit so the upgrade is reviewable)"
+      echo ""
+      exec bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh"
+      ;;
+  esac
+
+  bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$project_dir" "${args[@]}"
+
+  if [ "$run_setup" = true ] && [ -f "$project_dir/setup.sh" ]; then
     if [ "$setup_existed" = true ]; then
       tk_warn "setup.sh already existed, so touchstone left it in place and did not run it."
       tk_dim "Run manually if desired: bash setup.sh"
       return 0
     fi
     echo ""
-    bash "$(pwd)/setup.sh"
+    bash "$project_dir/setup.sh"
   fi
 }
 
@@ -271,7 +305,147 @@ cmd_status() {
   echo ""
 }
 
+cmd_doctor_project() {
+  local project_dir issues=0
+  project_dir="$(pwd)"
+
+  tk_header "Touchstone Project Doctor — $(basename "$project_dir")"
+
+  # 1. Is this a touchstone-managed project?
+  if [ ! -f "$project_dir/.touchstone-version" ]; then
+    if [ -f "$project_dir/.toolkit-version" ]; then
+      tk_fail "Legacy .toolkit-version found"
+      tk_dim "  Fix: touchstone migrate-from-toolkit"
+      echo ""
+      return 1
+    fi
+    tk_fail "Not a touchstone project (no .touchstone-version)"
+    tk_dim "  Fix: touchstone init"
+    echo ""
+    return 1
+  fi
+
+  local installed_id current_id
+  installed_id="$(cat "$project_dir/.touchstone-version" 2>/dev/null | tr -d '[:space:]' || echo "")"
+  current_id="$(touchstone_current_id)"
+  if [ "$installed_id" = "$current_id" ]; then
+    tk_ok "touchstone version matches: ${installed_id:0:12}"
+  else
+    tk_warn "touchstone out of date (installed ${installed_id:0:12}, current ${current_id:0:12})"
+    tk_dim "  Fix: touchstone update"
+    issues=$((issues + 1))
+  fi
+
+  # 2. Git hooks installed? This is the footgun that silently ungates a repo.
+  if [ ! -f "$project_dir/.pre-commit-config.yaml" ]; then
+    tk_warn ".pre-commit-config.yaml is missing"
+    tk_dim "  Fix: touchstone init  (reconciles missing templates)"
+    issues=$((issues + 1))
+  else
+    if [ -f "$project_dir/.git/hooks/pre-commit" ] && [ -f "$project_dir/.git/hooks/pre-push" ]; then
+      tk_ok "git hooks installed (.git/hooks/pre-commit, .git/hooks/pre-push)"
+    else
+      tk_fail "git hooks NOT installed — repo is ungated"
+      if command -v pre-commit >/dev/null 2>&1; then
+        tk_dim "  Fix: touchstone init   (idempotent — reinstalls missing hooks)"
+      else
+        tk_dim "  Fix: brew install pre-commit && touchstone init"
+      fi
+      issues=$((issues + 1))
+    fi
+  fi
+
+  # 3. Manifest files present?
+  if [ -f "$project_dir/.touchstone-manifest" ]; then
+    local missing=0 line
+    while IFS= read -r line || [ -n "$line" ]; do
+      line="${line#"${line%%[![:space:]]*}"}"
+      line="${line%"${line##*[![:space:]]}"}"
+      [ -z "$line" ] && continue
+      case "$line" in \#*) continue ;; esac
+      if [ ! -e "$project_dir/$line" ]; then
+        tk_fail "manifest file missing: $line"
+        missing=$((missing + 1))
+      fi
+    done < "$project_dir/.touchstone-manifest"
+    if [ "$missing" -eq 0 ]; then
+      tk_ok "manifest files all present"
+    else
+      tk_dim "  Fix: touchstone init  (reconciles missing files)"
+      issues=$((issues + missing))
+    fi
+  else
+    tk_warn ".touchstone-manifest missing"
+    tk_dim "  Fix: touchstone init"
+    issues=$((issues + 1))
+  fi
+
+  # 4. Scripts executable?
+  if [ -d "$project_dir/scripts" ]; then
+    local not_executable=0 script
+    for script in "$project_dir/scripts/"*.sh; do
+      [ -f "$script" ] || continue
+      if [ ! -x "$script" ]; then
+        tk_fail "not executable: scripts/$(basename "$script")"
+        not_executable=$((not_executable + 1))
+      fi
+    done
+    if [ "$not_executable" -eq 0 ]; then
+      tk_ok "scripts are executable"
+    else
+      tk_dim "  Fix: chmod +x $project_dir/scripts/*.sh"
+      issues=$((issues + not_executable))
+    fi
+  fi
+
+  # 5. Registered in ~/.touchstone-projects?  Informational — 'touchstone sync'
+  # and 'touchstone list' depend on it, but the repo is still functionally gated.
+  local projects_file="$HOME/.touchstone-projects"
+  if [ -f "$projects_file" ] && grep -qxF "$project_dir" "$projects_file" 2>/dev/null; then
+    tk_ok "registered in ~/.touchstone-projects"
+  else
+    tk_dim "not in ~/.touchstone-projects (touchstone sync won't update this project)"
+    tk_dim "  Fix: echo \"$project_dir\" >> $projects_file"
+  fi
+
+  # 6. Optional — Codex review config present?
+  if [ -f "$project_dir/.codex-review.toml" ]; then
+    tk_ok ".codex-review.toml present"
+  else
+    tk_dim ".codex-review.toml not found (optional — configures AI review)"
+  fi
+
+  echo ""
+  if [ "$issues" -eq 0 ]; then
+    tk_ok "Project is fully armed."
+    echo ""
+    return 0
+  fi
+  tk_warn "$issues issue(s) found. See fixes above, or run: touchstone init"
+  echo ""
+  return 1
+}
+
 cmd_doctor() {
+  local project_mode=false
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --project) project_mode=true; shift ;;
+      -h|--help)
+        echo "Usage: touchstone doctor [--project]"
+        echo "  (no flag)   Check touchstone installation health (CLI, tools, projects)"
+        echo "  --project   Check per-project health (hooks, manifest, registry)"
+        return 0
+        ;;
+      *) echo "ERROR: unknown argument '$1'" >&2; exit 1 ;;
+    esac
+  done
+
+  if [ "$project_mode" = true ]; then
+    cmd_doctor_project
+    return $?
+  fi
+
   local version
   version="$(touchstone_version_str)"
   local issues=0
@@ -725,6 +899,7 @@ cmd_help() {
   echo ""
   echo "  ${BOLD}Touchstone commands:${RESET}"
   printf "    ${BOLD}touchstone doctor${RESET}                 Check installation health\n"
+  printf "    ${BOLD}touchstone doctor${RESET} --project       Check per-project health (hooks, manifest, registry)\n"
   printf "    ${BOLD}touchstone version${RESET}                Show installed version\n"
   printf "    ${BOLD}touchstone changelog${RESET} [N]          Show last N releases (default 10)\n"
   printf "    ${BOLD}touchstone skills${RESET}                 List Claude Code skills\n"
@@ -760,7 +935,7 @@ case "$COMMAND" in
   changelog)    cmd_changelog "$@" ;;
   release)      cmd_release "$@" ;;
   version)      cmd_version ;;
-  doctor)       cmd_doctor ;;
+  doctor)       cmd_doctor "$@" ;;
   help|-h|--help) cmd_help ;;
   *)
     printf "${RED}Unknown command: $COMMAND${RESET}\n" >&2

--- a/bin/touchstone
+++ b/bin/touchstone
@@ -152,7 +152,11 @@ cmd_init() {
   local project_dir installed_id current_id init_state="fresh"
   project_dir="$(pwd)"
 
-  if [ -f "$project_dir/.toolkit-version" ] && [ ! -f "$project_dir/.touchstone-version" ]; then
+  if [ -f "$project_dir/.toolkit-version" ] && [ -f "$project_dir/.touchstone-version" ]; then
+    tk_fail "Migration conflict: both .toolkit-version and .touchstone-version are present in $project_dir"
+    tk_dim "  Fix: rm .toolkit-version   (touchstone has already been installed here)"
+    return 1
+  elif [ -f "$project_dir/.toolkit-version" ]; then
     init_state="legacy-toolkit"
   elif [ -f "$project_dir/.touchstone-version" ]; then
     installed_id="$(cat "$project_dir/.touchstone-version" 2>/dev/null | tr -d '[:space:]' || echo "")"
@@ -311,7 +315,14 @@ cmd_doctor_project() {
 
   tk_header "Touchstone Project Doctor — $(basename "$project_dir")"
 
-  # 1. Is this a touchstone-managed project?
+  # 1. Is this a touchstone-managed project? Reject migration-conflict state first —
+  # a project with both files is mid-migration and must not be reported healthy.
+  if [ -f "$project_dir/.toolkit-version" ] && [ -f "$project_dir/.touchstone-version" ]; then
+    tk_fail "Migration conflict: both .toolkit-version and .touchstone-version present"
+    tk_dim "  Fix: rm .toolkit-version   (touchstone has already been installed)"
+    echo ""
+    return 1
+  fi
   if [ ! -f "$project_dir/.touchstone-version" ]; then
     if [ -f "$project_dir/.toolkit-version" ]; then
       tk_fail "Legacy .toolkit-version found"

--- a/bin/touchstone
+++ b/bin/touchstone
@@ -187,7 +187,10 @@ cmd_init() {
 
   bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$project_dir" "${args[@]}"
 
-  if [ "$run_setup" = true ] && [ -f "$project_dir/setup.sh" ]; then
+  # Only fresh init runs setup.sh automatically. Reconciling an existing repo
+  # must not re-trigger machine-wide dev-tool installs or interactive prompts
+  # just because the user happened to delete setup.sh before re-running init.
+  if [ "$init_state" = "fresh" ] && [ "$run_setup" = true ] && [ -f "$project_dir/setup.sh" ]; then
     if [ "$setup_existed" = true ]; then
       tk_warn "setup.sh already existed, so touchstone left it in place and did not run it."
       tk_dim "Run manually if desired: bash setup.sh"

--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -445,7 +445,21 @@ if [[ "$PROJECT_DIR" != /* ]]; then
   PROJECT_DIR="$(pwd)/$PROJECT_DIR"
 fi
 
-echo "==> Bootstrapping project at $PROJECT_DIR"
+# Detect re-init state early so prompts and summary adapt to the case.
+# Fresh = first touchstone bootstrap; reinit = repair/reconcile an already-touchstoned project.
+if [ -f "$PROJECT_DIR/.touchstone-version" ]; then
+  RE_INIT=true
+  echo "==> Reconciling touchstone files in $PROJECT_DIR"
+else
+  RE_INIT=false
+  echo "==> Bootstrapping project at $PROJECT_DIR"
+fi
+
+# Summary counters — populated by copy_file / copy_file_force, emitted at end.
+FILES_ADDED=0
+FILES_EXISTING=0
+FILES_UPDATED=0
+FILES_UNCHANGED=0
 
 # Create directory if needed.
 mkdir -p "$PROJECT_DIR"
@@ -472,10 +486,12 @@ copy_file() {
       return 1
     fi
     echo "    exists (skipped): $(basename "$dst")"
+    FILES_EXISTING=$((FILES_EXISTING + 1))
   else
     cp "$src" "$dst"
     LAST_COPY_CREATED=true
     echo "    + $(basename "$dst")"
+    FILES_ADDED=$((FILES_ADDED + 1))
   fi
 }
 
@@ -489,6 +505,7 @@ copy_file_force() {
 
   if [ -f "$dst" ] && diff -q "$src" "$dst" >/dev/null 2>&1; then
     echo "    same (skipped): $(basename "$dst")"
+    FILES_UNCHANGED=$((FILES_UNCHANGED + 1))
     return
   fi
 
@@ -501,11 +518,13 @@ copy_file_force() {
     cp "$dst" "$backup_path"
     cp "$src" "$dst"
     echo "    ! $(basename "$dst") (backed up as $(basename "$backup_path"))"
+    FILES_UPDATED=$((FILES_UPDATED + 1))
     return
   fi
 
   cp "$src" "$dst"
   echo "    + $(basename "$dst")"
+  FILES_ADDED=$((FILES_ADDED + 1))
 }
 
 write_touchstone_manifest() {
@@ -716,6 +735,7 @@ print_review_setup_hint() {
 echo ""
 echo "==> Copying templates (project-owned, won't be auto-updated):"
 copy_file "$TOUCHSTONE_ROOT/templates/CLAUDE.md" "$PROJECT_DIR/CLAUDE.md"
+CLAUDE_MD_CREATED="$LAST_COPY_CREATED"
 copy_file "$TOUCHSTONE_ROOT/templates/AGENTS.md" "$PROJECT_DIR/AGENTS.md"
 copy_file "$TOUCHSTONE_ROOT/templates/pre-commit-config.yaml" "$PROJECT_DIR/.pre-commit-config.yaml"
 copy_file "$TOUCHSTONE_ROOT/templates/gitignore" "$PROJECT_DIR/.gitignore"
@@ -774,7 +794,7 @@ INPUT_NAME=""
 INPUT_DESC=""
 INPUT_TEST=""
 
-if [ -t 0 ] && [ -f "$PROJECT_DIR/CLAUDE.md" ]; then
+if [ -t 0 ] && [ "$CLAUDE_MD_CREATED" = true ]; then
   echo ""
   echo "==> Fill in project details (press Enter to skip any):"
   echo ""
@@ -967,14 +987,52 @@ echo ""
 HOOK_INSTALL_STATUS=0
 touchstone_install_hooks "$PROJECT_DIR" || HOOK_INSTALL_STATUS=$?
 
+# --------------------------------------------------------------------------
+# Summary block — every init exits with a checkable state, not silent success.
+# --------------------------------------------------------------------------
 echo ""
-echo "==> Done! Next steps:"
-echo ""
-if [ "$HOOK_INSTALL_STATUS" -eq 2 ]; then
-  echo "   ! Git hooks are not installed — setup.sh will install pre-commit and rerun the install."
+if [ "$RE_INIT" = true ]; then
+  echo "==> touchstone reconciled:"
+else
+  echo "==> touchstone bootstrapped:"
 fi
-echo "   1. Review CLAUDE.md and AGENTS.md — add architecture, key files, hard-won lessons"
-echo "   2. Run setup.sh to install all dev tools:"
-echo "        cd $PROJECT_DIR && bash setup.sh"
-echo "   3. Review .codex-review.toml if you want to change AI reviewer behavior"
+printf '    files:    %d added, %d unchanged' "$FILES_ADDED" "$FILES_UNCHANGED"
+if [ "$FILES_UPDATED" -gt 0 ]; then
+  printf ', %d updated (previous content backed up as .bak)' "$FILES_UPDATED"
+fi
+if [ "$FILES_EXISTING" -gt 0 ]; then
+  printf ', %d already present' "$FILES_EXISTING"
+fi
+printf '\n'
+printf '    version:  %s\n' "$TOUCHSTONE_SHA"
+
+case "$HOOK_INSTALL_STATUS" in
+  0) printf '    hooks:    installed (pre-commit, pre-push, commit-msg)\n' ;;
+  1) printf '    hooks:    SKIPPED — no .pre-commit-config.yaml (unexpected)\n' ;;
+  2) printf '    hooks:    NOT INSTALLED — pre-commit CLI missing\n' ;;
+  3) printf '    hooks:    PARTIAL — one or more installs failed (see above)\n' ;;
+esac
+
+if [ "$REGISTER" = true ]; then
+  printf '    registry: %s\n' "$PROJECTS_FILE"
+else
+  printf '    registry: skipped (--no-register)\n'
+fi
+
+echo ""
+echo "Next steps:"
+STEP_NUM=1
+if [ "$HOOK_INSTALL_STATUS" -eq 2 ]; then
+  printf '  %d. Install pre-commit to gate commits & pushes:\n' "$STEP_NUM"
+  printf '       brew install pre-commit   # or: pip install pre-commit\n'
+  printf '       Then rerun: touchstone init\n'
+  STEP_NUM=$((STEP_NUM + 1))
+fi
+if [ "$RE_INIT" = false ]; then
+  printf '  %d. Fill in CLAUDE.md and AGENTS.md (architecture, key files, hard-won lessons)\n' "$STEP_NUM"
+  STEP_NUM=$((STEP_NUM + 1))
+fi
+printf '  %d. Install dev tools and project deps: cd %s && bash setup.sh\n' "$STEP_NUM" "$PROJECT_DIR"
+STEP_NUM=$((STEP_NUM + 1))
+printf '  %d. Verify the install: touchstone doctor --project\n' "$STEP_NUM"
 echo ""

--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -794,7 +794,7 @@ INPUT_NAME=""
 INPUT_DESC=""
 INPUT_TEST=""
 
-if [ -t 0 ] && [ "$CLAUDE_MD_CREATED" = true ]; then
+if [ -t 0 ] && [ "$RE_INIT" = false ] && [ "$CLAUDE_MD_CREATED" = true ]; then
   echo ""
   echo "==> Fill in project details (press Enter to skip any):"
   echo ""

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -544,17 +544,41 @@ fi
 # backfill deleted touchstone-owned files, re-register) without re-prompting — not silently
 # do nothing and not clobber project-owned content.
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_REINIT" --no-register >/dev/null
-# Simulate drift: delete an installed hook shim and a synced principle file.
+# Simulate drift: delete an installed hook shim, a synced principle file, and the
+# project-owned CLAUDE.md (worst case — reconcile must backfill it but MUST NOT prompt).
 rm -f "$PROJECT_REINIT/.git/hooks/pre-push"
 rm -f "$PROJECT_REINIT/principles/engineering-principles.md"
-# Overwrite a project-owned file so we can verify reconciliation did NOT clobber user edits.
-echo "custom-user-content" > "$PROJECT_REINIT/CLAUDE.md"
-PATH="$HOOKS_FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_REINIT" --no-register >"$TEST_DIR/reinit-output.txt" 2>&1
+rm -f "$PROJECT_REINIT/CLAUDE.md"
+# Run from a non-TTY so interactive prompts would hang if the gating is wrong.
+PATH="$HOOKS_FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_REINIT" --no-register </dev/null >"$TEST_DIR/reinit-output.txt" 2>&1
 assert_exists "$PROJECT_REINIT/.git/hooks/pre-push"
 assert_exists "$PROJECT_REINIT/principles/engineering-principles.md"
-assert_contains "$PROJECT_REINIT/CLAUDE.md" 'custom-user-content'
+assert_exists "$PROJECT_REINIT/CLAUDE.md"
 assert_contains "$TEST_DIR/reinit-output.txt" 'Reconciling touchstone files'
 assert_contains "$TEST_DIR/reinit-output.txt" 'touchstone reconciled:'
+assert_not_contains "$TEST_DIR/reinit-output.txt" 'Fill in project details'
+
+# Reconcile in a repo where setup.sh was deleted must NOT re-run setup (no dev-tool installs
+# during a repair). Bootstrap, delete setup.sh, rerun init — verify backfill without invocation.
+PROJECT_REINIT_SETUP="$TEST_DIR/test-project-reinit-setup"
+PATH="$HOOKS_FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_REINIT_SETUP" --no-register >/dev/null
+rm -f "$PROJECT_REINIT_SETUP/setup.sh"
+cat > "$PROJECT_REINIT_SETUP/setup.sh.marker" <<'MARKER'
+# Touchstone should never run setup.sh during reconcile; if it does, this test catches it.
+MARKER
+# Replace the template setup.sh with a marker-logging version via a wrapper PATH.
+REINIT_SETUP_LOG="$TEST_DIR/reinit-setup.log"
+: > "$REINIT_SETUP_LOG"
+REINIT_SETUP_FAKE_BIN="$TEST_DIR/reinit-setup-fake-bin"
+mkdir -p "$REINIT_SETUP_FAKE_BIN"
+cp "$HOOKS_FAKE_BIN/pre-commit" "$REINIT_SETUP_FAKE_BIN/pre-commit"
+(cd "$PROJECT_REINIT_SETUP" && PATH="$REINIT_SETUP_FAKE_BIN:$PATH" TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" init --no-register) </dev/null >"$TEST_DIR/reinit-setup-output.txt" 2>&1
+assert_exists "$PROJECT_REINIT_SETUP/setup.sh"
+# Setup.sh itself would print 'Setting up' if it ran — we assert it did NOT.
+if grep -q 'Setting up' "$TEST_DIR/reinit-setup-output.txt" 2>/dev/null; then
+  echo "FAIL: init reconcile must not run setup.sh even if the file was backfilled" >&2
+  ERRORS=$((ERRORS + 1))
+fi
 
 # touchstone doctor --project must exit clean on a fully-armed repo.
 # Use the fake pre-commit so hooks install regardless of what's on the tester's real PATH.

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -66,6 +66,11 @@ PROJECT_GITBUTLER="$TEST_DIR/test-project-gitbutler"
 PROJECT_HOOKS_WITH="$TEST_DIR/test-project-hooks-with"
 PROJECT_HOOKS_WITHOUT="$TEST_DIR/test-project-hooks-without"
 PROJECT_PYTEST_EMPTY="$TEST_DIR/test-project-pytest-empty"
+PROJECT_REINIT="$TEST_DIR/test-project-reinit"
+PROJECT_DOCTOR="$TEST_DIR/test-project-doctor"
+PROJECT_OUTDATED="$TEST_DIR/test-project-outdated"
+PROJECT_DOCTOR_FRESH="$TEST_DIR/test-project-doctor-fresh"
+PROJECT_DOCTOR_LEGACY="$TEST_DIR/test-project-doctor-legacy"
 
 # Git repo
 assert_exists "$PROJECT/.git"
@@ -532,6 +537,80 @@ if (cd "$PROJECT_PYTEST_EMPTY" && PATH="$PYTEST_FAKE_BIN:$PATH" bash scripts/tou
   assert_contains "$TEST_DIR/pytest-empty-output.txt" 'pytest found no tests; skipped'
 else
   echo "FAIL: pytest exit 5 must be a graceful skip, not a failure" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# Re-running init on an already-touchstoned repo must reconcile (install missing hooks,
+# backfill deleted touchstone-owned files, re-register) without re-prompting — not silently
+# do nothing and not clobber project-owned content.
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_REINIT" --no-register >/dev/null
+# Simulate drift: delete an installed hook shim and a synced principle file.
+rm -f "$PROJECT_REINIT/.git/hooks/pre-push"
+rm -f "$PROJECT_REINIT/principles/engineering-principles.md"
+# Overwrite a project-owned file so we can verify reconciliation did NOT clobber user edits.
+echo "custom-user-content" > "$PROJECT_REINIT/CLAUDE.md"
+PATH="$HOOKS_FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_REINIT" --no-register >"$TEST_DIR/reinit-output.txt" 2>&1
+assert_exists "$PROJECT_REINIT/.git/hooks/pre-push"
+assert_exists "$PROJECT_REINIT/principles/engineering-principles.md"
+assert_contains "$PROJECT_REINIT/CLAUDE.md" 'custom-user-content'
+assert_contains "$TEST_DIR/reinit-output.txt" 'Reconciling touchstone files'
+assert_contains "$TEST_DIR/reinit-output.txt" 'touchstone reconciled:'
+
+# touchstone doctor --project must exit clean on a fully-armed repo.
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_DOCTOR" --no-register >/dev/null
+if (cd "$PROJECT_DOCTOR" && TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" doctor --project) >"$TEST_DIR/doctor-clean.txt" 2>&1; then
+  assert_contains "$TEST_DIR/doctor-clean.txt" 'Project is fully armed'
+else
+  echo "FAIL: doctor --project should exit 0 on a fresh bootstrap" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# Break hooks and rerun doctor — it must exit nonzero and flag the gap.
+rm -f "$PROJECT_DOCTOR/.git/hooks/pre-push"
+if (cd "$PROJECT_DOCTOR" && TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" doctor --project) >"$TEST_DIR/doctor-broken.txt" 2>&1; then
+  echo "FAIL: doctor --project should exit nonzero when hooks are missing" >&2
+  ERRORS=$((ERRORS + 1))
+else
+  assert_contains "$TEST_DIR/doctor-broken.txt" 'git hooks NOT installed'
+fi
+
+# doctor --project outside a touchstoned repo must flag it, not claim health.
+mkdir -p "$PROJECT_DOCTOR_FRESH"
+if (cd "$PROJECT_DOCTOR_FRESH" && TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" doctor --project) >"$TEST_DIR/doctor-fresh.txt" 2>&1; then
+  echo "FAIL: doctor --project should exit nonzero outside a touchstoned project" >&2
+  ERRORS=$((ERRORS + 1))
+else
+  assert_contains "$TEST_DIR/doctor-fresh.txt" 'Not a touchstone project'
+fi
+
+# doctor --project on a legacy .toolkit-version repo must point to the migration command.
+mkdir -p "$PROJECT_DOCTOR_LEGACY"
+echo "legacy-sha" > "$PROJECT_DOCTOR_LEGACY/.toolkit-version"
+if (cd "$PROJECT_DOCTOR_LEGACY" && TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" doctor --project) >"$TEST_DIR/doctor-legacy.txt" 2>&1; then
+  echo "FAIL: doctor --project should exit nonzero on a legacy .toolkit-version repo" >&2
+  ERRORS=$((ERRORS + 1))
+else
+  assert_contains "$TEST_DIR/doctor-legacy.txt" 'touchstone migrate-from-toolkit'
+fi
+
+# touchstone init on an outdated project must delegate to the update flow (branch + commit),
+# not silently backup-and-replace files in place.
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_OUTDATED" --no-register >/dev/null
+(cd "$PROJECT_OUTDATED" && git add -A && git -c user.email=test@touchstone -c user.name=test commit --no-verify -m "initial" >/dev/null)
+echo "0000000000000000000000000000000000000001" > "$PROJECT_OUTDATED/.touchstone-version"
+(cd "$PROJECT_OUTDATED" && git -c user.email=test@touchstone -c user.name=test commit --no-verify -am "pin to old touchstone" >/dev/null)
+if (cd "$PROJECT_OUTDATED" && TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" init --no-setup) >"$TEST_DIR/init-outdated.txt" 2>&1; then
+  assert_contains "$TEST_DIR/init-outdated.txt" 'upgrading'
+  UPDATE_BRANCH="$(git -C "$PROJECT_OUTDATED" branch --show-current)"
+  case "$UPDATE_BRANCH" in
+    chore/touchstone-*) ;;
+    *)
+      echo "FAIL: init on outdated project should land on a chore/touchstone-* branch, got '$UPDATE_BRANCH'" >&2
+      ERRORS=$((ERRORS + 1))
+      ;;
+  esac
+else
+  echo "FAIL: init on outdated project should not exit nonzero (stdout: $(cat "$TEST_DIR/init-outdated.txt"))" >&2
   ERRORS=$((ERRORS + 1))
 fi
 

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -557,7 +557,8 @@ assert_contains "$TEST_DIR/reinit-output.txt" 'Reconciling touchstone files'
 assert_contains "$TEST_DIR/reinit-output.txt" 'touchstone reconciled:'
 
 # touchstone doctor --project must exit clean on a fully-armed repo.
-bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_DOCTOR" --no-register >/dev/null
+# Use the fake pre-commit so hooks install regardless of what's on the tester's real PATH.
+PATH="$HOOKS_FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_DOCTOR" --no-register >/dev/null
 if (cd "$PROJECT_DOCTOR" && TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" doctor --project) >"$TEST_DIR/doctor-clean.txt" 2>&1; then
   assert_contains "$TEST_DIR/doctor-clean.txt" 'Project is fully armed'
 else
@@ -593,12 +594,35 @@ else
   assert_contains "$TEST_DIR/doctor-legacy.txt" 'touchstone migrate-from-toolkit'
 fi
 
+# Both .toolkit-version and .touchstone-version is an in-flight migration conflict —
+# neither doctor nor init may report healthy in that state.
+PROJECT_MIGRATION_CONFLICT="$TEST_DIR/test-project-migration-conflict"
+mkdir -p "$PROJECT_MIGRATION_CONFLICT"
+echo "legacy-sha" > "$PROJECT_MIGRATION_CONFLICT/.toolkit-version"
+echo "touchstone-sha" > "$PROJECT_MIGRATION_CONFLICT/.touchstone-version"
+if (cd "$PROJECT_MIGRATION_CONFLICT" && TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" doctor --project) >"$TEST_DIR/doctor-conflict.txt" 2>&1; then
+  echo "FAIL: doctor --project should exit nonzero when both .toolkit-version and .touchstone-version exist" >&2
+  ERRORS=$((ERRORS + 1))
+else
+  assert_contains "$TEST_DIR/doctor-conflict.txt" 'Migration conflict'
+fi
+if (cd "$PROJECT_MIGRATION_CONFLICT" && TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" init --no-setup --no-register) >"$TEST_DIR/init-conflict.txt" 2>&1; then
+  echo "FAIL: touchstone init should exit nonzero in the migration-conflict state" >&2
+  ERRORS=$((ERRORS + 1))
+else
+  assert_contains "$TEST_DIR/init-conflict.txt" 'Migration conflict'
+fi
+
 # touchstone init on an outdated project must delegate to the update flow (branch + commit),
 # not silently backup-and-replace files in place.
-bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_OUTDATED" --no-register >/dev/null
-(cd "$PROJECT_OUTDATED" && git add -A && git -c user.email=test@touchstone -c user.name=test commit --no-verify -m "initial" >/dev/null)
+PATH="$HOOKS_FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_OUTDATED" --no-register >/dev/null
+# Configure the committer identity locally so the delegated update-project.sh commit
+# works on CI machines without a global Git identity.
+git -C "$PROJECT_OUTDATED" config user.email test@touchstone
+git -C "$PROJECT_OUTDATED" config user.name test-committer
+(cd "$PROJECT_OUTDATED" && git add -A && git commit --no-verify -m "initial" >/dev/null)
 echo "0000000000000000000000000000000000000001" > "$PROJECT_OUTDATED/.touchstone-version"
-(cd "$PROJECT_OUTDATED" && git -c user.email=test@touchstone -c user.name=test commit --no-verify -am "pin to old touchstone" >/dev/null)
+(cd "$PROJECT_OUTDATED" && git commit --no-verify -am "pin to old touchstone" >/dev/null)
 if (cd "$PROJECT_OUTDATED" && TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" init --no-setup) >"$TEST_DIR/init-outdated.txt" 2>&1; then
   assert_contains "$TEST_DIR/init-outdated.txt" 'upgrading'
   UPDATE_BRANCH="$(git -C "$PROJECT_OUTDATED" branch --show-current)"


### PR DESCRIPTION
Before this, 'touchstone init' on an already-bootstrapped repo silently re-ran
the prompts and didn't cover the drift cases users actually hit. This rework
makes init state-aware and adds a per-project doctor so the repair path is
always visible.

Init now detects fresh | current | outdated | legacy-toolkit:
- fresh: bootstrap as before, with the new summary block
- current (reconcile): no interactive prompts, backfill missing touchstone-owned
  files, reinstall any missing hooks via the PR1 helper
- outdated: delegate to 'touchstone update' so the upgrade lands as a
  chore/touchstone-* branch + commit (preserves the clean-worktree discipline)
- legacy-toolkit: error with the migrate-from-toolkit pointer

Every init exits with a summary (files added/unchanged/updated, version,
hooks status, registry, next steps) — no more silent success.

'touchstone doctor --project' is a new per-project check: version match,
hooks installed, manifest files present, scripts executable, registry.
Exits nonzero on any health issue.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
