### PR TITLE
docs(principles): sharpen rules, resolve contradictions, add four

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ touchstone/
 | `VERSION` | Current semver version |
 | `~/.touchstone-projects` | Registry of all bootstrapped projects |
 
-Release history lives in `git log` and `gh release list` — there is no `CHANGELOG.md`. Duplicating release history in a markdown file was a documentation-ownership violation (per `principles/documentation-ownership.md`: "when in doubt, delete the duplicate"). Run `gh release list` or `git log --oneline` for the canonical list.
+Release history lives in `git log` and `gh release list` — there is no `CHANGELOG.md`. Duplicating release history in a markdown file was a documentation-ownership violation (see `principles/documentation-ownership.md`). Run `gh release list` or `git log --oneline` for the canonical list.
 
 ## Release & Distribution
 

--- a/README.md
+++ b/README.md
@@ -200,8 +200,8 @@ The `touchstone` CLI checks for new versions hourly. When a newer release exists
 
 Universal engineering standards, extracted and battle-tested from production systems:
 
-- **[engineering-principles.md](principles/engineering-principles.md)** — No band-aids, no silent failures, every fix gets a test, think in invariants, derive don't persist, one code path, audit weak-point classes
-- **[pre-implementation-checklist.md](principles/pre-implementation-checklist.md)** — 4 questions to answer before writing any code
+- **[engineering-principles.md](principles/engineering-principles.md)** — No band-aids, narrow interfaces, no silent failures, every fix gets a test, derive don't persist, one code path, version data boundaries, separate behavior from tidying, recoverable irreversibles, compatibility at boundaries, audit weak-point classes
+- **[pre-implementation-checklist.md](principles/pre-implementation-checklist.md)** — Pre-flight questions that route back to the canonical principles
 - **[audit-weak-points.md](principles/audit-weak-points.md)** — Methodology: find one bug → audit the whole class → ranked fix → guardrail test
 - **[documentation-ownership.md](principles/documentation-ownership.md)** — Single canonical owner per volatile fact
 - **[git-workflow.md](principles/git-workflow.md)** — Feature branch → PR → AI merge review → squash merge

--- a/principles/README.md
+++ b/principles/README.md
@@ -4,8 +4,8 @@ Universal engineering standards that apply to all projects. These are imported b
 
 | File | Summary |
 |------|---------|
-| [engineering-principles.md](engineering-principles.md) | Hard requirements: no band-aids, no silent failures, every fix gets a test |
-| [pre-implementation-checklist.md](pre-implementation-checklist.md) | 4 questions to answer before writing any code |
+| [engineering-principles.md](engineering-principles.md) | Hard requirements: no band-aids, narrow interfaces, no silent failures, every fix gets a test, recoverable irreversibles, compatibility at boundaries |
+| [pre-implementation-checklist.md](pre-implementation-checklist.md) | Pre-flight questions that route back to the canonical principles |
 | [audit-weak-points.md](audit-weak-points.md) | Methodology for auditing structural bug patterns |
 | [documentation-ownership.md](documentation-ownership.md) | Single canonical owner per volatile fact |
 | [git-workflow.md](git-workflow.md) | Feature branch lifecycle with merge/default-branch review |

--- a/principles/audit-weak-points.md
+++ b/principles/audit-weak-points.md
@@ -6,11 +6,11 @@ When you find a structural bug, don't just fix the one you noticed. The same pat
 
 1. **Identify the pattern.** Name it precisely. Examples: "stale data contamination," "hardcoded resource list instead of registry lookup," "file-persisted state on a read-only filesystem," "hardcoded absolute values instead of ratios."
 
-2. **Search exhaustively.** Use grep, AST tools, or an exploration agent to find every instance of the pattern. Cast a wide net — the most dangerous instances are the ones in code paths you weren't looking at.
+2. **Search until the reviewed surface is explicit.** Use grep, AST tools, or an exploration agent to find instances of the pattern. State what you searched (queries, tools, directories) and what you intentionally left out of scope. "Exhaustive" is unverifiable; "reviewed and bounded" is. The most dangerous instances are the ones in code paths you weren't looking at, so cast wide and make your coverage legible.
 
 3. **Produce a ranked punch-list.** Sort by production impact, not by how easy they are to fix. The instance that silently corrupts data in a hot path matters more than the one in a rarely-used utility.
 
