### PR TITLE
feat(ci): add opt-in GitHub Actions validate workflow template

### DIFF
--- a/bin/touchstone
+++ b/bin/touchstone
@@ -76,12 +76,12 @@ escape_sed_replacement() {
 
 cmd_new() {
   if [ "$#" -lt 1 ]; then
-    echo "Usage: touchstone new <project-dir> [--no-register] [--type node|python|swift|rust|go|generic|auto] [--unsafe-paths path1,path2] [--reviewer codex|claude|gemini|local|auto|none] [--review-routing all-hosted|all-local|small-local] [--gitbutler|--no-gitbutler]" >&2
+    echo "Usage: touchstone new <project-dir> [--no-register] [--type node|python|swift|rust|go|generic|auto] [--unsafe-paths path1,path2] [--reviewer codex|claude|gemini|local|auto|none] [--review-routing all-hosted|all-local|small-local] [--gitbutler|--no-gitbutler] [--ci github|--no-ci]" >&2
     exit 1
   fi
   case "${1:-}" in
     -h|--help)
-      echo "Usage: touchstone new <project-dir> [--no-register] [--type node|python|swift|rust|go|generic|auto] [--unsafe-paths path1,path2] [--reviewer codex|claude|gemini|local|auto|none] [--review-routing all-hosted|all-local|small-local] [--small-review-lines N] [--gitbutler|--no-gitbutler] [--gitbutler-mcp|--no-gitbutler-mcp]"
+      echo "Usage: touchstone new <project-dir> [--no-register] [--type node|python|swift|rust|go|generic|auto] [--unsafe-paths path1,path2] [--reviewer codex|claude|gemini|local|auto|none] [--review-routing all-hosted|all-local|small-local] [--small-review-lines N] [--gitbutler|--no-gitbutler] [--gitbutler-mcp|--no-gitbutler-mcp] [--ci github|--no-ci]"
       return 0
       ;;
   esac
@@ -110,7 +110,7 @@ cmd_init() {
         shift
         ;;
       -h|--help)
-        echo "Usage: touchstone init [--no-setup] [--no-ship] [--type node|python|swift|rust|go|generic|auto] [--no-register] [--unsafe-paths path1,path2] [--reviewer codex|claude|gemini|local|auto|none] [--review-routing all-hosted|all-local|small-local] [--small-review-lines N] [--gitbutler|--no-gitbutler] [--gitbutler-mcp|--no-gitbutler-mcp]"
+        echo "Usage: touchstone init [--no-setup] [--no-ship] [--type node|python|swift|rust|go|generic|auto] [--no-register] [--unsafe-paths path1,path2] [--reviewer codex|claude|gemini|local|auto|none] [--review-routing all-hosted|all-local|small-local] [--small-review-lines N] [--gitbutler|--no-gitbutler] [--gitbutler-mcp|--no-gitbutler-mcp] [--ci github|--no-ci]"
         return 0
         ;;
       --type)
@@ -141,13 +141,23 @@ cmd_init() {
         args+=("$1" "$2")
         shift 2
         ;;
-      --no-ai-review|--no-review|--review-assist|--no-review-assist|--review-autofix|--no-review-autofix|--gitbutler|--no-gitbutler|--gitbutler-mcp|--no-gitbutler-mcp)
+      --ci)
+        # --ci may stand alone (defaults to github) or take a value.
+        if [ "$#" -ge 2 ] && [[ "$2" != --* ]]; then
+          args+=("$1" "$2")
+          shift 2
+        else
+          args+=("$1")
+          shift
+        fi
+        ;;
+      --no-ai-review|--no-review|--review-assist|--no-review-assist|--review-autofix|--no-review-autofix|--gitbutler|--no-gitbutler|--gitbutler-mcp|--no-gitbutler-mcp|--no-ci)
         args+=("$1")
         shift
         ;;
       *)
         echo "ERROR: unknown argument '$1'" >&2
-        echo "Usage: touchstone init [--no-setup] [--no-ship] [--type node|python|swift|rust|go|generic|auto] [--no-register] [--unsafe-paths path1,path2] [--reviewer codex|claude|gemini|local|auto|none] [--review-routing all-hosted|all-local|small-local] [--gitbutler|--no-gitbutler]" >&2
+        echo "Usage: touchstone init [--no-setup] [--no-ship] [--type node|python|swift|rust|go|generic|auto] [--no-register] [--unsafe-paths path1,path2] [--reviewer codex|claude|gemini|local|auto|none] [--review-routing all-hosted|all-local|small-local] [--gitbutler|--no-gitbutler] [--ci github]" >&2
         exit 1
         ;;
     esac

