### PR TITLE
feat(init): auto-ship touchstone upgrade via open-pr.sh

### DIFF
--- a/bin/touchstone
+++ b/bin/touchstone
@@ -4,7 +4,7 @@
 #
 # Usage:
 #   touchstone new <project-dir>          Create a new project with touchstone files
-#   touchstone init [--no-setup] [--type node|python|swift|rust|go|generic|auto] [--reviewer codex|claude|gemini|local|auto|none]
+#   touchstone init [--no-setup] [--no-ship] [--type node|python|swift|rust|go|generic|auto] [--reviewer codex|claude|gemini|local|auto|none]
 #                                      Add touchstone to the current project
 #   touchstone run <task>                  Run profile task: lint, test, build, typecheck, validate
 #   touchstone update                     Update current project to latest touchstone
@@ -91,6 +91,7 @@ cmd_init() {
   # Init the current directory — bootstrap + setup in one command.
   local run_setup=true
   local setup_existed=false
+  local ship_upgrade=true
   local args=()
 
   while [ "$#" -gt 0 ]; do
@@ -99,8 +100,16 @@ cmd_init() {
         run_setup=false
         shift
         ;;
+      --ship)
+        ship_upgrade=true
+        shift
+        ;;
+      --no-ship)
+        ship_upgrade=false
+        shift
+        ;;
       -h|--help)
-        echo "Usage: touchstone init [--no-setup] [--type node|python|swift|rust|go|generic|auto] [--no-register] [--unsafe-paths path1,path2] [--reviewer codex|claude|gemini|local|auto|none] [--review-routing all-hosted|all-local|small-local] [--small-review-lines N] [--gitbutler|--no-gitbutler] [--gitbutler-mcp|--no-gitbutler-mcp]"
+        echo "Usage: touchstone init [--no-setup] [--no-ship] [--type node|python|swift|rust|go|generic|auto] [--no-register] [--unsafe-paths path1,path2] [--reviewer codex|claude|gemini|local|auto|none] [--review-routing all-hosted|all-local|small-local] [--small-review-lines N] [--gitbutler|--no-gitbutler] [--gitbutler-mcp|--no-gitbutler-mcp]"
         return 0
         ;;
       --type)
@@ -137,7 +146,7 @@ cmd_init() {
         ;;
       *)
         echo "ERROR: unknown argument '$1'" >&2
-        echo "Usage: touchstone init [--no-setup] [--type node|python|swift|rust|go|generic|auto] [--no-register] [--unsafe-paths path1,path2] [--reviewer codex|claude|gemini|local|auto|none] [--review-routing all-hosted|all-local|small-local] [--gitbutler|--no-gitbutler]" >&2
+        echo "Usage: touchstone init [--no-setup] [--no-ship] [--type node|python|swift|rust|go|generic|auto] [--no-register] [--unsafe-paths path1,path2] [--reviewer codex|claude|gemini|local|auto|none] [--review-routing all-hosted|all-local|small-local] [--gitbutler|--no-gitbutler]" >&2
         exit 1
         ;;
     esac
@@ -179,9 +188,15 @@ cmd_init() {
       tk_header "Touchstone init — upgrading"
       tk_dim "  installed: ${installed_id:0:12}"
       tk_dim "  current:   ${current_id:0:12}"
-      tk_info "Delegating to 'touchstone update' (branch + commit so the upgrade is reviewable)"
+      local update_args=()
+      if [ "$ship_upgrade" = true ]; then
+        tk_info "Delegating to 'touchstone update --ship' (branch + commit + auto-merge PR)"
+        update_args+=("--ship")
+      else
+        tk_info "Delegating to 'touchstone update' (branch + commit so the upgrade is reviewable)"
+      fi
       echo ""
-      exec bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh"
+      exec bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh" "${update_args[@]}"
       ;;
   esac
 

--- a/bootstrap/update-project.sh
+++ b/bootstrap/update-project.sh
@@ -24,15 +24,18 @@ PROJECT_DIR="$(pwd)"
 DRY_RUN=false
 CHECK_ONLY=false
 REQUESTED_BRANCH=""
+SHIP=false
 
 usage() {
-  echo "Usage: $0 [--dry-run|-n] [--check] [--branch <name>]"
+  echo "Usage: $0 [--dry-run|-n] [--check] [--branch <name>] [--ship]"
 }
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --dry-run|-n) DRY_RUN=true; shift ;;
     --check) CHECK_ONLY=true; shift ;;
+    --ship) SHIP=true; shift ;;
+    --no-ship) SHIP=false; shift ;;
     --branch)
       [ "$#" -ge 2 ] || { echo "ERROR: --branch requires a value" >&2; exit 1; }
       REQUESTED_BRANCH="$2"
@@ -386,11 +389,28 @@ echo "      diff $TOUCHSTONE_ROOT/templates/pre-commit-config.yaml ./.pre-commit
 echo "      diff $TOUCHSTONE_ROOT/hooks/codex-review.config.example.toml ./.codex-review.toml"
 
 if [ "$DRY_RUN" = false ]; then
