### PR TITLE
feat(run): include build in Node validate when distinct from typecheck

### DIFF
--- a/scripts/touchstone-run.sh
+++ b/scripts/touchstone-run.sh
@@ -225,6 +225,14 @@ run_node_action() {
       fi
       ok "no package.json '$action' script; skipped"
       ;;
+    build_if_distinct)
+      # Bundler builds (webpack/vite/esbuild/turbopack) catch errors typecheck
+      # misses. Only fire when both scripts are declared — "build: tsc" (build
+      # IS typecheck) shouldn't double-run during validate.
+      if has_package_script typecheck && has_package_script build; then
+        run_node_script build
+      fi
+      ;;
     *)
       warn "unknown Node action: $action"
       return 1
@@ -270,6 +278,9 @@ run_python_action() {
         ok "python not found; skipped"
       fi
       ;;
+    build_if_distinct)
+      : # no default Python build — nothing useful to add during validate
+      ;;
     *)
       warn "unknown Python action: $action"
       return 1
@@ -301,6 +312,9 @@ run_rust_action() {
     typecheck) run_shell_command "cargo check --all-targets --all-features" ;;
     build) run_shell_command "cargo build --all" ;;
     test) run_shell_command "cargo test --all" ;;
+    build_if_distinct)
+      : # cargo check already runs the full compiler — cargo build would repeat
+      ;;
     *)
       warn "unknown Rust action: $action"
       return 1
@@ -326,6 +340,9 @@ run_swift_action() {
       ;;
     typecheck|build) run_shell_command "swift build" ;;
     test) run_shell_command "swift test" ;;
+    build_if_distinct)
+      : # swift typecheck IS swift build — running it again would repeat
+      ;;
     *)
       warn "unknown Swift action: $action"
       return 1
@@ -345,6 +362,9 @@ run_go_action() {
     lint) run_shell_command "go vet ./..." ;;
     typecheck|build) run_shell_command "go build ./..." ;;
     test) run_shell_command "go test ./..." ;;
+    build_if_distinct)
+      : # go typecheck IS go build — running it again would repeat
+      ;;
     *)
       warn "unknown Go action: $action"
       return 1
@@ -362,6 +382,12 @@ run_profile_action() {
     swift) run_swift_action "$action" ;;
     go) run_go_action "$action" ;;
     generic|"")
+      # build_if_distinct is a validate-time extra — silently no-op for generic
+      # so "touchstone run validate" doesn't print a scary "no default command"
+      # line on every non-typed project.
+      if [ "$action" = "build_if_distinct" ]; then
+        return 0
+      fi
       ok "generic project has no default '$action' command; set ${action}_command in .touchstone-config"
       ;;
     *)
@@ -437,6 +463,11 @@ run_validate() {
 
   run_action lint
   run_action typecheck
+  # Node targets with distinct typecheck + build scripts: run the bundler too.
+  # Other profiles no-op because their typecheck already runs the compiler.
+  # Distinctness is per-target, so this flows through run_targets_action just
+  # like every other action — no special-casing for monorepo vs single-package.
+  run_action build_if_distinct
   run_action test
 }
 

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -413,6 +413,40 @@ printf '{"packageManager":"pnpm@9.0.0","scripts":{"lint":"echo lint","typecheck"
 assert_contains "$RUNNER_LOG" 'pnpm|.*/test-project-node|lint'
 assert_contains "$RUNNER_LOG" 'pnpm|.*/test-project-node|typecheck'
 assert_contains "$RUNNER_LOG" 'pnpm|.*/test-project-node|test'
+# No "build" script declared — build_if_distinct must skip to avoid running a
+# nonexistent script. Regression guard for "validate runs build unconditionally".
+if grep -q 'pnpm|.*/test-project-node|build' "$RUNNER_LOG"; then
+  echo "FAIL: touchstone-run.sh validate must not run build when no build script is declared" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# Node project with BOTH typecheck and build scripts — validate must run build
+# so bundler-level errors (import paths, env, CSS modules) get caught before a
+# default-branch push, in addition to typecheck.
+PROJECT_NODE_BUILD="$TEST_DIR/test-project-node-build"
+mkdir -p "$PROJECT_NODE_BUILD/scripts"
+cp "$TOUCHSTONE_ROOT/scripts/touchstone-run.sh" "$PROJECT_NODE_BUILD/scripts/touchstone-run.sh"
+printf 'project_type=node\n' > "$PROJECT_NODE_BUILD/.touchstone-config"
+printf '{"packageManager":"pnpm@9.0.0","scripts":{"lint":"echo lint","typecheck":"echo typecheck","build":"echo build","test":"echo test"}}\n' > "$PROJECT_NODE_BUILD/package.json"
+: > "$RUNNER_LOG"
+(cd "$PROJECT_NODE_BUILD" && PATH="$RUNNER_FAKE_BIN:$PATH" RUNNER_LOG="$RUNNER_LOG" bash scripts/touchstone-run.sh validate) >/dev/null
+assert_contains "$RUNNER_LOG" 'pnpm|.*/test-project-node-build|typecheck'
+assert_contains "$RUNNER_LOG" 'pnpm|.*/test-project-node-build|build'
+assert_contains "$RUNNER_LOG" 'pnpm|.*/test-project-node-build|test'
+
+# Node project with only build, no typecheck — "build: tsc" style where build
+# IS typecheck. validate must not double-run the same command.
+PROJECT_NODE_BUILD_ONLY="$TEST_DIR/test-project-node-build-only"
+mkdir -p "$PROJECT_NODE_BUILD_ONLY/scripts"
+cp "$TOUCHSTONE_ROOT/scripts/touchstone-run.sh" "$PROJECT_NODE_BUILD_ONLY/scripts/touchstone-run.sh"
+printf 'project_type=node\n' > "$PROJECT_NODE_BUILD_ONLY/.touchstone-config"
+printf '{"packageManager":"pnpm@9.0.0","scripts":{"lint":"echo lint","build":"tsc","test":"echo test"}}\n' > "$PROJECT_NODE_BUILD_ONLY/package.json"
+: > "$RUNNER_LOG"
+(cd "$PROJECT_NODE_BUILD_ONLY" && PATH="$RUNNER_FAKE_BIN:$PATH" RUNNER_LOG="$RUNNER_LOG" bash scripts/touchstone-run.sh validate) >/dev/null
+if grep -q 'pnpm|.*/test-project-node-build-only|build' "$RUNNER_LOG"; then
+  echo "FAIL: build should not run during validate when typecheck is absent (build IS typecheck)" >&2
+  ERRORS=$((ERRORS + 1))
+fi
 
 SWIFT_PROJECT="$TEST_DIR/swift-runner"
 mkdir -p "$SWIFT_PROJECT/scripts"


### PR DESCRIPTION
validate now runs lint -> typecheck -> build_if_distinct -> test. The new
build_if_distinct action is a no-op for every profile except Node; for
Node it invokes the "build" package.json script only when a "typecheck"
script is also declared. This catches bundler-level errors (import paths,
env resolution, CSS modules, worker imports) that typecheck alone misses,
without double-running when build IS typecheck ("build: tsc").

Rust/Swift/Go stay unchanged — their typecheck already runs the compiler.
Python also stays unchanged (no default build step). Generic projects
silently no-op instead of printing the "no default command" line so
validate output doesn't grow noisier on untyped repos.

Because the dispatch flows through run_action -> run_targets_action,
monorepo targets get the same per-target distinctness check: only Node
targets with both scripts run build during validate.

Tests added: Node with typecheck+build runs build, Node with build-only
(no typecheck) skips build, regression guard on the existing typecheck+
test-only case.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