-4. **Fix in tiers.** Start with the highest-impact instances. Don't try to fix everything in one PR — large blast radius increases review risk and rollback cost.
+4. **Fix in tiers, and track the tail.** Start with the highest-impact instances. Don't try to fix everything in one PR — large blast radius increases review risk and rollback cost. If you split the fix across PRs, commit the ranked list somewhere durable (issue, ADR, follow-up task) so the lower-priority instances don't get abandoned. Prefer landing the guardrail (step 6) in the first PR — it stops new copies while you work through the existing ones.
 
 5. **Reset contaminated state where filtering doesn't work.** Some derived state (trained models, accumulated statistics, cached computations) can't be "filtered" to exclude pre-fix data — it has to be rebuilt from scratch. Identify these cases and handle them explicitly.
 

--- a/principles/documentation-ownership.md
+++ b/principles/documentation-ownership.md
@@ -12,4 +12,6 @@ Every volatile fact in the project's documentation must have exactly one canonic
 
 4. **Config examples live in example files, not prose.** A `config.example.json` or `.env.example` is the canonical source of config shape. Documentation should point to the example file, not duplicate large config blocks that go stale.
 
-5. **When in doubt, delete the duplicate.** If you find the same fact in two places and can't easily determine which is canonical, delete the less-authoritative copy and add a link to the other. One correct source is better than two potentially-wrong sources.
+5. **Identify the owner, then link — don't delete first.** If you find the same fact in two places, decide which file owns it, then replace the less-authoritative copy with a link to the owner. Only delete outright when the duplicated context adds no value that a link wouldn't serve. Deletion before ownership is established can lose useful framing that belongs in the canonical doc.
+
+6. **Duplication found mid-PR gets a follow-up, not silence.** If you notice duplicated documentation while working on an unrelated change, don't bury the finding. File a follow-up issue or note the duplication in the PR description so it gets resolved instead of rediscovered.

--- a/principles/engineering-principles.md
+++ b/principles/engineering-principles.md
@@ -1,38 +1,44 @@
 # Engineering Principles (HARD REQUIREMENTS)
 
-These are non-negotiable. Every code change must satisfy all of them.
+These are non-negotiable. Every code change must be reviewed against them; any exception must be explicit, justified, and disclosed in the PR.
 
 ## No band-aids
-Fix root causes, not symptoms. If a fix patches a symptom, say so explicitly: *"This patches the symptom. The root cause is X and fixing it properly would require Y. Which do you want?"*
+Fix the root cause unless the PR explicitly documents why a symptom patch is the safer scoped change. If it's a symptom patch, say so: *"This patches the symptom. The root cause is X and fixing it properly would require Y. Which do you want?"* Undocumented symptom patches compound — a year later you have a codebase full of thin fixes and nobody remembers which ones were intentional.
 
-## Design for scale-up
-Use percentages, ratios, and relative values — not magic numbers or hard-coded absolute values. Code should work correctly regardless of scale (10 users or 10 million, $100 or $100K).
+## Keep interfaces narrow
+Expose the smallest stable interface that lets callers do their job. Don't leak storage shape, vendor SDKs, temporary flags, or workflow sequencing across module boundaries. A deep module hides substantial complexity behind a stable contract; a shallow module exports its complexity to every caller and makes every future fix broad and risky.
+
+## Derive limits from domain; test at scale boundaries
+Derive thresholds, sizes, limits, and allocations from input, configuration, or named domain constants. Hard-code a value only when it represents a real invariant, and document why. Test behavior at small, typical, and large scales — not just the shape you developed against. Code that only works at one scale will silently misbehave at the scales you forgot.
 
 ## Derive, don't persist
