### PR TITLE
feat(bootstrap): add --scaffold-tests for Python, Node, and Go profiles

### DIFF
--- a/bin/touchstone
+++ b/bin/touchstone
@@ -759,31 +759,34 @@ _touchstone_doctor_check_lint() {
 # Profile-aware test-presence heuristic. Matches typical layout conventions
 # without running the language's test discovery — speed matters here, and the
 # check is a nudge, not an authoritative answer.
+#
+# Every profile's check must look for test FILES, never just the convention
+# directory — an empty tests/ (or one with only helpers) is not tests.
+# Reporting an empty directory as "tests found" would preserve the silent-skip
+# gap this check exists to close.
 _touchstone_profile_has_tests() {
   local profile="$1" dir="$2" matches
   case "$profile" in
     python)
-      [ -d "$dir/tests" ] && return 0
       matches="$(find "$dir" -maxdepth 3 -type f \
         \( -name 'test_*.py' -o -name '*_test.py' \) -print -quit 2>/dev/null || true)"
       [ -n "$matches" ]
       ;;
     node)
-      if [ -d "$dir/__tests__" ] || [ -d "$dir/tests" ] || [ -d "$dir/test" ] \
-         || [ -d "$dir/src/__tests__" ]; then
-        return 0
-      fi
       matches="$(find "$dir" -maxdepth 4 -type f \
         \( -name '*.test.ts' -o -name '*.test.tsx' -o -name '*.test.js' -o -name '*.test.jsx' \
            -o -name '*.spec.ts' -o -name '*.spec.js' \) -print -quit 2>/dev/null || true)"
       [ -n "$matches" ]
       ;;
     rust)
-      [ -d "$dir/tests" ] && return 0
+      # Rust: tests/*.rs are integration tests; #[test] attributes live in src/.
+      matches="$(find "$dir/tests" -maxdepth 2 -type f -name '*.rs' -print -quit 2>/dev/null || true)"
+      [ -n "$matches" ] && return 0
       [ -d "$dir/src" ] && grep -rlq '#\[test\]' "$dir/src" 2>/dev/null
       ;;
     swift)
-      [ -d "$dir/Tests" ]
+      matches="$(find "$dir/Tests" -maxdepth 3 -type f -name '*.swift' -print -quit 2>/dev/null || true)"
+      [ -n "$matches" ]
       ;;
     go)
       matches="$(find "$dir" -maxdepth 4 -type f -name '*_test.go' -print -quit 2>/dev/null || true)"

--- a/bin/touchstone
+++ b/bin/touchstone
@@ -76,12 +76,12 @@ escape_sed_replacement() {
 
 cmd_new() {
   if [ "$#" -lt 1 ]; then
-    echo "Usage: touchstone new <project-dir> [--no-register] [--type node|python|swift|rust|go|generic|auto] [--unsafe-paths path1,path2] [--reviewer codex|claude|gemini|local|auto|none] [--review-routing all-hosted|all-local|small-local] [--gitbutler|--no-gitbutler] [--ci github|--no-ci]" >&2
+    echo "Usage: touchstone new <project-dir> [--no-register] [--type node|python|swift|rust|go|generic|auto] [--unsafe-paths path1,path2] [--reviewer codex|claude|gemini|local|auto|none] [--review-routing all-hosted|all-local|small-local] [--gitbutler|--no-gitbutler] [--ci github|--no-ci] [--scaffold-tests]" >&2
     exit 1
   fi
   case "${1:-}" in
     -h|--help)
-      echo "Usage: touchstone new <project-dir> [--no-register] [--type node|python|swift|rust|go|generic|auto] [--unsafe-paths path1,path2] [--reviewer codex|claude|gemini|local|auto|none] [--review-routing all-hosted|all-local|small-local] [--small-review-lines N] [--gitbutler|--no-gitbutler] [--gitbutler-mcp|--no-gitbutler-mcp] [--ci github|--no-ci]"
+      echo "Usage: touchstone new <project-dir> [--no-register] [--type node|python|swift|rust|go|generic|auto] [--unsafe-paths path1,path2] [--reviewer codex|claude|gemini|local|auto|none] [--review-routing all-hosted|all-local|small-local] [--small-review-lines N] [--gitbutler|--no-gitbutler] [--gitbutler-mcp|--no-gitbutler-mcp] [--ci github|--no-ci] [--scaffold-tests]"
       return 0
       ;;
   esac
@@ -110,7 +110,7 @@ cmd_init() {
         shift
         ;;
       -h|--help)
-        echo "Usage: touchstone init [--no-setup] [--no-ship] [--type node|python|swift|rust|go|generic|auto] [--no-register] [--unsafe-paths path1,path2] [--reviewer codex|claude|gemini|local|auto|none] [--review-routing all-hosted|all-local|small-local] [--small-review-lines N] [--gitbutler|--no-gitbutler] [--gitbutler-mcp|--no-gitbutler-mcp] [--ci github|--no-ci]"
+        echo "Usage: touchstone init [--no-setup] [--no-ship] [--type node|python|swift|rust|go|generic|auto] [--no-register] [--unsafe-paths path1,path2] [--reviewer codex|claude|gemini|local|auto|none] [--review-routing all-hosted|all-local|small-local] [--small-review-lines N] [--gitbutler|--no-gitbutler] [--gitbutler-mcp|--no-gitbutler-mcp] [--ci github|--no-ci] [--scaffold-tests]"
         return 0
         ;;
       --type)
