### PR TITLE
chore(hooks): drop unused commit-msg install across entry points

### DIFF
--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -1007,7 +1007,7 @@ printf '\n'
 printf '    version:  %s\n' "$TOUCHSTONE_SHA"
 
 case "$HOOK_INSTALL_STATUS" in
-  0) printf '    hooks:    installed (pre-commit, pre-push, commit-msg)\n' ;;
+  0) printf '    hooks:    installed (pre-commit, pre-push)\n' ;;
   1) printf '    hooks:    SKIPPED — no .pre-commit-config.yaml (unexpected)\n' ;;
   2) printf '    hooks:    NOT INSTALLED — pre-commit CLI missing\n' ;;
   3) printf '    hooks:    PARTIAL — one or more installs failed (see above)\n' ;;

--- a/lib/install-hooks.sh
+++ b/lib/install-hooks.sh
@@ -7,6 +7,10 @@
 # the helper encodes gap states (pre-commit missing, install failures) in the
 # return status — they are not fatal errors for the caller's workflow.
 #
+# Installs pre-commit and pre-push hook types only. commit-msg is intentionally
+# skipped — no commit-msg hooks are configured in any shipped config, so
+# installing that type would create an empty shim that runs on every commit.
+#
 # Outputs progress to stdout. Returns:
 #   0  hooks installed (idempotent — safe to re-run)
 #   1  no .pre-commit-config.yaml in project_dir, nothing to do
@@ -28,7 +32,7 @@ touchstone_install_hooks() {
   if ! command -v pre-commit >/dev/null 2>&1; then
     echo "==> Git hooks skipped: pre-commit CLI is not installed."
     echo "    Install it:  brew install pre-commit  (or: pip install pre-commit)"
-    echo "    Then run:    cd \"$project_dir\" && pre-commit install --hook-type pre-commit --hook-type pre-push --hook-type commit-msg"
+    echo "    Then run:    cd \"$project_dir\" && pre-commit install --hook-type pre-commit --hook-type pre-push"
     return 2
   fi
 
@@ -37,7 +41,7 @@ touchstone_install_hooks() {
   (cd "$project_dir" && git config --unset-all core.hooksPath 2>/dev/null || true)
 
   local hook_type out status=0
-  for hook_type in pre-commit pre-push commit-msg; do
+  for hook_type in pre-commit pre-push; do
     if out="$(cd "$project_dir" && pre-commit install --hook-type "$hook_type" 2>&1)"; then
       printf '    %s\n' "$(printf '%s' "$out" | tail -1)"
     else

--- a/setup.sh
+++ b/setup.sh
@@ -254,8 +254,7 @@ if [ -f ".pre-commit-config.yaml" ]; then
   # Install hook shims (environments install lazily on first run).
   pre-commit install 2>&1 | tail -1 | while read -r line; do ok "$line"; done
   pre-commit install --hook-type pre-push 2>&1 | tail -1 | while read -r line; do ok "$line"; done
-  pre-commit install --hook-type commit-msg 2>&1 | tail -1 | while read -r line; do ok "$line"; done
-  ok "pre-commit hooks installed (pre-commit, pre-push, commit-msg)"
+  ok "pre-commit hooks installed (pre-commit, pre-push)"
 else
   warn "No .pre-commit-config.yaml found — skipping hooks"
 fi

--- a/templates/setup.sh
+++ b/templates/setup.sh
@@ -416,8 +416,7 @@ if [ -f ".pre-commit-config.yaml" ]; then
   # Install hook shims (environments install lazily on first run).
   pre-commit install 2>&1 | tail -1 | while read -r line; do ok "$line"; done
   pre-commit install --hook-type pre-push 2>&1 | tail -1 | while read -r line; do ok "$line"; done
-  pre-commit install --hook-type commit-msg 2>&1 | tail -1 | while read -r line; do ok "$line"; done
-  ok "pre-commit hooks installed (pre-commit, pre-push, commit-msg)"
+  ok "pre-commit hooks installed (pre-commit, pre-push)"
 else
   warn "No .pre-commit-config.yaml found — skipping hooks"
 fi

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -482,10 +482,6 @@ case "\$*" in
     mkdir -p .git/hooks && : > .git/hooks/pre-push
     printf 'pre-commit installed at .git/hooks/pre-push\n'
     ;;
-  "install --hook-type commit-msg")
-    mkdir -p .git/hooks && : > .git/hooks/commit-msg
-    printf 'pre-commit installed at .git/hooks/commit-msg\n'
-    ;;
   *)
     exit 0
     ;;
@@ -497,10 +493,14 @@ chmod +x "$HOOKS_FAKE_BIN/pre-commit"
 PATH="$HOOKS_FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_HOOKS_WITH" --no-register >/dev/null
 assert_contains "$HOOKS_LOG" '^install --hook-type pre-commit$'
 assert_contains "$HOOKS_LOG" '^install --hook-type pre-push$'
-assert_contains "$HOOKS_LOG" '^install --hook-type commit-msg$'
+# commit-msg install is intentionally NOT performed — no commit-msg hooks are configured.
+if grep -q '^install --hook-type commit-msg$' "$HOOKS_LOG"; then
+  echo "FAIL: commit-msg hook should not be installed — no commit-msg hooks are configured" >&2
+  ERRORS=$((ERRORS + 1))
+fi
 assert_exists "$PROJECT_HOOKS_WITH/.git/hooks/pre-commit"
 assert_exists "$PROJECT_HOOKS_WITH/.git/hooks/pre-push"
-assert_exists "$PROJECT_HOOKS_WITH/.git/hooks/commit-msg"
+assert_not_exists "$PROJECT_HOOKS_WITH/.git/hooks/commit-msg"
 
 # Bootstrap without pre-commit on PATH must print the gap, succeed (no fatal error),
 # and leave hooks uninstalled — rather than silently "succeed" with an ungated repo.


### PR DESCRIPTION
No commit-msg hooks are configured in templates/pre-commit-config.yaml
or the root .pre-commit-config.yaml, so installing that hook type just
creates an empty shim that runs on every commit. Removed from
lib/install-hooks.sh, bootstrap/new-project.sh summary, setup.sh, and
templates/setup.sh. test-bootstrap.sh now asserts commit-msg is not
installed.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
