### PR TITLE
docs(readme): add 'test runner, not test suite' stance + new flag rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ bash setup.sh --deps-only
 | `touchstone init --review-routing small-local --reviewer codex --local-review-command '<command>'` | Use local review for small diffs and a hosted reviewer for larger diffs |
 | `touchstone init --no-ai-review` | Add touchstone with AI review disabled |
 | `touchstone init --gitbutler` | Add touchstone with optional GitButler workflow setup |
-| `touchstone init --ci github` | Add `.github/workflows/validate.yml` that runs the same checks as local pre-push |
+| `touchstone init --ci github` | Add `.github/workflows/validate.yml` that runs pre-commit hygiene and `touchstone run validate` on every PR |
 | `touchstone init --scaffold-tests` | Write one placeholder smoke test for Python, Node, or Go projects (Rust and Swift already ship scaffolds via `cargo init` / `swift package init`) |
 | `touchstone new <dir>` | Bootstrap a new project with principles, scripts, hooks, and templates |
 | `touchstone new <dir> --type node` | Bootstrap with an explicit Node/TypeScript, Swift, Rust, Go, Python, or generic profile |

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ bash setup.sh --deps-only
 | `touchstone init --no-ai-review` | Add touchstone with AI review disabled |
 | `touchstone init --gitbutler` | Add touchstone with optional GitButler workflow setup |
 | `touchstone init --ci github` | Add `.github/workflows/validate.yml` that runs the same checks as local pre-push |
-| `touchstone init --scaffold-tests` | Write one placeholder smoke test for the detected profile so the pre-push test gate has something to run |
+| `touchstone init --scaffold-tests` | Write one placeholder smoke test for Python, Node, or Go projects (Rust and Swift already ship scaffolds via `cargo init` / `swift package init`) |
 | `touchstone new <dir>` | Bootstrap a new project with principles, scripts, hooks, and templates |
 | `touchstone new <dir> --type node` | Bootstrap with an explicit Node/TypeScript, Swift, Rust, Go, Python, or generic profile |
 | `touchstone new <dir> --reviewer local --local-review-command '<command>'` | Bootstrap a new project with a local reviewer command |
@@ -133,7 +133,7 @@ bash setup.sh --deps-only
 | `touchstone new <dir> --no-ai-review` | Bootstrap a new project with AI review disabled |
 | `touchstone new <dir> --gitbutler` | Bootstrap with optional GitButler workflow setup |
 | `touchstone new <dir> --ci github` | Bootstrap with the opt-in GitHub Actions validate workflow |
-| `touchstone new <dir> --scaffold-tests` | Bootstrap with a placeholder smoke test for the detected profile |
+| `touchstone new <dir> --scaffold-tests` | Bootstrap with a placeholder smoke test for Python, Node, or Go projects |
 | `touchstone detect` | Show the detected project profile for the current repo |
 | `touchstone run <task>` | Run profile-aware `lint`, `typecheck`, `build`, `test`, or `validate` |
 | `touchstone update` | Create a branch and commit that updates the current project's touchstone-owned files |
@@ -188,7 +188,7 @@ When you run `touchstone new`, these files get created in your project:
 
 Touchstone enforces a test **runner**, not a test **suite**. The pre-push hook invokes `scripts/touchstone-run.sh validate`, which dispatches lint/typecheck/build/test per profile — but every profile silently skips when the underlying tool or test file is absent (correct runtime UX: a fresh scaffold shouldn't reject pushes just because the first test hasn't been written yet). Consequence: a repo with zero test files passes the gate.
 
-`touchstone doctor --project` is where those gaps become visible. It reports per-profile test presence, profile-specific linter availability (`ruff`, `swift-format`), pre-push hook integrity, and unknown profile values — in lock-step with the runner's dispatcher so doctor never claims more coverage than `validate` actually runs. Use `touchstone init --scaffold-tests` to seed a profile-appropriate placeholder test and `touchstone init --ci github` to add a GitHub Actions workflow that runs the same `validate` path CI-side.
+`touchstone doctor --project` is where those gaps become visible. It reports per-profile test presence, profile-specific linter availability (`ruff`, `swift-format`), pre-push hook integrity, and unknown profile values — in lock-step with the runner's dispatcher so doctor never claims more coverage than `validate` actually runs. Use `touchstone init --scaffold-tests` to seed a placeholder smoke test (Python, Node, and Go; Rust and Swift already get tests from `cargo init` / `swift package init`) and `touchstone init --ci github` to add a GitHub Actions workflow that runs the same `validate` path CI-side.
 
 ### Keeping projects up to date
 

--- a/README.md
+++ b/README.md
@@ -118,16 +118,22 @@ bash setup.sh --deps-only
 | Command | What it does |
 |---------|-------------|
 | `touchstone init [--no-setup]` | Add touchstone to the current project |