-Compute from the source of truth when possible. Persisted derived state goes stale silently. If you must persist, document the source of truth and the refresh mechanism.
+Compute from the source of truth by default. Persist derived state only when recomputation is too slow, too expensive, or externally required — and when you do, document in the same commit: the source of truth, the invalidation trigger, the rebuild path, and a reconciliation check. Undocumented persisted state goes stale silently; that is the failure mode this rule prevents.
 
 ## No silent failures
-Every exception is either re-raised or logged with enough context to debug from production logs alone. No `except: pass`. No swallowed errors. No default values returned on failure without a log line. No fallback behavior that masks broken state.
+Every exception is either re-raised or logged with enough context to debug from production logs alone. No `except: pass`. No swallowed errors. No default values returned on failure without a log line. Fallback behavior may continue only when it reports what failed, what was skipped, and what safety boundary still holds.
 
 **The rule:** if something fails, the failure must be visible to someone — an operator, a log aggregator, a monitoring dashboard. A failure that nobody can see is the most dangerous kind.
 
 ## Every fix gets a test
-Bug fixes must include a test that reproduces the exact failure mode. A bug fix without a test means the bug can recur silently. The test should fail on the old code and pass on the new code — if it passes on both, it's not testing the right thing.
+Bug fixes must include a test that reproduces the exact failure mode, and the test must run in CI — not just locally. A bug fix without a regression test means the bug can recur silently the next time someone refactors nearby. The test should fail on the old code and pass on the new code — if it passes on both, it isn't testing the right thing.
 
 ## Think in invariants
-Assert correctness properties in tests, not just happy-path behavior. What must always be true? What relationship between values must hold? Test the invariants, not just the outputs.
+For nontrivial logic, name at least one invariant and assert it — either in a test or as a runtime boundary check. What must always be true? What relationship between values must hold? Happy-path outputs tell you the code worked for one input; invariants tell you it can't be wrong for any input in the covered space.
 
 ## One code path
-Avoid creating separate code paths for different modes (test/prod, paper/live, dev/staging). Divergent paths drift apart silently, and bugs in one path don't surface until it's too late. If modes must differ, the divergence should be as late and as narrow as possible (e.g., the final I/O call), not a fork at the top of the pipeline.
+Share business logic across modes (test/prod, paper/live, dev/staging). Divergent paths drift apart silently, and bugs in one path don't surface until it's too late. If modes must differ, confine the difference to adapters, configuration, or the final I/O boundary — not a fork at the top of the pipeline.
 
-## Current decisions from current data
-Never blend pre-change and post-change data in any read that drives a decision. When a model, algorithm, or data source is materially changed, establish a boundary (cohort, epoch, version) and ensure every downstream consumer honors it. Aggregating across the boundary dilutes signal with noise from the old regime.
+## Version your data boundaries
+When a model, algorithm, or data source changes in a way that affects decisions, rankings, persisted state, metrics, or user-visible behavior, establish a boundary (cohort, epoch, version) and ensure every downstream consumer honors it. Reads that drive decisions must not blend data across the boundary; aggregating across it dilutes signal with noise from the old regime.
+
+## Separate behavior changes from tidying
+Do not mix functional changes with broad renames, formatting sweeps, dependency churn, or unrelated refactors. If cleanup is needed, do it before or after the behavior change in a separate commit or PR. Reviewers must be able to see the semantic change without diff noise; mixed changes hide regressions and make rollback unsafe.
+
+## Make irreversible actions recoverable
+Any destructive or one-way operation must have a recovery path before it runs. Deletes, migrations, format rewrites, external side effects, and history rewrites need a dry run, backup, idempotency key, rollback plan, or forward-fix plan. A change is not safe because it passed once; it is safe when failure leaves the system in a known recoverable state.
+
+## Preserve compatibility at boundaries
+Changes to public APIs, config files, schemas, CLIs, hooks, templates, and generated artifacts must include a compatibility or migration plan. Accept old and new formats during rollout when downstream projects may lag. Boundary breaks multiply: one local assumption becomes N downstream failures. This applies doubly to Touchstone itself, which ships files into every project that uses it.
 
 ## Audit one weak-point class at a time