-  echo ""
-  echo "==> Done. Review the update branch:"
-  echo "    branch: $UPDATE_BRANCH"
-  echo "    git diff ${ORIGINAL_BRANCH}...HEAD"
-  echo "    bash scripts/open-pr.sh"
+  if [ "$SHIP" = true ] && [ "${COMMIT_CREATED:-false}" = true ]; then
+    if [ ! -x "$PROJECT_DIR/scripts/open-pr.sh" ]; then
+      echo ""
+      echo "==> --ship requested but scripts/open-pr.sh is missing or not executable."
+      echo "    branch: $UPDATE_BRANCH (left for manual ship)"
+    else
+      echo ""
+      echo "==> Shipping update via scripts/open-pr.sh --auto-merge..."
+      if ! (cd "$PROJECT_DIR" && bash scripts/open-pr.sh --auto-merge); then
+        echo ""
+        echo "==> Ship failed (see errors above). The update commit is preserved on:"
+        echo "    branch: $UPDATE_BRANCH"
+        echo "    Re-ship when ready:  cd $PROJECT_DIR && bash scripts/open-pr.sh --auto-merge"
+      fi
+    fi
+  else
+    echo ""
+    echo "==> Done. Review the update branch:"
+    echo "    branch: $UPDATE_BRANCH"
+    echo "    git diff ${ORIGINAL_BRANCH}...HEAD"
+    echo "    bash scripts/open-pr.sh --auto-merge"
+  fi
 else
   echo ""
   echo "==> Dry run complete. Apply with: touchstone update"

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -647,7 +647,7 @@ git -C "$PROJECT_OUTDATED" config user.name test-committer
 (cd "$PROJECT_OUTDATED" && git add -A && git commit --no-verify -m "initial" >/dev/null)
 echo "0000000000000000000000000000000000000001" > "$PROJECT_OUTDATED/.touchstone-version"
 (cd "$PROJECT_OUTDATED" && git commit --no-verify -am "pin to old touchstone" >/dev/null)
-if (cd "$PROJECT_OUTDATED" && TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" init --no-setup) >"$TEST_DIR/init-outdated.txt" 2>&1; then
+if (cd "$PROJECT_OUTDATED" && TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" init --no-setup --no-ship) >"$TEST_DIR/init-outdated.txt" 2>&1; then
   assert_contains "$TEST_DIR/init-outdated.txt" 'upgrading'
   UPDATE_BRANCH="$(git -C "$PROJECT_OUTDATED" branch --show-current)"
   case "$UPDATE_BRANCH" in
@@ -659,6 +659,40 @@ if (cd "$PROJECT_OUTDATED" && TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/
   esac
 else
   echo "FAIL: init on outdated project should not exit nonzero (stdout: $(cat "$TEST_DIR/init-outdated.txt"))" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# touchstone init on an outdated project defaults to --ship. With no reachable remote
+# the ship attempt must fail soft: branch preserved, exit 0, clear message.
+PROJECT_OUTDATED_SHIP="$TEST_DIR/outdated-ship-project"
+PATH="$HOOKS_FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_OUTDATED_SHIP" --no-register >/dev/null
+git -C "$PROJECT_OUTDATED_SHIP" config user.email test@touchstone
+git -C "$PROJECT_OUTDATED_SHIP" config user.name test-committer
+(cd "$PROJECT_OUTDATED_SHIP" && git add -A && git commit --no-verify -m "initial" >/dev/null)
+echo "0000000000000000000000000000000000000001" > "$PROJECT_OUTDATED_SHIP/.touchstone-version"
+(cd "$PROJECT_OUTDATED_SHIP" && git commit --no-verify -am "pin to old touchstone" >/dev/null)
+# Stub gh so open-pr.sh fails fast without real network.
+GH_STUB_BIN="$TEST_DIR/gh-stub-bin"
+mkdir -p "$GH_STUB_BIN"
+cat > "$GH_STUB_BIN/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+echo "gh: stubbed failure" >&2
+exit 1
+GHSTUB
+chmod +x "$GH_STUB_BIN/gh"
+if (cd "$PROJECT_OUTDATED_SHIP" && PATH="$GH_STUB_BIN:$HOOKS_FAKE_BIN:$PATH" TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" init --no-setup) >"$TEST_DIR/init-outdated-ship.txt" 2>&1; then
+  assert_contains "$TEST_DIR/init-outdated-ship.txt" 'Shipping update via scripts/open-pr.sh'
+  assert_contains "$TEST_DIR/init-outdated-ship.txt" 'Ship failed'
+  SHIP_BRANCH="$(git -C "$PROJECT_OUTDATED_SHIP" branch --show-current)"
+  case "$SHIP_BRANCH" in
+    chore/touchstone-*) ;;
+    *)
+      echo "FAIL: ship-failure path should preserve the chore/touchstone-* branch, got '$SHIP_BRANCH'" >&2
+      ERRORS=$((ERRORS + 1))
+      ;;
+  esac
+else
+  echo "FAIL: init --ship with failing gh should still exit 0 (branch preserved); stdout: $(cat "$TEST_DIR/init-outdated-ship.txt")" >&2
   ERRORS=$((ERRORS + 1))
 fi
 


### PR DESCRIPTION
touchstone init on an outdated repo now runs scripts/open-pr.sh --auto-merge
after the update commit, closing the gap between "ran the command" and
"upgrade is on main." --no-ship opts out. If the ship step fails, the
chore/touchstone-* branch is preserved with a clear re-ship hint.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