@@ -157,7 +157,7 @@ cmd_init() {
         ;;
       *)
         echo "ERROR: unknown argument '$1'" >&2
-        echo "Usage: touchstone init [--no-setup] [--no-ship] [--type node|python|swift|rust|go|generic|auto] [--no-register] [--unsafe-paths path1,path2] [--reviewer codex|claude|gemini|local|auto|none] [--review-routing all-hosted|all-local|small-local] [--gitbutler|--no-gitbutler] [--ci github]" >&2
+        echo "Usage: touchstone init [--no-setup] [--no-ship] [--type node|python|swift|rust|go|generic|auto] [--no-register] [--unsafe-paths path1,path2] [--reviewer codex|claude|gemini|local|auto|none] [--review-routing all-hosted|all-local|small-local] [--gitbutler|--no-gitbutler] [--ci github|--no-ci] [--scaffold-tests]" >&2
         exit 1
         ;;
     esac
@@ -773,9 +773,13 @@ _touchstone_profile_has_tests() {
       [ -n "$matches" ]
       ;;
     node)
+      # Kept in sync with bootstrap/new-project.sh:_profile_has_any_tests_node.
+      # Covers .test.{ts,tsx,js,jsx} and .spec.{ts,tsx,js,jsx} — React/TS
+      # projects commonly declare "*.spec.tsx" files under src/.
       matches="$(find "$dir" -maxdepth 4 -type f \
         \( -name '*.test.ts' -o -name '*.test.tsx' -o -name '*.test.js' -o -name '*.test.jsx' \
-           -o -name '*.spec.ts' -o -name '*.spec.js' \) -print -quit 2>/dev/null || true)"
+           -o -name '*.spec.ts' -o -name '*.spec.tsx' -o -name '*.spec.js' -o -name '*.spec.jsx' \) \
+        -print -quit 2>/dev/null || true)"
       [ -n "$matches" ]
       ;;
     rust)

--- a/bin/touchstone
+++ b/bin/touchstone
@@ -151,7 +151,7 @@ cmd_init() {
           shift
         fi
         ;;
-      --no-ai-review|--no-review|--review-assist|--no-review-assist|--review-autofix|--no-review-autofix|--gitbutler|--no-gitbutler|--gitbutler-mcp|--no-gitbutler-mcp|--no-ci)
+      --no-ai-review|--no-review|--review-assist|--no-review-assist|--review-autofix|--no-review-autofix|--gitbutler|--no-gitbutler|--gitbutler-mcp|--no-gitbutler-mcp|--no-ci|--scaffold-tests)
         args+=("$1")
         shift
         ;;

--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -429,21 +429,19 @@ GOTEST
 }
 
 _profile_has_any_tests_python() {
-  local dir="$1"
-  [ -d "$dir/tests" ] && return 0
-  local matches
+  local dir="$1" matches
+  # Match discoverable test FILES, not merely a tests/ directory — an empty
+  # tests/ (or one with only __init__.py / helpers) doesn't satisfy the
+  # purpose of scaffolding and leaves the "validate silently skips" gap open.
   matches="$(find "$dir" -maxdepth 3 -type f \
     \( -name 'test_*.py' -o -name '*_test.py' \) -print -quit 2>/dev/null || true)"
   [ -n "$matches" ]
 }
 
 _profile_has_any_tests_node() {
-  local dir="$1"
-  if [ -d "$dir/__tests__" ] || [ -d "$dir/tests" ] || [ -d "$dir/test" ] \
-     || [ -d "$dir/src/__tests__" ]; then
-    return 0
-  fi
-  local matches
+  local dir="$1" matches
+  # Same reason as Python — treating any __tests__/tests/test directory as
+  # "tests present" lets empty scaffolds pass through silently.
   matches="$(find "$dir" -maxdepth 4 -type f \
     \( -name '*.test.ts' -o -name '*.test.tsx' -o -name '*.test.js' -o -name '*.test.jsx' \
        -o -name '*.spec.ts' -o -name '*.spec.js' \) -print -quit 2>/dev/null || true)"
@@ -1045,7 +1043,13 @@ if [ -t 0 ] && [ "$RE_INIT" = false ] && [ "$CLAUDE_MD_CREATED" = true ]; then
   fi
 fi
 
-# Default project type if not set.
+# Default project type if not set. On re-init (.touchstone-config already
+# exists), read the profile from config before falling back to manifest
+# detection — otherwise per-profile flags like --scaffold-tests would dispatch
+# to the WRONG profile when the user doesn't re-pass --type on every call.
+if [ -z "$INPUT_TYPE" ] && [ -f "$PROJECT_DIR/.touchstone-config" ]; then
+  INPUT_TYPE="$(sed -n 's/^[[:space:]]*project_type[[:space:]]*=[[:space:]]*//p' "$PROJECT_DIR/.touchstone-config" | head -1)"
+fi
 INPUT_TYPE="${INPUT_TYPE:-auto}"
 INPUT_TYPE="$(normalize_project_type "$INPUT_TYPE")"
 if [ "$INPUT_TYPE" = "auto" ]; then

--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -457,6 +457,45 @@ _profile_has_any_tests_go() {
   [ -n "$matches" ]
 }
 
+# Resolve the project profile exactly like scripts/touchstone-run.sh:load_config
+# and bin/touchstone:cmd_doctor_project do, so per-profile flags here dispatch
+# against the same profile the runner and doctor would use:
+#   - project_type= and profile= are aliases for the same slot, last-write-wins
+#   - empty or "auto" -> detect from manifest files
+#   - "generic" with a detected non-generic profile -> upgrade to the detected
+resolve_project_type_from_config() {
+  local dir="$1" line value candidate result=""
+
+  if [ -f "$dir/.touchstone-config" ]; then
+    while IFS= read -r line || [ -n "$line" ]; do
+      line="${line#"${line%%[![:space:]]*}"}"
+      case "$line" in \#*|"") continue ;; esac
+      case "$line" in *=*) ;; *) continue ;; esac
+      candidate="${line%%=*}"
+      candidate="${candidate#"${candidate%%[![:space:]]*}"}"
+      candidate="${candidate%"${candidate##*[![:space:]]}"}"
+      case "$candidate" in
+        project_type|profile)
+          value="${line#*=}"
+          value="${value#"${value%%[![:space:]]*}"}"
+          value="${value%"${value##*[![:space:]]}"}"
+          result="$value"
+          ;;
+      esac
+    done < "$dir/.touchstone-config"
+  fi
+
+  if [ -z "$result" ] || [ "$result" = "auto" ]; then
+    result="$(detect_project_type "$dir")"
+  elif [ "$result" = "generic" ]; then
+    local detected
+    detected="$(detect_project_type "$dir")"
+    [ "$detected" != "generic" ] && result="$detected"
+  fi
+
+  printf '%s' "$result"
+}
+
 if [ "$#" -lt 1 ]; then
   usage >&2
   exit 1
