### PR TITLE
feat(doctor): surface Autumn Garage siblings in doctor --project

### DIFF
--- a/bin/touchstone
+++ b/bin/touchstone
@@ -545,6 +545,14 @@ cmd_doctor_project() {
     _touchstone_doctor_check_lint "$project_dir" "$profile" ""
   fi
 
+  # 8. Autumn Garage siblings — orientation-only, never blocking.
+  # Autumn Garage Doctrine 0001 forbids code imports across the trio, so this
+  # check is file-contract only: shell out to the sibling CLI for a version
+  # string and look at the project-local marker directory. Absence is normal.
+  tk_info "Autumn Garage siblings"
+  _touchstone_doctor_check_sibling "$project_dir" cortex   ".cortex"            "brew install autumngarage/cortex/cortex"
+  _touchstone_doctor_check_sibling "$project_dir" sentinel ".sentinel"          "brew install autumngarage/sentinel/sentinel"
+
   echo ""
   if [ "$issues" -eq 0 ]; then
     tk_ok "Project is fully armed."
@@ -554,6 +562,63 @@ cmd_doctor_project() {
   tk_warn "$issues issue(s) found. See fixes above, or run: touchstone init"
   echo ""
   return 1
+}
+
+# Report presence + version of a sibling CLI in the Autumn Garage trio.
+# File-contract only — no code imports, no reading sibling config beyond a
+# presence check on the marker directory. `command -v` for the CLI; a 3s
+# timeout on the version subcommand so a hung sibling can't stall doctor.
+# Absence is never an issue (does not touch $issues in the caller); a CLI
+# that's missing while the marker directory is present is an unusual state
+# worth flagging (tk_warn), still non-blocking.
+#
+# Always returns 0 so `set -e` in the caller doesn't abort on a missing CLI.
+_touchstone_doctor_check_sibling() {
+  local project_dir="$1" name="$2" marker_rel="$3" install_hint="$4"
+  local marker_state="absent" marker_note
+  if [ -d "$project_dir/$marker_rel" ]; then
+    marker_state="present"
+  fi
+  marker_note="${marker_rel}/ ${marker_state}"
+
+  if command -v "$name" >/dev/null 2>&1; then
+    local version_raw="" version=""
+    # 3-second wall-clock cap per probe so a hung sibling can't stall doctor.
+    # `perl -e alarm` is portable across macOS + Linux without needing GNU timeout.
+    # Try `<cli> version` first (cortex convention, Touchstone convention);
+    # fall back to `<cli> --version` (Click / argparse default, Sentinel).
+    # Both stdout and stderr are captured because Click prints --version to stdout
+    # but unknown-subcommand errors to stderr — combining them keeps the regex
+    # hunt below from accidentally parsing "Error: No such command 'version'".
+    for probe in "version" "--version"; do
+      version_raw="$(perl -e 'alarm 3; exec @ARGV' "$name" "$probe" 2>/dev/null || true)"
+      # A semver-ish token in the output means we found a real version reply;
+      # otherwise try the next probe.
+      if printf '%s' "$version_raw" | grep -Eq '[0-9]+\.[0-9]+(\.[0-9]+)?'; then
+        break
+      fi
+      version_raw=""
+    done
+    # Extract the first semver-ish token so the output shape is stable even if
+    # the sibling's version output wraps the number with other text.
+    version="$(printf '%s' "$version_raw" | awk '
+      { for (i=1;i<=NF;i++) if (match($i, /[0-9]+\.[0-9]+(\.[0-9]+)?/)) {
+          print substr($i, RSTART, RLENGTH); exit
+        }
+      }
+    ')"
+    [ -z "$version" ] && version="?"
+    tk_ok "$name $version (installed) — $marker_note"
+    return 0
+  fi
+
+  if [ "$marker_state" = "present" ]; then
+    tk_warn "$name CLI missing but $marker_rel/ present — install: $install_hint"
+    return 0
+  fi
+
+  tk_dim "$name not installed"
+  return 0
 }
 
 # Report whether .touchstone-config assigns a non-empty value to the given key.

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -888,6 +888,77 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
+# Autumn Garage siblings block must appear in doctor --project output on every
+# project, regardless of whether cortex/sentinel are installed. Absence is the
+# normal case for most users; missing-block would be an orientation regression.
+# Skip asserting exact version strings — those are machine-dependent. The
+# section header alone proves the code path ran.
+assert_contains "$TEST_DIR/doctor-clean.txt" 'Autumn Garage siblings'
+
+# Sibling detection must not error, warn-exit, or block when cortex/sentinel
+# are absent from PATH. Simulate a clean machine by pinning PATH to the
+# system dirs plus the fake pre-commit hook installer. Use an absolute path
+# to touchstone so the CLI is still reachable with the trimmed PATH.
+PROJECT_DOCTOR_NO_SIBLINGS="$TEST_DIR/test-project-doctor-no-siblings"
+PATH="$HOOKS_FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_DOCTOR_NO_SIBLINGS" --no-register >/dev/null
+if (cd "$PROJECT_DOCTOR_NO_SIBLINGS" && PATH="/usr/bin:/bin" TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" doctor --project) >"$TEST_DIR/doctor-no-siblings.txt" 2>&1; then
+  assert_contains "$TEST_DIR/doctor-no-siblings.txt" 'Autumn Garage siblings'
+  assert_contains "$TEST_DIR/doctor-no-siblings.txt" 'cortex not installed'
+  assert_contains "$TEST_DIR/doctor-no-siblings.txt" 'sentinel not installed'
+else
+  echo "FAIL: doctor --project should exit 0 when Autumn Garage siblings are absent — absence is not a bug" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# Mixed state — CLI absent but marker directory present — is unusual enough
+# that doctor warns and points at the install hint, but still never errors.
+# This is the class of failure where a user deleted a brew-installed CLI but
+# left its project state behind; a silent pass would hide the drift.
+PROJECT_DOCTOR_MARKER_ONLY="$TEST_DIR/test-project-doctor-marker-only"
+PATH="$HOOKS_FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_DOCTOR_MARKER_ONLY" --no-register >/dev/null
+mkdir -p "$PROJECT_DOCTOR_MARKER_ONLY/.cortex"
+if (cd "$PROJECT_DOCTOR_MARKER_ONLY" && PATH="/usr/bin:/bin" TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" doctor --project) >"$TEST_DIR/doctor-marker-only.txt" 2>&1; then
+  assert_contains "$TEST_DIR/doctor-marker-only.txt" 'cortex CLI missing but .cortex/ present'
+else
+  echo "FAIL: doctor --project should exit 0 when a sibling CLI is missing but its marker dir is present — still non-blocking" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# Installed case — a sibling CLI on PATH must be reported as "(installed)".
+# Use a stub script so the test is deterministic across machines. The stub
+# responds to both `version` and `--version` so the probe-fallback branch
+# doesn't accidentally pass on the wrong probe — either convention is valid.
+SIBLING_STUB_BIN="$TEST_DIR/sibling-stub-bin"
+mkdir -p "$SIBLING_STUB_BIN"
+cat > "$SIBLING_STUB_BIN/cortex" <<'CORTEXSTUB'
+#!/usr/bin/env bash
+case "${1:-}" in
+  version|--version) echo "cortex 9.9.9"; exit 0 ;;
+  *) echo "stub cortex"; exit 0 ;;
+esac
+CORTEXSTUB
+chmod +x "$SIBLING_STUB_BIN/cortex"
+cat > "$SIBLING_STUB_BIN/sentinel" <<'SENTINELSTUB'
+#!/usr/bin/env bash
+case "${1:-}" in
+  version) echo "Error: no such command" >&2; exit 2 ;;
+  --version) echo "sentinel, version 8.8.8"; exit 0 ;;
+  *) echo "stub sentinel"; exit 0 ;;
+esac
+SENTINELSTUB
+chmod +x "$SIBLING_STUB_BIN/sentinel"
+
+PROJECT_DOCTOR_SIBLINGS="$TEST_DIR/test-project-doctor-with-siblings"
+PATH="$HOOKS_FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_DOCTOR_SIBLINGS" --no-register >/dev/null
+if (cd "$PROJECT_DOCTOR_SIBLINGS" && PATH="$SIBLING_STUB_BIN:/usr/bin:/bin" TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" doctor --project) >"$TEST_DIR/doctor-with-siblings.txt" 2>&1; then
+  assert_contains "$TEST_DIR/doctor-with-siblings.txt" 'cortex 9.9.9 (installed)'
+  # Sentinel only responds to --version — asserts the probe-fallback works.
+  assert_contains "$TEST_DIR/doctor-with-siblings.txt" 'sentinel 8.8.8 (installed)'
+else
+  echo "FAIL: doctor --project should exit 0 when Autumn Garage siblings are installed and reply with a version" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
 # Break hooks and rerun doctor — it must exit nonzero and flag the gap.
 rm -f "$PROJECT_DOCTOR/.git/hooks/pre-push"
 if (cd "$PROJECT_DOCTOR" && TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" doctor --project) >"$TEST_DIR/doctor-broken.txt" 2>&1; then


### PR DESCRIPTION
## Summary

- Add an `Autumn Garage siblings:` block to `touchstone doctor --project` reporting presence + version of `cortex` and `sentinel`, the sibling tools in the Autumn Garage trio.
- File-contract + CLI-shell-out only per Autumn Garage Doctrine 0001 (`shutil.which` / `command -v` equivalent + marker-dir check). No code imports across the trio.
- Absence is never an issue. Marker-only state (CLI missing but `.cortex/` / `.sentinel/` present) is surfaced as a warn-level hint with an install pointer but stays non-blocking.

Stacked on #47.

## Implementation notes

- `command -v <cli>` for PATH presence.
- `<cli> version` then `<cli> --version` fallback so both Touchstone-style and Click-style siblings are covered (Sentinel uses `--version`).
- 3s `perl -e alarm` timeout per probe — portable across macOS + Linux without needing GNU coreutils timeout. A hung sibling subprocess can't stall doctor.
- Semver-ish token extracted from the version output so the displayed format stays stable even if a sibling reformats.

## Output shapes

```
Autumn Garage siblings:
  ✓ cortex 0.1.0 (installed) — .cortex/ present
  ✓ sentinel 0.2.0 (installed) — .sentinel/ absent
```

```
Autumn Garage siblings:
  — cortex not installed
  — sentinel not installed
```

```
Autumn Garage siblings:
  ! cortex CLI missing but .cortex/ present — install: brew install autumngarage/cortex/cortex
  ✓ sentinel 0.2.0 (installed) — .sentinel/ absent
```

## Test plan

- [x] `for test in tests/test-*.sh; do bash "$test"; done` — all 9 pass
- [x] New `test-bootstrap.sh` cases cover fresh scaffold, siblings-absent (PATH trimmed), marker-only (`.cortex/` created, PATH trimmed), and installed-via-stub (with stub sentinel responding only to `--version`, exercising the probe-fallback branch)
- [x] Version strings not asserted (machine-dependent); section header + state strings are

## Gotchas

- `scripts/open-pr.sh` hardcodes `--base $DEFAULT_BRANCH`, so this PR was opened via `gh pr create --base feat/new-interactive-wizard` directly. Same bypass the Cortex R2 agent used; already tracked in `autumn-garage/TODOS.md`.