### PR TITLE
chore: dogfood touchstone-validate path in Touchstone's own pre-push

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,12 +27,16 @@ repos:
         always_run: true
         pass_filenames: false
 
-  # Self-tests (run on pre-push alongside Codex review)
+  # Self-tests via the same touchstone-run.sh validate path downstream projects
+  # use. Touchstone's .touchstone-config sets validate_command to loop through
+  # tests/test-*.sh — this means any change to the validate dispatcher that
+  # breaks the downstream flow also breaks Touchstone's own pre-push, so the
+  # dogfood discipline catches regressions the templates would otherwise hide.
   - repo: local
     hooks:
-      - id: self-tests
-        name: Touchstone self-tests
-        entry: /usr/bin/env bash -c 'set -e; for test in tests/test-*.sh; do /usr/bin/env bash "$test"; done'
+      - id: touchstone-validate
+        name: Touchstone project validation
+        entry: /usr/bin/env bash scripts/touchstone-run.sh validate
         language: system
         stages: [pre-push]
         always_run: true

--- a/.touchstone-config
+++ b/.touchstone-config
@@ -1,0 +1,18 @@
+# touchstone project profile. Commit this file so all clones use the same commands.
+#
+# Touchstone dogfoods its own validate path: the pre-push hook runs
+# `scripts/touchstone-run.sh validate`, which reads this file and executes
+# validate_command below. That loops through every tests/test-*.sh script —
+# the same coverage as the previous bespoke self-tests pre-commit hook, but
+# routed through the shared entrypoint downstream projects use.
+project_type=generic
+package_manager=auto
+monorepo=false
+targets=
+git_workflow=git
+gitbutler_mcp=false
+lint_command=
+typecheck_command=
+build_command=
+test_command=
+validate_command=for t in tests/test-*.sh; do bash "$t" || exit 1; done

--- a/tests/test-dogfood.sh
+++ b/tests/test-dogfood.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# tests/test-dogfood.sh — verify Touchstone's own repo uses the same validate
+# entrypoint it ships to downstream projects. A regression here would mean
+# the shared entrypoint could break without anyone noticing until a downstream
+# project tried to use it.
+#
+set -euo pipefail
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PRE_COMMIT_CONFIG="$TOUCHSTONE_ROOT/.pre-commit-config.yaml"
+TOUCHSTONE_CONFIG="$TOUCHSTONE_ROOT/.touchstone-config"
+
+if [ ! -f "$PRE_COMMIT_CONFIG" ]; then
+  echo "FAIL: $PRE_COMMIT_CONFIG is missing" >&2
+  exit 1
+fi
+
+# Touchstone must gate pushes via the same touchstone-validate hook downstream
+# projects get from templates/pre-commit-config.yaml — otherwise a regression
+# in the dispatcher only surfaces on downstream projects.
+if ! grep -q 'id: touchstone-validate' "$PRE_COMMIT_CONFIG"; then
+  echo "FAIL: $PRE_COMMIT_CONFIG must dogfood the touchstone-validate hook" >&2
+  echo "      Downstream projects use this hook; Touchstone must exercise the same path." >&2
+  exit 1
+fi
+
+if ! grep -q 'scripts/touchstone-run.sh validate' "$PRE_COMMIT_CONFIG"; then
+  echo "FAIL: touchstone-validate hook must invoke scripts/touchstone-run.sh validate" >&2
+  exit 1
+fi
+
+# The bespoke self-tests hook was retired in favor of routing through the shared
+# validate entrypoint. Re-adding it would break the dogfood loop.
+if grep -q 'id: self-tests' "$PRE_COMMIT_CONFIG"; then
+  echo "FAIL: the bespoke 'self-tests' hook was replaced by 'touchstone-validate' — do not re-add it" >&2
+  exit 1
+fi
+
+# .touchstone-config must set a validate_command that actually runs the
+# self-tests; an empty validate_command would silently reduce coverage to
+# zero since touchstone is a generic project with no profile defaults.
+if [ ! -f "$TOUCHSTONE_CONFIG" ]; then
+  echo "FAIL: $TOUCHSTONE_CONFIG is missing — the validate hook would no-op without it" >&2
+  exit 1
+fi
+
+VALIDATE_LINE="$(sed -n 's/^validate_command[[:space:]]*=[[:space:]]*//p' "$TOUCHSTONE_CONFIG" | head -1)"
+if [ -z "$VALIDATE_LINE" ]; then
+  echo "FAIL: validate_command in $TOUCHSTONE_CONFIG is empty — dogfood loop has no coverage" >&2
+  exit 1
+fi
+
+if ! printf '%s' "$VALIDATE_LINE" | grep -q 'tests/test-\*\.sh'; then
+  echo "FAIL: validate_command must exercise tests/test-*.sh to cover the full self-test surface" >&2
+  echo "      Current value: $VALIDATE_LINE" >&2
+  exit 1
+fi
+
+echo "==> PASS: Touchstone dogfoods its own validate path"


### PR DESCRIPTION
Replaced the bespoke self-tests pre-commit hook with the same
touchstone-validate hook downstream projects get from templates/. The
hook invokes scripts/touchstone-run.sh validate, which reads the new
.touchstone-config and executes the validate_command loop over every
tests/test-*.sh script. Same coverage as before; now routed through the
shared entrypoint.

Why it matters: a regression in the validate dispatcher (run_validate,
run_action, run_targets_action, or any profile handler) now also breaks
Touchstone's own pre-push — so dogfood discipline catches dispatch-layer
bugs before they reach a downstream project. Previously the bespoke
for-loop hook meant touchstone-run.sh could silently rot between
downstream deployments.

Added tests/test-dogfood.sh as the guardrail: fails if the
touchstone-validate hook goes missing, if scripts/touchstone-run.sh
validate is replaced, if the old self-tests hook reappears, or if
validate_command is emptied / stops covering tests/test-*.sh.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