@@ -1046,12 +1085,13 @@ if [ -t 0 ] && [ "$RE_INIT" = false ] && [ "$CLAUDE_MD_CREATED" = true ]; then
   fi
 fi
 
-# Default project type if not set. On re-init (.touchstone-config already
-# exists), read the profile from config before falling back to manifest
-# detection — otherwise per-profile flags like --scaffold-tests would dispatch
-# to the WRONG profile when the user doesn't re-pass --type on every call.
+# Default project type if not set. Mirror the runner's resolution so a flag
+# like --scaffold-tests dispatches against the same profile that validate
+# and doctor see — otherwise a config like "project_type=generic\nprofile=python"
+# or "project_type=generic" plus an added pyproject.toml would silently
+# demote the flag to generic while the rest of the stack runs Python.
 if [ -z "$INPUT_TYPE" ] && [ -f "$PROJECT_DIR/.touchstone-config" ]; then
-  INPUT_TYPE="$(sed -n 's/^[[:space:]]*project_type[[:space:]]*=[[:space:]]*//p' "$PROJECT_DIR/.touchstone-config" | head -1)"
+  INPUT_TYPE="$(resolve_project_type_from_config "$PROJECT_DIR")"
 fi
 INPUT_TYPE="${INPUT_TYPE:-auto}"
 INPUT_TYPE="$(normalize_project_type "$INPUT_TYPE")"

--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -441,10 +441,13 @@ _profile_has_any_tests_python() {
 _profile_has_any_tests_node() {
   local dir="$1" matches
   # Same reason as Python — treating any __tests__/tests/test directory as
-  # "tests present" lets empty scaffolds pass through silently.
+  # "tests present" lets empty scaffolds pass through silently. Covers all
+  # four extension pairs (.ts/.tsx/.js/.jsx) for both .test.* and .spec.*
+  # conventions — React/TS projects commonly use Button.spec.tsx.
   matches="$(find "$dir" -maxdepth 4 -type f \
     \( -name '*.test.ts' -o -name '*.test.tsx' -o -name '*.test.js' -o -name '*.test.jsx' \
-       -o -name '*.spec.ts' -o -name '*.spec.js' \) -print -quit 2>/dev/null || true)"
+       -o -name '*.spec.ts' -o -name '*.spec.tsx' -o -name '*.spec.js' -o -name '*.spec.jsx' \) \
+    -print -quit 2>/dev/null || true)"
   [ -n "$matches" ]
 }
 

--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -38,11 +38,12 @@ INPUT_SMALL_REVIEW_LINES=""
 INPUT_GIT_WORKFLOW=""
 INPUT_GITBUTLER_MCP=""
 INPUT_CI=""