-When you find a structural bug pattern, don't just fix the one you noticed. Audit the whole class:
-1. Search for all instances of the pattern across the codebase
-2. Produce a ranked punch-list (production impact first)
-3. Fix in tiers — highest impact first
-4. Add a guardrail test (AST-based, lint rule, or integration test) that catches future regressions
-
-This discipline prevents re-auditing the same code twice and catches bugs before they compound.
+When you find a structural bug, audit the whole class — not just the one you noticed. See [audit-weak-points.md](audit-weak-points.md) for the methodology. This discipline prevents re-auditing the same code twice and catches bugs before they compound.

--- a/principles/engineering-principles.md
+++ b/principles/engineering-principles.md
@@ -38,7 +38,7 @@ Do not mix functional changes with broad renames, formatting sweeps, dependency 
 Any destructive or one-way operation must have a recovery path before it runs. Deletes, migrations, format rewrites, external side effects, and history rewrites need a dry run, backup, idempotency key, rollback plan, or forward-fix plan. A change is not safe because it passed once; it is safe when failure leaves the system in a known recoverable state.
 
 ## Preserve compatibility at boundaries
-Changes to public APIs, config files, schemas, CLIs, hooks, templates, and generated artifacts must include a compatibility or migration plan. Accept old and new formats during rollout when downstream projects may lag. Boundary breaks multiply: one local assumption becomes N downstream failures. This applies doubly to Touchstone itself, which ships files into every project that uses it.
+Changes to public APIs, config files, schemas, CLIs, hooks, templates, and generated artifacts must include a compatibility or migration plan. Accept old and new formats during rollout when downstream consumers may lag. Boundary breaks multiply: one local assumption becomes N downstream failures.
 
 ## Audit one weak-point class at a time
 When you find a structural bug, audit the whole class — not just the one you noticed. See [audit-weak-points.md](audit-weak-points.md) for the methodology. This discipline prevents re-auditing the same code twice and catches bugs before they compound.

--- a/principles/git-workflow.md
+++ b/principles/git-workflow.md
@@ -20,7 +20,7 @@ Normal code changes go through a feature branch + PR + merge. Emergency bypasses
 
 If the project has Codex review configured (see `.codex-review.toml` for policy and the `codex-review` hook in `.pre-commit-config.yaml` for the entry point), a pre-push hook gates default-branch pushes (including squash-merges via `merge-pr.sh`). The mechanism is `stages: [pre-push]` in `.pre-commit-config.yaml`; it skips feature-branch pushes and only activates when the push target is the default branch. Behavior:
 - Runs `codex exec --full-auto` against the diff vs the default branch
-- Auto-fixes only mechanical or low-risk findings (typos, whitespace, trivial doc drift); behavior changes — including added logging, error handling, or retry logic — stay in the PR for human review
+- Auto-fixes only low-risk findings (typos, missing imports, adding logging to empty exception handlers, named constants for unexplained magic numbers); anything that changes control flow, business logic, or retry/error-handling semantics stays in the PR for human review
 - Blocks the push for unsafe findings (high-scrutiny paths)
 - Loops up to `max_iterations` times (default 3)
 - Gracefully skips if the Codex CLI isn't installed, printing a visible "review skipped" line so the missing safety boundary isn't silent

--- a/principles/git-workflow.md
+++ b/principles/git-workflow.md
@@ -1,6 +1,6 @@
 # Git Workflow
 
-Every code change goes through a feature branch + PR + merge. No exceptions for "small" changes. This discipline catches bugs before they land on the default branch and creates an audit trail for every change.
+Normal code changes go through a feature branch + PR + merge. Emergency bypasses are allowed only through the documented emergency path below, and must be disclosed in the next recovery PR. This discipline catches bugs before they land on the default branch and creates an audit trail for every change, while leaving a legible escape hatch for production incidents.
 
 ## The lifecycle
 
