### PR TITLE
feat(ui): double-rail verdicts signed touchstone + init hero banner

### DIFF
--- a/bin/touchstone
+++ b/bin/touchstone
@@ -39,6 +39,7 @@ export TOUCHSTONE_ROOT
 # Source shared libraries.
 source "$TOUCHSTONE_ROOT/lib/auto-update.sh"
 source "$TOUCHSTONE_ROOT/lib/colors.sh"
+source "$TOUCHSTONE_ROOT/lib/ui.sh"
 
 # Auto-update check (throttled, non-blocking on failure).
 touchstone_auto_update || true
@@ -199,6 +200,9 @@ cmd_init() {
       exec bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh" "${update_args[@]}"
       ;;
   esac
+
+  # Fresh init: greet with the branded hero so setup feels like setup.
+  tk_hero "setting up this project"
 
   bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$project_dir" "${args[@]}"
 

--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -1560,22 +1560,33 @@ tk_have_gum() { command -v gum >/dev/null 2>&1; }
 
 tk_paint() {
   # tk_paint <hex> <bold|plain> <text...>
+  # Falls back to plain text if gum is missing, disabled, or fails —
+  # the hook is running under `set -euo pipefail`, so silent gum failure
+  # would otherwise produce empty strings in the verdict lines.
   local color="$1"; shift
   local flag="$1"; shift
+  local rendered=""
   if [ "$C_TTY" = "1" ] && tk_have_gum; then
     if [ "$flag" = "bold" ]; then
-      gum style --foreground "$color" --bold "$*"
+      rendered="$(gum style --foreground "$color" --bold "$*" 2>/dev/null || true)"
     else
-      gum style --foreground "$color" "$*"
+      rendered="$(gum style --foreground "$color" "$*" 2>/dev/null || true)"
     fi
+  fi
+  if [ -n "$rendered" ]; then
+    printf '%s' "$rendered"
   else
     printf '%s' "$*"
   fi
 }
 
 tk_rail() {
+  local rendered=""
   if [ "$C_TTY" = "1" ] && tk_have_gum; then
-    gum style --foreground "$TK_BRAND_ORANGE" "▌▌"
+    rendered="$(gum style --foreground "$TK_BRAND_ORANGE" "▌▌" 2>/dev/null || true)"
+  fi
+  if [ -n "$rendered" ]; then
+    printf '%s' "$rendered"
   else
     printf '▌▌'
   fi

--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -1539,20 +1539,88 @@ print_summary() {
 if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
   C_DIM='\033[2m' C_GREEN='\033[0;32m'
   C_YELLOW='\033[0;33m' C_RED='\033[0;31m' C_CYAN='\033[0;36m' C_RESET='\033[0m'
+  C_TTY=1
 else
   C_DIM='' C_GREEN='' C_YELLOW='' C_RED='' C_CYAN='' C_RESET=''
+  C_TTY=0
 fi
+
+# --------------------------------------------------------------------------
+# Branded UI — double-rail verdicts signed "touchstone".
+# Mirrors lib/ui.sh; kept inline so this hook stays self-contained when
+# synced into downstream projects as scripts/codex-review.sh.
+# --------------------------------------------------------------------------
+
+TK_BRAND_ORANGE="#FF6B35"
+TK_BRAND_LIME="#A3E635"
+TK_BRAND_RED="#EF4444"
+TK_BRAND_DIM="#6B7280"
+
+tk_have_gum() { command -v gum >/dev/null 2>&1; }
+
+tk_paint() {
+  # tk_paint <hex> <bold|plain> <text...>
+  local color="$1"; shift
+  local flag="$1"; shift
+  if [ "$C_TTY" = "1" ] && tk_have_gum; then
+    if [ "$flag" = "bold" ]; then
+      gum style --foreground "$color" --bold "$*"
+    else
+      gum style --foreground "$color" "$*"
+    fi
+  else
+    printf '%s' "$*"
+  fi
+}
+
+tk_rail() {
+  if [ "$C_TTY" = "1" ] && tk_have_gum; then
+    gum style --foreground "$TK_BRAND_ORANGE" "▌▌"
+  else
+    printf '▌▌'
+  fi
+}
+
+tk_signature_line() {
+  # Dim "touchstone vX.Y.Z" line; version resolved via TOUCHSTONE_ROOT when set.
+  local version=""
+  if [ -n "${TOUCHSTONE_ROOT:-}" ] && [ -f "$TOUCHSTONE_ROOT/VERSION" ]; then
+    version="$(tr -d '[:space:]' < "$TOUCHSTONE_ROOT/VERSION" 2>/dev/null || true)"
+  fi
+  if [ -n "$version" ]; then
+    tk_paint "$TK_BRAND_DIM" plain "touchstone v${version}"
+  else
+    tk_paint "$TK_BRAND_DIM" plain "touchstone"
+  fi
+}
+
+tk_verdict() {
+  # tk_verdict <ok|fail|info> <headline> [subtitle]
+  local state="$1" headline="$2" subtitle="${3:-}"
+  local rail mark painted_headline
+  rail="$(tk_rail)"
+
+  case "$state" in
+    ok)   mark="$(tk_paint "$TK_BRAND_LIME" plain "✓")"
+          painted_headline="$(tk_paint "$TK_BRAND_LIME" bold "$headline")" ;;
+    fail) mark="$(tk_paint "$TK_BRAND_RED"  plain "✗")"
+          painted_headline="$(tk_paint "$TK_BRAND_RED"  bold "$headline")" ;;
+    *)    mark="$(tk_paint "$TK_BRAND_DIM"  plain "•")"
+          painted_headline="$(tk_paint "$TK_BRAND_DIM"  bold "$headline")" ;;
+  esac
+
+  printf '\n  %s  %s  %s\n' "$rail" "$painted_headline" "$mark"
+  if [ -n "$subtitle" ]; then
+    printf '  %s  %s\n' "$rail" "$(tk_paint "$TK_BRAND_DIM" plain "$subtitle")"
+  fi
+  printf '  %s  %s\n\n' "$rail" "$(tk_signature_line)"
+}
 
 print_banner() {
   [ "$BANNER_PRINTED" = false ] || return 0
   local label
   label="$(reviewer_label)"
-  printf "${C_CYAN}"
-  printf '\n  ╔══════════════════════════════════════╗\n'
-  printf '  ║         ⚡ TOUCHSTONE REVIEW ⚡        ║\n'
-  printf '  ║     %s merge code review%s║\n' "$label" "$(printf '%*s' $((23 - ${#label})) '')"
-  printf '  ╚══════════════════════════════════════╝\n\n'
-  printf "${C_RESET}"
+  tk_verdict info "REVIEW STARTING" "${label} · merge code review"
   BANNER_PRINTED=true
 }
 