+INPUT_SCAFFOLD_TESTS=false
 REVIEW_CONFIG_REQUESTED=false
 WORKFLOW_CONFIG_REQUESTED=false
 
 usage() {
-  echo "Usage: $0 <project-dir> [--no-register] [--type node|python|swift|rust|go|generic|auto] [--unsafe-paths path1,path2] [--reviewer codex|claude|gemini|local|auto|none] [--review-routing all-hosted|all-local|small-local] [--small-review-lines N] [--review-assist|--no-review-assist] [--review-autofix|--no-review-autofix] [--local-review-command <command>] [--gitbutler|--no-gitbutler] [--gitbutler-mcp|--no-gitbutler-mcp] [--ci github|none]"
+  echo "Usage: $0 <project-dir> [--no-register] [--type node|python|swift|rust|go|generic|auto] [--unsafe-paths path1,path2] [--reviewer codex|claude|gemini|local|auto|none] [--review-routing all-hosted|all-local|small-local] [--small-review-lines N] [--review-assist|--no-review-assist] [--review-autofix|--no-review-autofix] [--local-review-command <command>] [--gitbutler|--no-gitbutler] [--gitbutler-mcp|--no-gitbutler-mcp] [--ci github|none] [--scaffold-tests]"
 }
 
 trim() {
@@ -326,6 +327,128 @@ detect_targets() {
   printf '%s\n' "$targets"
 }
 
+# Profile-aware test scaffolder. Called only when --scaffold-tests is set.
+# Writes exactly one smoke test per profile when no tests already exist —
+# never overwrites, so re-running with the flag on a project that has real
+# tests is a no-op. Framework-agnostic filenames so whatever the project
+# adopts later (vitest/jest/bun test; pytest; go test; cargo test) discovers
+# these without config changes.
+scaffold_smoke_test_for_profile() {
+  local project_dir="$1" profile="$2"
+
+  case "$profile" in
+    python)
+      if _profile_has_any_tests_python "$project_dir"; then
+        echo "==> tests: already present; skipping scaffold"
+        return 0
+      fi
+      mkdir -p "$project_dir/tests"
+      if [ ! -f "$project_dir/tests/__init__.py" ]; then
+        : > "$project_dir/tests/__init__.py"
+      fi
+      cat > "$project_dir/tests/test_smoke.py" <<'PYTEST'
+# Placeholder smoke test. Replace with real coverage as soon as there's
+# behavior worth testing — touchstone-run.sh test runs whatever exists here.
+def test_smoke() -> None:
+    assert True
+PYTEST
+      echo "==> tests: scaffolded tests/test_smoke.py (pytest)"
+      ;;
+    node)
+      if _profile_has_any_tests_node "$project_dir"; then
+        echo "==> tests: already present; skipping scaffold"
+        return 0
+      fi
+      mkdir -p "$project_dir/tests"
+      # .test.ts works with vitest, jest, and bun test without framework config.
+      # describe/it globals are injected by all three.
+      cat > "$project_dir/tests/smoke.test.ts" <<'NODETEST'
+// Placeholder smoke test. Replace with real coverage as soon as there's
+// behavior worth testing — touchstone-run.sh test runs whatever "test" script
+// package.json declares. Works with vitest/jest/bun test out of the box.
+describe("smoke", () => {
+  it("passes", () => {
+    expect(true).toBe(true);
+  });
+});
+NODETEST
+      echo "==> tests: scaffolded tests/smoke.test.ts (vitest/jest/bun test)"
+      ;;
+    go)
+      if _profile_has_any_tests_go "$project_dir"; then
+        echo "==> tests: already present; skipping scaffold"
+        return 0
+      fi
+      # Use the module's declared package if go.mod exists, else main.
+      local package_name="main"
+      if [ -f "$project_dir/go.mod" ]; then
+        # go test ./... finds *_test.go in any package — keep it simple.
+        package_name="$(sed -n 's/^module \([^/]*\).*/\1/p' "$project_dir/go.mod" | head -1)"
+        package_name="${package_name:-main}"
+      fi
+      cat > "$project_dir/smoke_test.go" <<GOTEST
+// Placeholder smoke test. Replace with real coverage as soon as there's
+// behavior worth testing — touchstone-run.sh test runs go test ./... over
+// every package in the module.
+package ${package_name}
+
+import "testing"
+
+func TestSmoke(t *testing.T) {
+	if false {
+		t.Fatal("unreachable")
+	}
+}
+GOTEST
+      echo "==> tests: scaffolded smoke_test.go (go test)"
+      ;;
+    rust)
+      # cargo init already creates src/lib.rs with #[test] or tests/ — scaffolding
+      # would either conflict or duplicate. Skip with a note.
+      echo "==> tests: skipped for rust (cargo init already scaffolds tests)"
+      ;;
+    swift)
+      # swift package init creates Tests/ — same reasoning as rust.
+      echo "==> tests: skipped for swift (swift package init already scaffolds Tests/)"
+      ;;
+    generic|"")
+      echo "==> tests: profile is 'generic' — no default test layout to scaffold"
+      echo "          set test_command= in .touchstone-config for your stack"
+      ;;
+    *)
+      echo "==> tests: scaffold not implemented for profile '$profile'"
+      ;;
+  esac
+}
+
+_profile_has_any_tests_python() {
+  local dir="$1"
+  [ -d "$dir/tests" ] && return 0
+  local matches
+  matches="$(find "$dir" -maxdepth 3 -type f \
+    \( -name 'test_*.py' -o -name '*_test.py' \) -print -quit 2>/dev/null || true)"
+  [ -n "$matches" ]
+}
+
+_profile_has_any_tests_node() {
+  local dir="$1"
+  if [ -d "$dir/__tests__" ] || [ -d "$dir/tests" ] || [ -d "$dir/test" ] \
+     || [ -d "$dir/src/__tests__" ]; then
+    return 0
+  fi
+  local matches
+  matches="$(find "$dir" -maxdepth 4 -type f \
+    \( -name '*.test.ts' -o -name '*.test.tsx' -o -name '*.test.js' -o -name '*.test.jsx' \
+       -o -name '*.spec.ts' -o -name '*.spec.js' \) -print -quit 2>/dev/null || true)"
+  [ -n "$matches" ]
+}
+
+_profile_has_any_tests_go() {
+  local dir="$1" matches
+  matches="$(find "$dir" -maxdepth 4 -type f -name '*_test.go' -print -quit 2>/dev/null || true)"
+  [ -n "$matches" ]
+}
+
 if [ "$#" -lt 1 ]; then
   usage >&2
   exit 1