@@ -20,10 +20,10 @@ Every code change goes through a feature branch + PR + merge. No exceptions for 
 
 If the project has Codex review configured (see `.codex-review.toml` for policy and the `codex-review` hook in `.pre-commit-config.yaml` for the entry point), a pre-push hook gates default-branch pushes (including squash-merges via `merge-pr.sh`). The mechanism is `stages: [pre-push]` in `.pre-commit-config.yaml`; it skips feature-branch pushes and only activates when the push target is the default branch. Behavior:
 - Runs `codex exec --full-auto` against the diff vs the default branch
-- Auto-fixes safe findings (typos, missing error logging, etc.)
+- Auto-fixes only mechanical or low-risk findings (typos, whitespace, trivial doc drift); behavior changes — including added logging, error handling, or retry logic — stay in the PR for human review
 - Blocks the push for unsafe findings (high-scrutiny paths)
 - Loops up to `max_iterations` times (default 3)
-- Gracefully skips if the Codex CLI isn't installed
+- Gracefully skips if the Codex CLI isn't installed, printing a visible "review skipped" line so the missing safety boundary isn't silent
 
 ## Periodic branch hygiene
 

--- a/principles/git-workflow.md
+++ b/principles/git-workflow.md
@@ -20,7 +20,7 @@ Normal code changes go through a feature branch + PR + merge. Emergency bypasses
 
 If the project has Codex review configured (see `.codex-review.toml` for policy and the `codex-review` hook in `.pre-commit-config.yaml` for the entry point), a pre-push hook gates default-branch pushes (including squash-merges via `merge-pr.sh`). The mechanism is `stages: [pre-push]` in `.pre-commit-config.yaml`; it skips feature-branch pushes and only activates when the push target is the default branch. Behavior:
 - Runs `codex exec --full-auto` against the diff vs the default branch
-- Auto-fixes only low-risk findings (typos, missing imports, adding logging to empty exception handlers, named constants for unexplained magic numbers); anything that changes control flow, business logic, or retry/error-handling semantics stays in the PR for human review
+- Auto-fixes only low-risk findings (typos, missing imports, missing null checks, adding logging to empty exception handlers, named constants for unexplained magic numbers); anything that changes business logic or retry/error-handling semantics stays in the PR for human review
 - Blocks the push for unsafe findings (high-scrutiny paths)
 - Loops up to `max_iterations` times (default 3)
 - Gracefully skips if the Codex CLI isn't installed, printing a visible "review skipped" line so the missing safety boundary isn't silent

--- a/principles/pre-implementation-checklist.md
+++ b/principles/pre-implementation-checklist.md
@@ -1,19 +1,25 @@
 # Pre-Implementation Checklist
 
-Before implementing any fix or feature, answer these questions. If you can't answer yes to all of them, stop and discuss scope.
+Before writing code, walk through these questions. If any answer exposes duplicated infrastructure, a symptom patch, a second code path, or unclear ownership, stop and discuss scope before continuing.
 
-## 1. Does shared infrastructure already solve this?
+This checklist is a pre-flight prompt; the canonical rules live in [engineering-principles.md](engineering-principles.md).
 
-Search the project's existing shared layers (utilities, base classes, common modules) before writing new infrastructure. If a subsystem hand-rolls something the shared layer already provides, the fix is migration — not more hand-rolling.
+## 1. Am I adding to or patching local infrastructure that shared infrastructure should own?
+
+Search the project's existing shared layers (utilities, base classes, common modules) before writing or extending anything local. If a subsystem hand-rolls something the shared layer already provides, the fix is migration — not more hand-rolling. A patch on hand-rolled code deepens the debt; migration eliminates it.
 
 ## 2. Am I fixing the root cause or the symptom?
 
-If the answer is "symptom," say so explicitly: *"This patches the symptom. The root cause is X and fixing it properly would require Y. Which do you want?"* Sometimes patching the symptom is the right call (time pressure, risk, scope). But it should be a conscious choice, not an accident.
+See **No band-aids** in the engineering principles. If this is a symptom patch, the PR must say so explicitly and name the root cause. Patching a symptom is sometimes the right call (time pressure, scope, risk) — but it must be a conscious, documented choice, not an accident.
 
 ## 3. Will this create a second code path?
 