@@ -1660,18 +1728,11 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
   case "$LAST_LINE" in
     CODEX_REVIEW_CLEAN)
       phase "done — clean"
-      echo ""
-      printf "${C_GREEN}"
-      cat <<'PASS'
-  ╔══════════════════════════════════════╗
-  ║           ✅ ALL CLEAR              ║
-  ║         Push approved.              ║
-  ╚══════════════════════════════════════╝
-PASS
-      printf "${C_RESET}"
+      clean_subtitle="${REVIEWER_LABEL} · ${DIFF_LINE_COUNT} lines · push approved"
       if [ "$FIX_COMMITS" -gt 0 ]; then
-        printf "  ${C_DIM}($FIX_COMMITS auto-fix commit(s) applied)${C_RESET}\n"
+        clean_subtitle="${clean_subtitle} · ${FIX_COMMITS} auto-fix commit(s)"
       fi
+      tk_verdict ok "ALL CLEAR" "$clean_subtitle"
       REVIEW_EXIT_REASON="clean"
       print_summary
       write_clean_review_cache "$REVIEW_CACHE_KEY" "$DIFF_LINE_COUNT"
@@ -1726,14 +1787,8 @@ PASS
     CODEX_REVIEW_BLOCKED)
       phase "done — blocked"
       REVIEW_FINDINGS_COUNT="$(printf '%s\n' "$OUTPUT" | grep -c '^- ' || true)"