@@ -452,6 +575,10 @@ while [ "$#" -gt 0 ]; do
       ;;
     --no-ci)
       INPUT_CI="none"
+      shift
+      ;;
+    --scaffold-tests)
+      INPUT_SCAFFOLD_TESTS=true
       shift
       ;;
     *) echo "ERROR: unknown argument '$1'" >&2; exit 1 ;;
@@ -1008,6 +1135,14 @@ if [ "$INPUT_TYPE" = "python" ]; then
   echo "==> Copying Python helper:"
   copy_file_force "$TOUCHSTONE_ROOT/scripts/run-pytest-in-venv.sh" "$PROJECT_DIR/scripts/run-pytest-in-venv.sh"
   chmod +x "$PROJECT_DIR/scripts/run-pytest-in-venv.sh" 2>/dev/null || true
+fi
+
+# Optional --scaffold-tests: write one smoke test per profile when no tests
+# exist, so a fresh repo has something for touchstone-run.sh test to find.
+# Off by default — project owners decide their test framework; we just prime
+# the runner with a minimal passing test that won't fight their choice.
+if [ "$INPUT_SCAFFOLD_TESTS" = true ]; then
+  scaffold_smoke_test_for_profile "$PROJECT_DIR" "$INPUT_TYPE"
 fi
 
 write_touchstone_manifest

--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -379,13 +379,20 @@ NODETEST
         echo "==> tests: already present; skipping scaffold"
         return 0
       fi
-      # Use the module's declared package if go.mod exists, else main.
-      local package_name="main"
-      if [ -f "$project_dir/go.mod" ]; then
-        # go test ./... finds *_test.go in any package — keep it simple.
-        package_name="$(sed -n 's/^module \([^/]*\).*/\1/p' "$project_dir/go.mod" | head -1)"
-        package_name="${package_name:-main}"
+      # Determine the package declaration for smoke_test.go. Go packages are
+      # declared per-file and must match every other .go file in the same
+      # directory, but a Go *module* path (e.g. github.com/acme/widget) is
+      # not a valid package identifier — package names are restricted to
+      # [a-zA-Z_][a-zA-Z0-9_]*. Match an existing root-level .go file if one
+      # exists; otherwise default to `main` (safe and compilable even in a
+      # library-style module with no other .go files at root).
+      local package_name="" first_go
+      first_go="$(find "$project_dir" -maxdepth 1 -type f -name '*.go' \
+        -not -name '*_test.go' -print -quit 2>/dev/null || true)"
+      if [ -n "$first_go" ] && [ -f "$first_go" ]; then
+        package_name="$(sed -n 's/^package \([a-zA-Z_][a-zA-Z0-9_]*\).*/\1/p' "$first_go" | head -1)"
       fi
+      package_name="${package_name:-main}"
       cat > "$project_dir/smoke_test.go" <<GOTEST
 // Placeholder smoke test. Replace with real coverage as soon as there's
 // behavior worth testing — touchstone-run.sh test runs go test ./... over
@@ -400,7 +407,7 @@ func TestSmoke(t *testing.T) {
 	}
 }
 GOTEST
-      echo "==> tests: scaffolded smoke_test.go (go test)"
+      echo "==> tests: scaffolded smoke_test.go (go test, package ${package_name})"
       ;;
     rust)
       # cargo init already creates src/lib.rs with #[test] or tests/ — scaffolding

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -65,6 +65,12 @@ PROJECT_REVIEW_HYBRID="$TEST_DIR/test-project-review-hybrid"
 PROJECT_GITBUTLER="$TEST_DIR/test-project-gitbutler"
 PROJECT_CI_OFF="$TEST_DIR/test-project-ci-off"
 PROJECT_CI_GITHUB="$TEST_DIR/test-project-ci-github"
+PROJECT_SCAFFOLD_OFF="$TEST_DIR/test-project-scaffold-off"
+PROJECT_SCAFFOLD_PY="$TEST_DIR/test-project-scaffold-python"
+PROJECT_SCAFFOLD_NODE="$TEST_DIR/test-project-scaffold-node"
+PROJECT_SCAFFOLD_GO="$TEST_DIR/test-project-scaffold-go"
+PROJECT_SCAFFOLD_GENERIC="$TEST_DIR/test-project-scaffold-generic"
+PROJECT_SCAFFOLD_EXISTING="$TEST_DIR/test-project-scaffold-existing"
 PROJECT_HOOKS_WITH="$TEST_DIR/test-project-hooks-with"
 PROJECT_HOOKS_WITHOUT="$TEST_DIR/test-project-hooks-without"
 PROJECT_PYTEST_EMPTY="$TEST_DIR/test-project-pytest-empty"