--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -37,11 +37,12 @@ INPUT_REVIEW_ROUTING=""
 INPUT_SMALL_REVIEW_LINES=""
 INPUT_GIT_WORKFLOW=""
 INPUT_GITBUTLER_MCP=""
+INPUT_CI=""
 REVIEW_CONFIG_REQUESTED=false
 WORKFLOW_CONFIG_REQUESTED=false
 
 usage() {
-  echo "Usage: $0 <project-dir> [--no-register] [--type node|python|swift|rust|go|generic|auto] [--unsafe-paths path1,path2] [--reviewer codex|claude|gemini|local|auto|none] [--review-routing all-hosted|all-local|small-local] [--small-review-lines N] [--review-assist|--no-review-assist] [--review-autofix|--no-review-autofix] [--local-review-command <command>] [--gitbutler|--no-gitbutler] [--gitbutler-mcp|--no-gitbutler-mcp]"
+  echo "Usage: $0 <project-dir> [--no-register] [--type node|python|swift|rust|go|generic|auto] [--unsafe-paths path1,path2] [--reviewer codex|claude|gemini|local|auto|none] [--review-routing all-hosted|all-local|small-local] [--small-review-lines N] [--review-assist|--no-review-assist] [--review-autofix|--no-review-autofix] [--local-review-command <command>] [--gitbutler|--no-gitbutler] [--gitbutler-mcp|--no-gitbutler-mcp] [--ci github|none]"
 }
 
 trim() {
@@ -436,6 +437,23 @@ while [ "$#" -gt 0 ]; do
       WORKFLOW_CONFIG_REQUESTED=true
       shift
       ;;
+    --ci)
+      # Accept either `--ci` alone (defaults to github) or `--ci <provider>`
+      # for future providers (gitlab, circle). For now only github is shipped.
+      if [ "$#" -ge 2 ] && [[ "$2" != --* ]]; then
+        case "$2" in
+          github|none) INPUT_CI="$2"; shift 2 ;;
+          *) echo "ERROR: --ci value must be one of: github, none" >&2; exit 1 ;;
+        esac
+      else
+        INPUT_CI="github"
+        shift
+      fi
+      ;;
+    --no-ci)
+      INPUT_CI="none"
+      shift
+      ;;
     *) echo "ERROR: unknown argument '$1'" >&2; exit 1 ;;
   esac
 done
@@ -761,6 +779,19 @@ copy_file_force "$TOUCHSTONE_ROOT/scripts/open-pr.sh" "$PROJECT_DIR/scripts/open
 copy_file_force "$TOUCHSTONE_ROOT/scripts/merge-pr.sh" "$PROJECT_DIR/scripts/merge-pr.sh"
 copy_file_force "$TOUCHSTONE_ROOT/scripts/cleanup-branches.sh" "$PROJECT_DIR/scripts/cleanup-branches.sh"
 chmod +x "$PROJECT_DIR/scripts/"*.sh
+
+# Optional CI workflow — opt-in via --ci. Not copied by default because not every
+# project uses GitHub Actions, and shipping a workflow file silently into every
+# bootstrap would force that opinion on GitLab/Bitbucket/self-hosted users.
+CI_WORKFLOW_CREATED=false
+if [ "$INPUT_CI" = "github" ]; then
+  echo ""
+  echo "==> Adding CI workflow (project-owned, won't be auto-updated):"
+  copy_file "$TOUCHSTONE_ROOT/templates/ci/github-validate.yml" "$PROJECT_DIR/.github/workflows/validate.yml"
+  if [ "$LAST_COPY_CREATED" = true ]; then
+    CI_WORKFLOW_CREATED=true
+  fi
+fi
 
 # Write touchstone version.
 # Use git SHA if this is a git clone, otherwise use VERSION (brew install).