+| `touchstone init --no-ship` | When init upgrades an outdated project, open a review branch instead of auto-merging the upgrade PR |
+| `touchstone migrate-from-toolkit` | Migrate a project from the legacy `.toolkit-*` files before re-running `touchstone init` |
 | `touchstone init --reviewer local --local-review-command '<command>'` | Add touchstone with a local reviewer command |
 | `touchstone init --review-routing small-local --reviewer codex --local-review-command '<command>'` | Use local review for small diffs and a hosted reviewer for larger diffs |
 | `touchstone init --no-ai-review` | Add touchstone with AI review disabled |
 | `touchstone init --gitbutler` | Add touchstone with optional GitButler workflow setup |
+| `touchstone init --ci github` | Add `.github/workflows/validate.yml` that runs the same checks as local pre-push |
+| `touchstone init --scaffold-tests` | Write one placeholder smoke test for the detected profile so the pre-push test gate has something to run |
 | `touchstone new <dir>` | Bootstrap a new project with principles, scripts, hooks, and templates |
 | `touchstone new <dir> --type node` | Bootstrap with an explicit Node/TypeScript, Swift, Rust, Go, Python, or generic profile |
 | `touchstone new <dir> --reviewer local --local-review-command '<command>'` | Bootstrap a new project with a local reviewer command |
 | `touchstone new <dir> --review-routing small-local --reviewer codex --local-review-command '<command>'` | Bootstrap with hybrid local/hosted review routing |
 | `touchstone new <dir> --no-ai-review` | Bootstrap a new project with AI review disabled |
 | `touchstone new <dir> --gitbutler` | Bootstrap with optional GitButler workflow setup |
+| `touchstone new <dir> --ci github` | Bootstrap with the opt-in GitHub Actions validate workflow |
+| `touchstone new <dir> --scaffold-tests` | Bootstrap with a placeholder smoke test for the detected profile |
 | `touchstone detect` | Show the detected project profile for the current repo |
 | `touchstone run <task>` | Run profile-aware `lint`, `typecheck`, `build`, `test`, or `validate` |
 | `touchstone update` | Create a branch and commit that updates the current project's touchstone-owned files |
@@ -147,7 +153,7 @@ bash setup.sh --deps-only
 | `touchstone doctor` | Health check — version, tools, project staleness |
 | `touchstone skills` | List Claude Code skills visible to the current repo and user |
 | `touchstone skills check` | Validate Claude Code skill frontmatter |
-| `touchstone release [--patch]` | Cut a Touchstone release; maintainers only |
+| `touchstone release [--major\|--minor\|--patch]` | Cut a Touchstone release; maintainers only |
 
 ## How it works
 
@@ -177,6 +183,12 @@ When you run `touchstone new`, these files get created in your project:
 - `scripts/run-pytest-in-venv.sh` — Legacy Python helper copied for Python profiles
 
 `setup.sh` installs dependencies for the detected project profile. It supports Node package managers, SwiftPM, Cargo, Go modules, and Python `requirements.txt`/`uv.lock`/`pyproject.toml` at the repo root and under `agent/`. `touchstone run validate` uses `.touchstone-config` to run profile-aware lint/typecheck/test commands.
+
+### What the gates actually enforce
+
+Touchstone enforces a test **runner**, not a test **suite**. The pre-push hook invokes `scripts/touchstone-run.sh validate`, which dispatches lint/typecheck/build/test per profile — but every profile silently skips when the underlying tool or test file is absent (correct runtime UX: a fresh scaffold shouldn't reject pushes just because the first test hasn't been written yet). Consequence: a repo with zero test files passes the gate.
+
+`touchstone doctor --project` is where those gaps become visible. It reports per-profile test presence, profile-specific linter availability (`ruff`, `swift-format`), pre-push hook integrity, and unknown profile values — in lock-step with the runner's dispatcher so doctor never claims more coverage than `validate` actually runs. Use `touchstone init --scaffold-tests` to seed a profile-appropriate placeholder test and `touchstone init --ci github` to add a GitHub Actions workflow that runs the same `validate` path CI-side.
 
 ### Keeping projects up to date
 


### PR DESCRIPTION
Names the gate model plainly so users don't assume more coverage than
touchstone-run.sh validate actually enforces. Runtime graceful-skip is
the right UX — a fresh scaffold shouldn't reject pushes — but that means
a repo with zero tests passes the gate, and the README now says so.

Points users at doctor --project for gap visibility, --scaffold-tests
for seeding the first placeholder, and --ci github for the CI backstop.
Adds table rows for those flags plus the pre-existing --no-ship,
migrate-from-toolkit, and release bump variants that had been sitting
uncommitted.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