@@ -255,6 +261,52 @@ if grep -q '^.github/workflows/validate\.yml$' "$PROJECT_CI_GITHUB/.touchstone-m
   echo "FAIL: .github/workflows/validate.yml must be project-owned, not tracked in the manifest" >&2
   ERRORS=$((ERRORS + 1))
 fi
+
+# Test scaffolding is opt-in. Default bootstrap must NOT create any test file —
+# project owners pick their test framework, and silently seeding tests would
+# force that opinion.
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_OFF" --no-register --type python >/dev/null
+assert_not_exists "$PROJECT_SCAFFOLD_OFF/tests/test_smoke.py"
+assert_not_exists "$PROJECT_SCAFFOLD_OFF/tests/smoke.test.ts"
+assert_not_exists "$PROJECT_SCAFFOLD_OFF/smoke_test.go"
+
+# --scaffold-tests + Python: writes tests/test_smoke.py with a pytest-discoverable
+# function, plus tests/__init__.py. The smoke test must actually assert and pass.
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_PY" --no-register --type python --scaffold-tests >/dev/null
+assert_exists "$PROJECT_SCAFFOLD_PY/tests/test_smoke.py"
+assert_exists "$PROJECT_SCAFFOLD_PY/tests/__init__.py"
+assert_contains "$PROJECT_SCAFFOLD_PY/tests/test_smoke.py" 'def test_smoke'
+assert_contains "$PROJECT_SCAFFOLD_PY/tests/test_smoke.py" 'assert True'
+
+# --scaffold-tests + Node: writes tests/smoke.test.ts in a framework-agnostic
+# format (vitest/jest/bun test all accept it).
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_NODE" --no-register --type node --scaffold-tests >/dev/null
+assert_exists "$PROJECT_SCAFFOLD_NODE/tests/smoke.test.ts"
+assert_contains "$PROJECT_SCAFFOLD_NODE/tests/smoke.test.ts" 'describe("smoke"'
+assert_contains "$PROJECT_SCAFFOLD_NODE/tests/smoke.test.ts" 'expect(true).toBe(true)'
+
+# --scaffold-tests + Go: writes smoke_test.go so go test ./... finds it.
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_GO" --no-register --type go --scaffold-tests >/dev/null
+assert_exists "$PROJECT_SCAFFOLD_GO/smoke_test.go"
+assert_contains "$PROJECT_SCAFFOLD_GO/smoke_test.go" 'func TestSmoke(t \*testing.T)'
+
+# --scaffold-tests + generic: no test file written, but the output must tell the
+# user why so they know to set test_command= in .touchstone-config.
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_GENERIC" --no-register --type generic --scaffold-tests >"$TEST_DIR/scaffold-generic.txt" 2>&1
+if find "$PROJECT_SCAFFOLD_GENERIC" -maxdepth 3 -type f \( -name 'test_*.py' -o -name '*_test.go' -o -name 'smoke.test.*' \) | grep -q .; then
+  echo "FAIL: --scaffold-tests must not create a test file for generic profile" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+assert_contains "$TEST_DIR/scaffold-generic.txt" "profile is 'generic'"
+
+# --scaffold-tests must not overwrite existing test files — re-running on a
+# project that already has tests is a no-op.
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_EXISTING" --no-register --type python >/dev/null
+mkdir -p "$PROJECT_SCAFFOLD_EXISTING/tests"
+printf 'def test_real():\n    assert 1 + 1 == 2\n' > "$PROJECT_SCAFFOLD_EXISTING/tests/test_real.py"
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_EXISTING" --no-register --scaffold-tests >/dev/null
+assert_not_exists "$PROJECT_SCAFFOLD_EXISTING/tests/test_smoke.py"
+assert_contains "$PROJECT_SCAFFOLD_EXISTING/tests/test_real.py" 'def test_real'
 
 # touchstone init must not run a pre-existing project setup.sh after preserving it.
 mkdir -p "$PROJECT_INIT_EXISTING_SETUP"

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -374,6 +374,23 @@ printf 'describe("Button", () => { it("renders", () => {}); });\n' > "$PROJECT_S
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_SPEC_TSX" --no-register --scaffold-tests >/dev/null
 assert_not_exists "$PROJECT_SCAFFOLD_SPEC_TSX/tests/smoke.test.ts"
 