-      echo ""
-      printf "${C_RED}"
-      printf '  ╔══════════════════════════════════════╗\n'
-      printf '  ║          🚫 PUSH BLOCKED           ║\n'
-      printf '  ║  %s found issues to address%s║\n' "$REVIEWER_LABEL" "$(printf '%*s' $((25 - ${#REVIEWER_LABEL})) '')"
-      printf '  ╚══════════════════════════════════════╝\n'
-      printf "${C_RESET}"
-      echo ""
+      blocked_subtitle="${REVIEWER_LABEL} flagged issues to address · push refused"
+      tk_verdict fail "PUSH BLOCKED" "$blocked_subtitle"
       printf '%s\n' "$OUTPUT" | sed 's/^/    /'
       echo ""
       if [ "$FIX_COMMITS" -gt 0 ]; then

--- a/lib/ui.sh
+++ b/lib/ui.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# lib/ui.sh — Touchstone branded UI helpers.
+#
+# Provides the double-rail verdict style and the figlet/gum hero banner.
+# Gracefully degrades when gum or figlet are not installed: the rails turn
+# into ASCII bars, and the hero turns into a bold "TOUCHSTONE" header.
+#
+# Sourced by bin/touchstone. The codex-review hook carries its own inline
+# copy because it ships into downstream projects without lib/.
+
+# Guard: only define helpers once per shell.
+if [ -n "${TK_UI_SOURCED:-}" ]; then return 0; fi
+TK_UI_SOURCED=1
+
+# Brand palette. Orange is the Touchstone signature color; lime/red are the
+# state accents; dim is for supporting text.
+TK_BRAND_ORANGE="#FF6B35"
+TK_BRAND_LIME="#A3E635"
+TK_BRAND_RED="#EF4444"
+TK_BRAND_DIM="#6B7280"
+
+tk_have_gum()    { command -v gum    >/dev/null 2>&1; }
+tk_have_figlet() { command -v figlet >/dev/null 2>&1; }
+
+tk_color_enabled() {
+  [ -t 1 ] && [ -z "${NO_COLOR:-}" ]
+}
+
+# Internal: render the double-rail prefix "▌▌" in brand orange. Returns
+# plain "▌▌" when color/gum are unavailable.
+_tk_rail() {
+  if tk_color_enabled && tk_have_gum; then
+    gum style --foreground "$TK_BRAND_ORANGE" "▌▌"
+  else
+    printf '▌▌'
+  fi
+}
+
+_tk_paint() {
+  local color="$1"; shift
+  local flag="$1"; shift
+  if tk_color_enabled && tk_have_gum; then
+    if [ "$flag" = "bold" ]; then
+      gum style --foreground "$color" --bold "$*"
+    else
+      gum style --foreground "$color" "$*"
+    fi
+  else
+    printf '%s' "$*"
+  fi
+}
+
+# tk_verdict <state> <headline> [subtitle]
+#   state: ok | fail | info
+# Renders the Option E double-rail verdict signed "touchstone".
+tk_verdict() {
+  local state="$1" headline="$2" subtitle="${3:-}"
+  local rail mark version_line sig
+  rail="$(_tk_rail)"
+
+  case "$state" in
+    ok)   mark="$(_tk_paint "$TK_BRAND_LIME" plain "✓")" ;;
+    fail) mark="$(_tk_paint "$TK_BRAND_RED"  plain "✗")" ;;
+    info) mark="$(_tk_paint "$TK_BRAND_DIM"  plain "•")" ;;
+    *)    mark="$(_tk_paint "$TK_BRAND_DIM"  plain "·")" ;;
+  esac
+
+  case "$state" in
+    ok)   headline="$(_tk_paint "$TK_BRAND_LIME" bold "$headline")" ;;
+    fail) headline="$(_tk_paint "$TK_BRAND_RED"  bold "$headline")" ;;
+    *)    headline="$(_tk_paint "$TK_BRAND_DIM"  bold "$headline")" ;;
+  esac
+
+  printf '\n  %s  %s  %s\n' "$rail" "$headline" "$mark"
+  if [ -n "$subtitle" ]; then
+    printf '  %s  %s\n' "$rail" "$(_tk_paint "$TK_BRAND_DIM" plain "$subtitle")"
+  fi
+  sig="$(tk_signature)"
+  printf '  %s  %s\n\n' "$rail" "$sig"
+}
+
+# tk_signature — the "touchstone vX.Y.Z" signature line (without rail).
+# The caller is responsible for placing it next to a rail when needed.
+tk_signature() {
+  local version
+  if [ -n "${TOUCHSTONE_ROOT:-}" ] && [ -f "$TOUCHSTONE_ROOT/VERSION" ]; then
+    version="$(tr -d '[:space:]' < "$TOUCHSTONE_ROOT/VERSION" 2>/dev/null || true)"
+  fi
+  if [ -n "$version" ]; then
+    _tk_paint "$TK_BRAND_DIM" plain "touchstone v${version}"
+  else
+    _tk_paint "$TK_BRAND_DIM" plain "touchstone"
+  fi
+}
+
+# tk_hero [subtitle] — figlet+gum hero banner for `touchstone init` /
+# `touchstone version`. Falls back to a bold header when figlet is missing.
+tk_hero() {
+  local subtitle="${1:-}"
+  local version=""
+  if [ -n "${TOUCHSTONE_ROOT:-}" ] && [ -f "$TOUCHSTONE_ROOT/VERSION" ]; then
+    version="$(tr -d '[:space:]' < "$TOUCHSTONE_ROOT/VERSION" 2>/dev/null || true)"
+  fi
+
+  if tk_have_figlet && tk_have_gum && tk_color_enabled; then
+    local banner
+    banner="$(figlet -f slant TOUCHSTONE 2>/dev/null || figlet TOUCHSTONE 2>/dev/null || true)"
+    if [ -n "$banner" ]; then
+      gum style --foreground "$TK_BRAND_ORANGE" --margin "1 2" "$banner"
+      if [ -n "$subtitle" ]; then
+        gum style --foreground "$TK_BRAND_DIM" --margin "0 2" "$subtitle${version:+ · v$version}"
+      elif [ -n "$version" ]; then
+        gum style --foreground "$TK_BRAND_DIM" --margin "0 2" "shared engineering platform · v${version}"
+      fi
+      printf '\n'
+      return 0
+    fi
+  fi
+
+  # Plain fallback.
+  printf '\n'
+  if tk_color_enabled; then
+    printf '  \033[1;38;5;208mTOUCHSTONE\033[0m'
+  else
+    printf '  TOUCHSTONE'
+  fi
+  if [ -n "$version" ]; then
+    printf '  v%s' "$version"
+  fi
+  printf '\n'
+  if [ -n "$subtitle" ]; then
+    if tk_color_enabled; then
+      printf '  \033[2m%s\033[0m\n' "$subtitle"
+    else
+      printf '  %s\n' "$subtitle"
+    fi
+  fi
+  printf '\n'
+}