-If yes, can you delete the old one in the same PR? If not, you're adding tech debt — flag it. Two code paths that do "almost the same thing" are a maintenance trap: they drift apart silently and bugs in one don't surface until production.
+See **One code path** in the engineering principles. If you must add a divergence, can you delete the old path in the same PR? If not, document the owner, the removal condition, and a follow-up issue before merging. Two code paths that do "almost the same thing" are a maintenance trap — they drift apart silently and bugs in one don't surface until production.
 
-## 4. Does this change touch a file with hand-rolled infrastructure?
+## 4. Am I changing a public boundary?
 
-If yes, the default action is migrating to the shared infrastructure, not patching the local copy. A patch on hand-rolled code deepens the debt. Migration eliminates it.
+If this touches a public API, config file, schema, CLI flag, hook, template, or generated artifact, see **Preserve compatibility at boundaries** in the engineering principles. Downstream consumers may lag — the PR must include a compatibility or migration plan before merging.
+
+## 5. Is this action reversible?
+
+If this deletes, migrates, rewrites history, or has external side effects, see **Make irreversible actions recoverable**. The PR must describe how failure leaves the system in a known recoverable state — dry run, backup, idempotency key, rollback, or forward-fix plan.


### PR DESCRIPTION
Independent review by Codex + a best-practices survey (Ousterhout,
Beck, Google SRE, Fowler, Larson) converged on the same critiques of
the existing principles. This commit applies the agreed changes.

Tightenings:
- Intro now admits explicit, justified exceptions instead of claiming
  "non-negotiable" then contradicting itself in the emergency path.
- "Fix root causes" → allows documented symptom patches.
- "Design for scale-up" → "Derive limits from domain; test at scale
  boundaries" — doesn't ban named constants, requires scale tests.
- "Derive, don't persist" → specifies what a persisted-state comment
  must include (source, invalidation, rebuild, reconciliation).
- "No silent failures" → fallback must report what failed, what was
  skipped, and what safety boundary still holds.
- "Every fix gets a test" → the test must run in CI, not just locally.
- "Think in invariants" → requires a named invariant assertion for
  nontrivial logic.
- "One code path" → scoped to business logic; I/O/adapters allowed.
- "Current decisions from current data" → renamed "Version your data
  boundaries"; generalized from ML-shaped to any bounded data change.
- Audit §9 → one-line pointer to audit-weak-points.md (was a
  duplicated summary, violating documentation-ownership).

Additions:
- Keep interfaces narrow (Ousterhout deep modules).
- Separate behavior changes from tidying (Beck "Tidy First").
- Make irreversible actions recoverable (Bezos one-way doors, SRE).
- Preserve compatibility at boundaries (Touchstone-specific —
  propagated files break downstream silently without this rule).

Contradictions resolved:
- git-workflow "No exceptions" vs the defined emergency path →
  "normal path + disclosed emergency bypass".
- "No silent failures" vs Codex-absent graceful skip → skip must
  print a visible "review skipped" line.

Checklist rewritten:
- Q1+Q4 merged (shared vs hand-rolled were the same question).
- Q2, Q3 now point to the canonical principles instead of
  restating them (documentation-ownership compliance).
- Added Q4 (public boundary) and Q5 (reversibility) to mirror
  the two new principles.

audit-weak-points.md:
- "Search exhaustively" → "Search until the reviewed surface is
  explicit" — exhaustive is unverifiable, bounded coverage isn't.
- "Fix in tiers" → adds durable-tracking requirement and a
  guardrail-first preference for split-PR work.

documentation-ownership.md:
- "Delete the duplicate" → "identify the owner, then link; delete
  only when linking adds nothing". Deletion-before-ownership loses
  useful framing.
- Added rule 6: duplication found mid-PR gets a follow-up, not
  silence.

All 6 self-tests still pass.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