+# Re-init profile resolution must match touchstone-run.sh:load_config semantics.
+# Two regression cases: (1) last-write-wins across project_type/profile aliases,
+# (2) generic promoted to the detected manifest profile.
+# (1) project_type=generic then profile=python ->  scaffolder runs python.
+PROJECT_SCAFFOLD_ALIAS="$TEST_DIR/test-project-scaffold-alias-lastwins"
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_ALIAS" --no-register --type generic >/dev/null
+printf 'profile=python\n' >> "$PROJECT_SCAFFOLD_ALIAS/.touchstone-config"
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_ALIAS" --no-register --scaffold-tests >/dev/null
+assert_exists "$PROJECT_SCAFFOLD_ALIAS/tests/test_smoke.py"
+
+# (2) project_type=generic but pyproject.toml exists -> detect upgrades to python.
+PROJECT_SCAFFOLD_PROMOTE="$TEST_DIR/test-project-scaffold-generic-promoted"
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_PROMOTE" --no-register --type generic >/dev/null
+printf '[project]\nname = "demo"\nversion = "0.0.0"\n' > "$PROJECT_SCAFFOLD_PROMOTE/pyproject.toml"
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_PROMOTE" --no-register --scaffold-tests >/dev/null
+assert_exists "$PROJECT_SCAFFOLD_PROMOTE/tests/test_smoke.py"
+
 # touchstone init must not run a pre-existing project setup.sh after preserving it.
 mkdir -p "$PROJECT_INIT_EXISTING_SETUP"
 git -C "$PROJECT_INIT_EXISTING_SETUP" init >/dev/null

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -289,6 +289,34 @@ assert_contains "$PROJECT_SCAFFOLD_NODE/tests/smoke.test.ts" 'expect(true).toBe(
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_GO" --no-register --type go --scaffold-tests >/dev/null
 assert_exists "$PROJECT_SCAFFOLD_GO/smoke_test.go"
 assert_contains "$PROJECT_SCAFFOLD_GO/smoke_test.go" 'func TestSmoke(t \*testing.T)'
+# Default package declaration must be a valid Go identifier — `main` for a
+# repo with no existing .go files.
+assert_contains "$PROJECT_SCAFFOLD_GO/smoke_test.go" '^package main$'
+
+# Go project with a real module path (e.g. module github.com/acme/widget)
+# must not let the module path leak into the package declaration — Go package
+# names are restricted identifiers, not domain paths. Regression guard for
+# "package github.com" which is invalid and breaks go test ./....
+PROJECT_SCAFFOLD_GO_MOD="$TEST_DIR/test-project-scaffold-go-mod"
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_GO_MOD" --no-register --type go >/dev/null
+printf 'module github.com/acme/widget\n\ngo 1.22\n' > "$PROJECT_SCAFFOLD_GO_MOD/go.mod"
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_GO_MOD" --no-register --scaffold-tests >/dev/null
+assert_exists "$PROJECT_SCAFFOLD_GO_MOD/smoke_test.go"
+if grep -q '^package github' "$PROJECT_SCAFFOLD_GO_MOD/smoke_test.go"; then
+  echo "FAIL: Go scaffold must not use the module path as the package name" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+assert_contains "$PROJECT_SCAFFOLD_GO_MOD/smoke_test.go" '^package main$'
+
+# When the repo already has .go files with a custom package, the scaffold must
+# match that package so go test ./... compiles (all files in a dir share one pkg).
+PROJECT_SCAFFOLD_GO_PKG="$TEST_DIR/test-project-scaffold-go-pkg"
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_GO_PKG" --no-register --type go >/dev/null
+printf 'module github.com/acme/widget\n\ngo 1.22\n' > "$PROJECT_SCAFFOLD_GO_PKG/go.mod"
+printf 'package widget\n\nfunc Hello() string { return "hi" }\n' > "$PROJECT_SCAFFOLD_GO_PKG/widget.go"
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_GO_PKG" --no-register --scaffold-tests >/dev/null
+assert_exists "$PROJECT_SCAFFOLD_GO_PKG/smoke_test.go"
+assert_contains "$PROJECT_SCAFFOLD_GO_PKG/smoke_test.go" '^package widget$'
 
 # --scaffold-tests + generic: no test file written, but the output must tell the
 # user why so they know to set test_command= in .touchstone-config.

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -336,6 +336,34 @@ bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_EXISTING" --
 assert_not_exists "$PROJECT_SCAFFOLD_EXISTING/tests/test_smoke.py"
 assert_contains "$PROJECT_SCAFFOLD_EXISTING/tests/test_real.py" 'def test_real'
 
+# Directory-exists != tests-exist. A tests/ dir containing only __init__.py
+# or helpers must still trigger scaffolding — otherwise --scaffold-tests
+# silently no-ops on the exact setups it's meant to help.
+PROJECT_SCAFFOLD_EMPTY_PY="$TEST_DIR/test-project-scaffold-empty-python"
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_EMPTY_PY" --no-register --type python >/dev/null
+mkdir -p "$PROJECT_SCAFFOLD_EMPTY_PY/tests"
+: > "$PROJECT_SCAFFOLD_EMPTY_PY/tests/__init__.py"
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_EMPTY_PY" --no-register --scaffold-tests >/dev/null
+assert_exists "$PROJECT_SCAFFOLD_EMPTY_PY/tests/test_smoke.py"
+
+# Same class bug for Node — an empty __tests__/tests/test directory must
+# not fool the scaffolder into thinking tests exist.
+PROJECT_SCAFFOLD_EMPTY_NODE="$TEST_DIR/test-project-scaffold-empty-node"
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_EMPTY_NODE" --no-register --type node >/dev/null
+mkdir -p "$PROJECT_SCAFFOLD_EMPTY_NODE/__tests__" "$PROJECT_SCAFFOLD_EMPTY_NODE/tests"
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_EMPTY_NODE" --no-register --type node --scaffold-tests >/dev/null
+assert_exists "$PROJECT_SCAFFOLD_EMPTY_NODE/tests/smoke.test.ts"
+
+# Re-init: when .touchstone-config already has project_type=X, flags like
+# --scaffold-tests that dispatch per profile must use that X, not fall back to
+# manifest detection. Manifest detection returns "generic" when no toolchain
+# files are present, which would silently drop --scaffold-tests behavior.
+PROJECT_SCAFFOLD_REINIT_PY="$TEST_DIR/test-project-scaffold-reinit-python"
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_REINIT_PY" --no-register --type python >/dev/null
+# No --type on the second call — must be resolved from .touchstone-config.
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_REINIT_PY" --no-register --scaffold-tests >/dev/null
+assert_exists "$PROJECT_SCAFFOLD_REINIT_PY/tests/test_smoke.py"
+
 # touchstone init must not run a pre-existing project setup.sh after preserving it.
 mkdir -p "$PROJECT_INIT_EXISTING_SETUP"
 git -C "$PROJECT_INIT_EXISTING_SETUP" init >/dev/null