--- a/lib/ui.sh
+++ b/lib/ui.sh
@@ -28,10 +28,16 @@ tk_color_enabled() {
 }
 
 # Internal: render the double-rail prefix "▌▌" in brand orange. Returns
-# plain "▌▌" when color/gum are unavailable.
+# plain "▌▌" when gum is missing, disabled, or fails. Callers may run
+# under `set -euo pipefail`; a silent gum failure would otherwise produce
+# empty strings in the verdict lines and hide the rail from the user.
 _tk_rail() {
+  local rendered=""
   if tk_color_enabled && tk_have_gum; then
-    gum style --foreground "$TK_BRAND_ORANGE" "▌▌"
+    rendered="$(gum style --foreground "$TK_BRAND_ORANGE" "▌▌" 2>/dev/null || true)"
+  fi
+  if [ -n "$rendered" ]; then
+    printf '%s' "$rendered"
   else
     printf '▌▌'
   fi
@@ -40,12 +46,16 @@ _tk_rail() {
 _tk_paint() {
   local color="$1"; shift
   local flag="$1"; shift
+  local rendered=""
   if tk_color_enabled && tk_have_gum; then
     if [ "$flag" = "bold" ]; then
-      gum style --foreground "$color" --bold "$*"
+      rendered="$(gum style --foreground "$color" --bold "$*" 2>/dev/null || true)"
     else
-      gum style --foreground "$color" "$*"
+      rendered="$(gum style --foreground "$color" "$*" 2>/dev/null || true)"
     fi
+  fi
+  if [ -n "$rendered" ]; then
+    printf '%s' "$rendered"
   else
     printf '%s' "$*"
   fi
@@ -104,17 +114,29 @@ tk_hero() {
   fi
 
   if tk_have_figlet && tk_have_gum && tk_color_enabled; then
-    local banner
+    local banner painted_banner painted_sub
     banner="$(figlet -f slant TOUCHSTONE 2>/dev/null || figlet TOUCHSTONE 2>/dev/null || true)"
     if [ -n "$banner" ]; then
-      gum style --foreground "$TK_BRAND_ORANGE" --margin "1 2" "$banner"
-      if [ -n "$subtitle" ]; then
-        gum style --foreground "$TK_BRAND_DIM" --margin "0 2" "$subtitle${version:+ · v$version}"
-      elif [ -n "$version" ]; then
-        gum style --foreground "$TK_BRAND_DIM" --margin "0 2" "shared engineering platform · v${version}"
+      painted_banner="$(gum style --foreground "$TK_BRAND_ORANGE" --margin "1 2" "$banner" 2>/dev/null || true)"
+      if [ -n "$painted_banner" ]; then
+        printf '%s\n' "$painted_banner"
+        local sub_text=""
+        if [ -n "$subtitle" ]; then
+          sub_text="$subtitle${version:+ · v$version}"
+        elif [ -n "$version" ]; then
+          sub_text="shared engineering platform · v${version}"
+        fi
+        if [ -n "$sub_text" ]; then
+          painted_sub="$(gum style --foreground "$TK_BRAND_DIM" --margin "0 2" "$sub_text" 2>/dev/null || true)"
+          if [ -n "$painted_sub" ]; then
+            printf '%s\n' "$painted_sub"
+          else
+            printf '  %s\n' "$sub_text"
+          fi
+        fi
+        printf '\n'
+        return 0
       fi
-      printf '\n'
-      return 0
     fi
   fi
 

--- a/lib/ui.sh
+++ b/lib/ui.sh
@@ -93,7 +93,7 @@ tk_verdict() {
 # tk_signature — the "touchstone vX.Y.Z" signature line (without rail).
 # The caller is responsible for placing it next to a rail when needed.
 tk_signature() {
-  local version
+  local version=""
   if [ -n "${TOUCHSTONE_ROOT:-}" ] && [ -f "$TOUCHSTONE_ROOT/VERSION" ]; then
     version="$(tr -d '[:space:]' < "$TOUCHSTONE_ROOT/VERSION" 2>/dev/null || true)"
   fi

--- a/prototypes/ui-banners.sh
+++ b/prototypes/ui-banners.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# prototypes/ui-banners.sh — visual prototypes for Touchstone's branded output.
+# Run this script in a real terminal to compare styles. Pick one and we'll wire
+# it into lib/ui.sh and hooks/codex-review.sh.
+#
+# Requires: gum (brew install gum). Falls back to plain echoes without it.
+#
+set -uo pipefail
+
+have_gum() { command -v gum >/dev/null 2>&1; }
+
+# Touchstone brand palette — pick whichever you like; these are placeholders.
+BRAND_ORANGE="#FF6B35"   # warm accent, reads "craft/tool"
+BRAND_SLATE="#4A6FA5"    # cool accent, reads "enterprise/trust"
+BRAND_INK="#1A1A2E"      # deep background accent
+BRAND_LIME="#A3E635"     # success-pop
+BRAND_RED="#EF4444"      # fail-pop
+BRAND_DIM="#6B7280"      # supporting text
+
+hr() { printf '\n\n'; printf '─%.0s' {1..72}; printf '  %s\n\n' "$1"; }
+
+# ------------------------------------------------------------
+hr "CURRENT — for reference"
+# ------------------------------------------------------------
+cat <<'EOF'
+
+  ╔══════════════════════════════════════╗
+  ║           ✅ ALL CLEAR              ║
+  ║         Push approved.              ║
+  ╚══════════════════════════════════════╝
+
+EOF
+
+# ------------------------------------------------------------
+hr "OPTION A — left-rail, orange brand, no box (bun/vercel style)"
+# ------------------------------------------------------------
+if have_gum; then
+  gum style --foreground "$BRAND_ORANGE" "▌ $(gum style --foreground "$BRAND_LIME" "✓") ALL CLEAR"
+  gum style --foreground "$BRAND_ORANGE" "▌ $(gum style --foreground "$BRAND_DIM" "  Push approved · Codex · 3m5s · 0 findings")"
+fi
+
+# ------------------------------------------------------------
+hr "OPTION B — rounded box, minimal, orange border"
+# ------------------------------------------------------------
+if have_gum; then
+  gum style \
+    --border rounded --padding "0 2" --margin "0 2" \
+    --border-foreground "$BRAND_ORANGE" \
+    --foreground "15" \
+    "$(gum style --foreground "$BRAND_LIME" "✓") ALL CLEAR" \
+    "$(gum style --foreground "$BRAND_DIM" "Codex · 3m5s · 0 findings")"
+fi
+
+# ------------------------------------------------------------
+hr "OPTION C — rounded box with title, slate brand"
+# ------------------------------------------------------------
+if have_gum; then
+  gum style \
+    --border rounded --padding "1 3" --margin "0 2" \
+    --border-foreground "$BRAND_SLATE" \
+    --foreground "15" --align center --width 44 \
+    "$(gum style --foreground "$BRAND_LIME" --bold "✓ ALL CLEAR")" \
+    "$(gum style --foreground "$BRAND_DIM" "Push approved")"
+fi
+
+# ------------------------------------------------------------
+hr "OPTION D — thick horizontal rule + inline label (biome/cargo style)"
+# ------------------------------------------------------------
+if have_gum; then
+  label="$(gum style --foreground "$BRAND_LIME" --bold " ✓ ALL CLEAR ")"
+  rule="$(gum style --foreground "$BRAND_ORANGE" "━━━━━━━━━━")"
+  printf '\n  %s%s%s\n' "$rule" "$label" "$rule"
+  printf '  %s\n\n' "$(gum style --foreground "$BRAND_DIM" "Codex · 3m5s · 0 findings · push approved")"
+fi
+
+# ------------------------------------------------------------
+hr "OPTION E — double left-rail, stronger brand presence"
+# ------------------------------------------------------------
+if have_gum; then
+  rail="$(gum style --foreground "$BRAND_ORANGE" "▌▌")"
+  printf '\n  %s  %s  %s\n' "$rail" "$(gum style --foreground "$BRAND_LIME" --bold "ALL CLEAR")" "$(gum style --foreground "$BRAND_DIM" "✓")"
+  printf '  %s  %s\n\n' "$rail" "$(gum style --foreground "$BRAND_DIM" "Codex · 3m5s · 0 findings · push approved")"
+fi
+
+# ------------------------------------------------------------
+hr "OPTION F — thick block rail, serious/technical"
+# ------------------------------------------------------------
+if have_gum; then
+  rail_ok="$(gum style --foreground "$BRAND_LIME" "█")"
+  rail_brand="$(gum style --foreground "$BRAND_ORANGE" "█")"
+  printf '\n  %s%s  %s\n' "$rail_brand" "$rail_ok" "$(gum style --bold "ALL CLEAR")"
+  printf '  %s%s  %s\n\n' "$rail_brand" "$rail_ok" "$(gum style --foreground "$BRAND_DIM" "Codex · 3m5s · 0 findings")"
+fi
+
+# ------------------------------------------------------------
+hr "OPTION G — blocked state, for contrast (rail pattern)"
+# ------------------------------------------------------------
+if have_gum; then
+  rail="$(gum style --foreground "$BRAND_RED" "▌")"
+  printf '\n  %s %s  %s\n' "$rail" "$(gum style --foreground "$BRAND_RED" --bold "✗")" "$(gum style --bold "BLOCKED")"
+  printf '  %s   %s\n' "$rail" "$(gum style --foreground "$BRAND_DIM" "Codex flagged 2 unsafe changes — push refused")"
+  printf '  %s   %s\n\n' "$rail" "$(gum style --foreground "$BRAND_DIM" "Re-run with CODEX_REVIEW_ALLOW_UNSAFE=1 to override")"
+fi
+
+# ------------------------------------------------------------
+hr "OPTION H — phase/progress ticker (for in-progress, not endings)"
+# ------------------------------------------------------------
+if have_gum; then
+  tick="$(gum style --foreground "$BRAND_ORANGE" "●")"
+  past="$(gum style --foreground "$BRAND_LIME" "●")"
+  idle="$(gum style --foreground "$BRAND_DIM" "○")"
+  printf '\n  %s loading diff\n' "$past"
+  printf '  %s checking cache\n' "$past"
+  printf '  %s running codex review %s\n' "$tick" "$(gum style --foreground "$BRAND_DIM" "(iter 1/3)")"
+  printf '  %s applying auto-fixes\n' "$idle"
+  printf '  %s final verdict\n\n' "$idle"
+fi
+
+# ------------------------------------------------------------
+hr "OPTION I — hero banner (for touchstone --version only, not per-op)"
+# ------------------------------------------------------------
+if command -v figlet >/dev/null 2>&1 && have_gum; then
+  banner="$(figlet -f slant TOUCHSTONE 2>/dev/null || figlet TOUCHSTONE)"
+  gum style --foreground "$BRAND_ORANGE" --margin "1 2" "$banner"
+  gum style --foreground "$BRAND_DIM" --margin "0 2" "shared engineering platform · v1.1.0"
+else
+  echo "  (install 'figlet' to see the hero banner prototype — brew install figlet)"
+fi
+
+# ------------------------------------------------------------
+hr "OPTION J — compact one-liner (for quiet/CI mode)"
+# ------------------------------------------------------------
+if have_gum; then
+  rail="$(gum style --foreground "$BRAND_ORANGE" "▌")"
+  ok="$(gum style --foreground "$BRAND_LIME" "✓")"
+  printf '%s %s touchstone: ALL CLEAR %s\n\n' "$rail" "$ok" "$(gum style --foreground "$BRAND_DIM" "(codex · 3m5s · 0 findings)")"
+fi
+
+printf '\n\n────────── Tell me which option (or mix) feels right ──────────\n\n'


### PR DESCRIPTION
- lib/ui.sh: brand palette, tk_verdict (ok/fail/info), tk_hero with
  figlet+gum rendering and plain-text fallback.
- hooks/codex-review.sh: replace the three ASCII-box banners (review
  start, ALL CLEAR, PUSH BLOCKED) with the double-rail verdict style;
  helpers inlined so the hook stays self-contained when synced.
- bin/touchstone: show the TOUCHSTONE hero at the start of a fresh
  init so setup feels like setup.
- prototypes/ui-banners.sh: design archive of the ten options we
  compared; kept as the decision trail for Option E.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