--- a/templates/ci/github-validate.yml
+++ b/templates/ci/github-validate.yml
@@ -1,0 +1,51 @@
+# Touchstone-provided starter CI workflow. Runs the same pre-commit hygiene
+# checks and `scripts/touchstone-run.sh validate` path that gate local pre-push.
+# A CI failure here means the same thing a pre-push rejection would mean locally.
+#
+# `touchstone-run.sh validate` silently skips when profile linters/tests are
+# absent (correct runtime UX). In CI that's useless — install your profile's
+# toolchain in the block below before the validate step, or CI will pass on
+# gaps pre-push would catch.
+
+name: validate
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # --- Add profile-specific toolchain steps here ---
+      # Node:
+      #   - uses: actions/setup-node@v4
+      #     with:
+      #       node-version: '20'
+      #       cache: 'pnpm'
+      # Python:
+      #   - uses: actions/setup-python@v5
+      #     with:
+      #       python-version: '3.12'
+      # Rust:
+      #   - uses: dtolnay/rust-toolchain@stable
+      # Go:
+      #   - uses: actions/setup-go@v5
+      #     with:
+      #       go-version: '1.23'
+      # Swift:
+      #   - uses: swift-actions/setup-swift@v2
+
+      - name: Install pre-commit
+        run: pipx install pre-commit
+
+      - name: Run pre-commit hygiene
+        run: pre-commit run --all-files --hook-stage pre-commit --show-diff-on-failure
+
+      - name: Run touchstone validate
+        run: bash scripts/touchstone-run.sh validate

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -63,6 +63,8 @@ PROJECT_REVIEW_NONE="$TEST_DIR/test-project-review-none"
 PROJECT_REVIEW_LOCAL="$TEST_DIR/test-project-review-local"
 PROJECT_REVIEW_HYBRID="$TEST_DIR/test-project-review-hybrid"
 PROJECT_GITBUTLER="$TEST_DIR/test-project-gitbutler"
+PROJECT_CI_OFF="$TEST_DIR/test-project-ci-off"
+PROJECT_CI_GITHUB="$TEST_DIR/test-project-ci-github"
 PROJECT_HOOKS_WITH="$TEST_DIR/test-project-hooks-with"
 PROJECT_HOOKS_WITHOUT="$TEST_DIR/test-project-hooks-without"
 PROJECT_PYTEST_EMPTY="$TEST_DIR/test-project-pytest-empty"
@@ -234,6 +236,25 @@ assert_contains "$PROJECT_REVIEW_HYBRID/.codex-review.toml" '^command = "local-r
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_GITBUTLER" --no-register --gitbutler --gitbutler-mcp
 assert_contains "$PROJECT_GITBUTLER/.touchstone-config" '^git_workflow=gitbutler$'
 assert_contains "$PROJECT_GITBUTLER/.touchstone-config" '^gitbutler_mcp=true$'
+
+# CI workflow is opt-in. Default bootstrap must NOT ship .github/workflows/validate.yml
+# — not every project uses GitHub Actions and silently adding a workflow would force
+# that opinion on GitLab/Bitbucket/self-hosted users.
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_CI_OFF" --no-register >/dev/null
+assert_not_exists "$PROJECT_CI_OFF/.github/workflows/validate.yml"
+
+# --ci (github) adds the validate workflow and keeps it project-owned.
+# The workflow must call scripts/touchstone-run.sh validate so CI exercises
+# the same dispatch path local pre-push does.
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_CI_GITHUB" --no-register --ci github >/dev/null
+assert_exists "$PROJECT_CI_GITHUB/.github/workflows/validate.yml"
+assert_contains "$PROJECT_CI_GITHUB/.github/workflows/validate.yml" 'scripts/touchstone-run.sh validate'
+# The workflow is project-owned — absent from the manifest so touchstone update
+# leaves the user's CI customizations alone.
+if grep -q '^.github/workflows/validate\.yml$' "$PROJECT_CI_GITHUB/.touchstone-manifest"; then
+  echo "FAIL: .github/workflows/validate.yml must be project-owned, not tracked in the manifest" >&2
+  ERRORS=$((ERRORS + 1))
+fi
 
 # touchstone init must not run a pre-existing project setup.sh after preserving it.
 mkdir -p "$PROJECT_INIT_EXISTING_SETUP"


### PR DESCRIPTION
New templates/ci/github-validate.yml mirrors the local pre-push gate:
installs pre-commit, runs pre-commit-stage hygiene hooks, then invokes
scripts/touchstone-run.sh validate. Copied to .github/workflows/validate.yml
only when the user passes --ci github — no auto-copy because not every
project uses GitHub Actions, and silently shipping a workflow would
force that opinion on GitLab/Bitbucket/self-hosted users.

The template has placeholder comments for profile-specific toolchain
installation (setup-node, setup-python, rust-toolchain, etc.) because
validate silently skips when tools aren't on PATH — correct runtime UX,
useless as a CI gate. Projects extend the template with their stack.

Wired through both `touchstone new --ci` and `touchstone init --ci`,
with --no-ci as the explicit opt-out. The workflow is project-owned
(not tracked in .touchstone-manifest) so touchstone update leaves the
user's CI customizations alone.

Tests added: default bootstrap does not ship the workflow, --ci github
ships it with the validate invocation, and it stays out of the manifest.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