@@ -740,6 +768,27 @@ if (cd "$PROJECT_DOCTOR" && TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/to
 else
   assert_contains "$TEST_DIR/doctor-broken.txt" 'git hooks NOT installed'
 fi
+
+# doctor shares the test-presence heuristic with --scaffold-tests — the same
+# "dir exists != tests exist" class bug applies. An empty tests/ directory
+# (or one with only __init__.py) must not be reported as "tests: found".
+PROJECT_DOCTOR_EMPTY_PY="$TEST_DIR/test-project-doctor-empty-python"
+PATH="$HOOKS_FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_DOCTOR_EMPTY_PY" --no-register --type python >/dev/null
+mkdir -p "$PROJECT_DOCTOR_EMPTY_PY/tests"
+: > "$PROJECT_DOCTOR_EMPTY_PY/tests/__init__.py"
+RUFF_STUB_EMPTY_PY="$TEST_DIR/ruff-stub-empty-py"
+mkdir -p "$RUFF_STUB_EMPTY_PY"
+cat > "$RUFF_STUB_EMPTY_PY/ruff" <<'RUFFSTUBEMPTYPY'
+#!/usr/bin/env bash
+exit 0
+RUFFSTUBEMPTYPY
+chmod +x "$RUFF_STUB_EMPTY_PY/ruff"
+(cd "$PROJECT_DOCTOR_EMPTY_PY" && PATH="$RUFF_STUB_EMPTY_PY:$PATH" TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" doctor --project) >"$TEST_DIR/doctor-empty-py.txt" 2>&1 || true
+if grep -q "tests: found for profile 'python'" "$TEST_DIR/doctor-empty-py.txt"; then
+  echo "FAIL: doctor must not report 'tests: found' when only tests/__init__.py exists" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+assert_contains "$TEST_DIR/doctor-empty-py.txt" "tests: not found for profile 'python'"
 
 # doctor must flag a pre-push hook whose content isn't the pre-commit-framework
 # shim — another framework silently replacing the file is the same class of

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -364,6 +364,16 @@ bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_REINIT_PY" -
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_REINIT_PY" --no-register --scaffold-tests >/dev/null
 assert_exists "$PROJECT_SCAFFOLD_REINIT_PY/tests/test_smoke.py"
 
+# React/TS projects commonly name tests Component.spec.tsx — the node test
+# predicate must include .spec.tsx / .spec.jsx, otherwise --scaffold-tests
+# incorrectly ADDS a placeholder next to real tests.
+PROJECT_SCAFFOLD_SPEC_TSX="$TEST_DIR/test-project-scaffold-spec-tsx"
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_SPEC_TSX" --no-register --type node >/dev/null
+mkdir -p "$PROJECT_SCAFFOLD_SPEC_TSX/src"
+printf 'describe("Button", () => { it("renders", () => {}); });\n' > "$PROJECT_SCAFFOLD_SPEC_TSX/src/Button.spec.tsx"
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_SPEC_TSX" --no-register --scaffold-tests >/dev/null
+assert_not_exists "$PROJECT_SCAFFOLD_SPEC_TSX/tests/smoke.test.ts"
+
 # touchstone init must not run a pre-existing project setup.sh after preserving it.
 mkdir -p "$PROJECT_INIT_EXISTING_SETUP"
 git -C "$PROJECT_INIT_EXISTING_SETUP" init >/dev/null


### PR DESCRIPTION
New --scaffold-tests flag writes one placeholder smoke test per detected
profile during touchstone new/init. Off by default — project owners pick
their stack, and silently seeding tests would force that opinion.

Per-profile behavior:
- python  -> tests/test_smoke.py + tests/__init__.py (pytest-discoverable)
- node    -> tests/smoke.test.ts (framework-agnostic: vitest/jest/bun test
             all accept describe/it/expect globals in this format)
- go      -> smoke_test.go with TestSmoke (go test ./... finds it)
- rust    -> skipped (cargo init already scaffolds tests)
- swift   -> skipped (swift package init already scaffolds Tests/)
- generic -> no-op with a note pointing at .touchstone-config test_command

Safety: never overwrites. Each profile's scaffolder runs a presence
check first and exits early if any test file already exists, so
re-running the flag on a real project is idempotent.

Wired through touchstone init / new. The flag exists to close the gap
where touchstone-run.sh test silently skips on repos with no tests,
which fresh bootstraps hit every time — without this, the pre-push test
gate has no signal until the first real test lands.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
