### PR TITLE
test: guard drift between hooks/ and scripts/ codex-review.sh

### DIFF
--- a/tests/test-codex-review-sync.sh
+++ b/tests/test-codex-review-sync.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# tests/test-codex-review-sync.sh — guard against drift between the source
+# `hooks/codex-review.sh` and the `scripts/codex-review.sh` copy that every
+# touchstone self-update and every downstream `update-project.sh` writes
+# from the same source. If they diverge mid-development, the stale copy
+# gets invoked by the local pre-push hook until the next self-update, and
+# the duplication stops being safe.
+#
+set -euo pipefail
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SOURCE="$TOUCHSTONE_ROOT/hooks/codex-review.sh"
+COPY="$TOUCHSTONE_ROOT/scripts/codex-review.sh"
+
+if [ ! -f "$SOURCE" ]; then
+  echo "FAIL: expected source file missing: $SOURCE" >&2
+  exit 1
+fi
+
+if [ ! -f "$COPY" ]; then
+  echo "FAIL: expected copy missing: $COPY" >&2
+  echo "      Regenerate with: cp $SOURCE $COPY" >&2
+  exit 1
+fi
+
+if ! cmp -s "$SOURCE" "$COPY"; then
+  echo "FAIL: scripts/codex-review.sh has drifted from hooks/codex-review.sh" >&2
+  echo "      bootstrap/update-project.sh treats them as the same file." >&2
+  echo "" >&2
+  diff -u "$SOURCE" "$COPY" | head -40 >&2
+  echo "" >&2
+  echo "  Resync with: cp hooks/codex-review.sh scripts/codex-review.sh" >&2
+  exit 1
+fi
+
+echo "==> PASS: hooks/codex-review.sh and scripts/codex-review.sh are in sync"


### PR DESCRIPTION
bootstrap/update-project.sh copies hooks/codex-review.sh into
scripts/codex-review.sh on every self-update and every downstream
update, so the two files are expected to be byte-identical. If one is
edited without the other during development, the stale copy runs in
the local pre-push hook until the next self-update reconciles them.

Add a self-test that asserts `cmp -s` equivalence and surfaces a diff
when they drift.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
