### PR TITLE
feat(new): visible registry write + first-push codex review exempt

### DIFF
--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -1227,6 +1227,11 @@ echo ""
 echo "==> Wrote .touchstone-version: $TOUCHSTONE_SHA"
 
 # Register in ~/.touchstone-projects for sync-all.sh.
+# The write is a silent side effect by default (opt-in stays default for
+# script-compat), so surface every registry outcome with an "==> " line:
+# the path we wrote to, the fact that we were already registered, or the
+# fact that registration was skipped. Always name the opt-out flag so the
+# next run doesn't need to grep for it.
 PROJECTS_FILE="$HOME/.touchstone-projects"
 if [ "$REGISTER" = true ]; then
   # Ensure file exists.
@@ -1234,10 +1239,12 @@ if [ "$REGISTER" = true ]; then
   # Add if not already registered.
   if ! grep -qxF "$PROJECT_DIR" "$PROJECTS_FILE" 2>/dev/null; then
     echo "$PROJECT_DIR" >> "$PROJECTS_FILE"
-    echo "==> Registered in $PROJECTS_FILE"
+    echo "==> Registered in $PROJECTS_FILE — opt out next time with --no-register"
   else
-    echo "==> Already registered in $PROJECTS_FILE"
+    echo "==> Already registered in $PROJECTS_FILE — opt out next time with --no-register"
   fi
+else
+  echo "==> Registry skipped (--no-register)"
 fi
 
 # --------------------------------------------------------------------------

--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -1063,6 +1063,24 @@ if should_skip_pre_push_review; then
   exit 0
 fi
 
+# First-push exemption: a pre-push to the default branch with a single commit
+# on HEAD is the initial scaffold push. Reviewing AI-generated template files
+# has near-zero signal and spends quota that belongs to real PRs. Skip with a
+# visible line so the absent safety boundary is not silent. Defensive: if
+# `git rev-list` fails for any reason (no commits, detached state, etc.), fall
+# through to the normal review path instead of silently skipping.
+if is_pre_push_hook && ! is_truthy "${CODEX_REVIEW_FORCE:-false}"; then
+  _firstpush_remote_branch="$(short_ref_name "${PRE_COMMIT_REMOTE_BRANCH:-}")"
+  _firstpush_default_branch="$(short_ref_name "$DEFAULT_BRANCH")"
+  if [ "$_firstpush_remote_branch" = "$_firstpush_default_branch" ]; then
+    if _firstpush_commit_count="$(git rev-list --count HEAD 2>/dev/null)" \
+      && [ "$_firstpush_commit_count" = "1" ]; then
+      echo "==> Codex review skipped — first push on a fresh scaffold (HEAD is the initial commit)."
+      exit 0
+    fi
+  fi
+fi
+
 if ! is_truthy "$REVIEW_ENABLED"; then
   echo "==> AI review disabled by .codex-review.toml — skipping review."
   exit 0

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -1063,6 +1063,24 @@ if should_skip_pre_push_review; then
   exit 0
 fi
 
+# First-push exemption: a pre-push to the default branch with a single commit
+# on HEAD is the initial scaffold push. Reviewing AI-generated template files
+# has near-zero signal and spends quota that belongs to real PRs. Skip with a
+# visible line so the absent safety boundary is not silent. Defensive: if
+# `git rev-list` fails for any reason (no commits, detached state, etc.), fall
+# through to the normal review path instead of silently skipping.
+if is_pre_push_hook && ! is_truthy "${CODEX_REVIEW_FORCE:-false}"; then
+  _firstpush_remote_branch="$(short_ref_name "${PRE_COMMIT_REMOTE_BRANCH:-}")"
+  _firstpush_default_branch="$(short_ref_name "$DEFAULT_BRANCH")"
+  if [ "$_firstpush_remote_branch" = "$_firstpush_default_branch" ]; then
+    if _firstpush_commit_count="$(git rev-list --count HEAD 2>/dev/null)" \
+      && [ "$_firstpush_commit_count" = "1" ]; then
+      echo "==> Codex review skipped — first push on a fresh scaffold (HEAD is the initial commit)."
+      exit 0
+    fi
+  fi
+fi
+
 if ! is_truthy "$REVIEW_ENABLED"; then
   echo "==> AI review disabled by .codex-review.toml — skipping review."
   exit 0

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -1441,7 +1441,24 @@ HOME="$REGISTRY_TMP" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_
   </dev/null >"$TEST_DIR/register.txt" 2>&1
 assert_exists "$REGISTRY_TMP/.touchstone-projects"
 assert_contains "$REGISTRY_TMP/.touchstone-projects" "$PROJECT_REGISTER"
+# Registry write must be visible: a silent append to ~/.touchstone-projects
+# loses the audit trail that motivates opt-in being the default. The line must
+# also name the opt-out flag so the next run doesn't need to grep docs for it.
+assert_contains "$TEST_DIR/register.txt" '==> Registered in .*\.touchstone-projects'
+assert_contains "$TEST_DIR/register.txt" '--no-register'
 rm -rf "$REGISTRY_TMP"
+
+# --no-register must print the visible skip line so the opt-out is auditable.
+# The scaffold summary already includes "registry: skipped (--no-register)" in
+# its trailing block; this assertion pins the dedicated log line that fires at
+# the moment the registry decision is made.
+PROJECT_REGISTER_SKIP="$TEST_DIR/test-project-register-skip"
+REGISTRY_SKIP_TMP="$(mktemp -d -t touchstone-registry-skip.XXXXXX)"
+HOME="$REGISTRY_SKIP_TMP" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_REGISTER_SKIP" --no-register \
+  </dev/null >"$TEST_DIR/register-skip.txt" 2>&1
+assert_not_exists "$REGISTRY_SKIP_TMP/.touchstone-projects"
+assert_contains "$TEST_DIR/register-skip.txt" '==> Registry skipped (--no-register)'
+rm -rf "$REGISTRY_SKIP_TMP"
 
 echo ""
 if [ "$ERRORS" -eq 0 ]; then

--- a/tests/test-review-hook.sh
+++ b/tests/test-review-hook.sh
@@ -133,6 +133,80 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
+echo "==> Test: review hook skips first-push on fresh scaffold (HEAD = 1 commit)"
+# First-push exemption: reviewing AI-generated scaffold templates is near-zero
+# signal and wastes reviewer quota. A single-commit HEAD on the default branch
+# is the unambiguous "initial scaffold push" signal. This test creates a fresh
+# repo with exactly one commit and asserts the hook exits 0 without invoking
+# the reviewer. The 2+ commit case is already covered by the preceding test.
+FIRSTPUSH_REPO="$TEST_DIR/firstpush-repo"
+FIRSTPUSH_OUTPUT="$TEST_DIR/firstpush-output.txt"
+mkdir -p "$FIRSTPUSH_REPO"
+git -C "$FIRSTPUSH_REPO" init -b main >/dev/null 2>&1
+git -C "$FIRSTPUSH_REPO" config user.name "Touchstone Test"
+git -C "$FIRSTPUSH_REPO" config user.email "touchstone@example.com"
+cp "$TOUCHSTONE_ROOT/.codex-review.toml" "$FIRSTPUSH_REPO/.codex-review.toml"
+printf 'scaffold\n' > "$FIRSTPUSH_REPO/README.md"
+git -C "$FIRSTPUSH_REPO" add .codex-review.toml README.md
+git -C "$FIRSTPUSH_REPO" commit -m "initial scaffold" >/dev/null 2>&1
+
+: > "$CODEX_CALLS_FILE"
+(
+  cd "$FIRSTPUSH_REPO"
+  PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CODEX_CALLS_FILE="$CODEX_CALLS_FILE" \
+    PRE_COMMIT=1 \
+    PRE_COMMIT_LOCAL_BRANCH="refs/heads/main" \
+    PRE_COMMIT_REMOTE_BRANCH="refs/heads/main" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$FIRSTPUSH_OUTPUT" 2>&1
+)
+
+CODEX_CALL_COUNT="$(wc -l < "$CODEX_CALLS_FILE" | tr -d ' ')"
+if [ "$CODEX_CALL_COUNT" = "0" ] \
+  && grep -q 'first push on a fresh scaffold' "$FIRSTPUSH_OUTPUT" \
+  && grep -q 'HEAD is the initial commit' "$FIRSTPUSH_OUTPUT"; then
+  echo "==> PASS: first-push on fresh scaffold skipped review"
+else
+  echo "FAIL: expected first-push skip on fresh scaffold" >&2
+  echo "codex call count: $CODEX_CALL_COUNT" >&2
+  cat "$FIRSTPUSH_OUTPUT" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo "==> Test: review hook does NOT skip when HEAD has 2+ commits on default branch"
+# Guard the boundary: once a second commit lands on top of the scaffold, the
+# first-push exemption must turn off — otherwise any push of only two commits
+# to the default branch would also skip review, which is the opposite of what
+# we want for a stacked hotfix flow.
+printf 'second\n' >> "$FIRSTPUSH_REPO/README.md"
+git -C "$FIRSTPUSH_REPO" add README.md
+git -C "$FIRSTPUSH_REPO" commit -m "second commit" >/dev/null 2>&1
+
+: > "$CODEX_CALLS_FILE"
+(
+  cd "$FIRSTPUSH_REPO"
+  PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CODEX_CALLS_FILE="$CODEX_CALLS_FILE" \
+    PRE_COMMIT=1 \
+    PRE_COMMIT_LOCAL_BRANCH="refs/heads/main" \
+    PRE_COMMIT_REMOTE_BRANCH="refs/heads/main" \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$TEST_DIR/firstpush-second-output.txt" 2>&1
+)
+
+CODEX_CALL_COUNT="$(wc -l < "$CODEX_CALLS_FILE" | tr -d ' ')"
+if [ "$CODEX_CALL_COUNT" = "1" ] \
+  && ! grep -q 'first push on a fresh scaffold' "$TEST_DIR/firstpush-second-output.txt"; then
+  echo "==> PASS: second-commit push on default branch ran review (first-push exemption did not misfire)"
+else
+  echo "FAIL: expected second-commit push to run review, not skip" >&2
+  echo "codex call count: $CODEX_CALL_COUNT" >&2
+  cat "$TEST_DIR/firstpush-second-output.txt" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
 echo "==> Test: review hook skips nested Codex review subprocesses"
 : > "$CODEX_CALLS_FILE"
 


### PR DESCRIPTION
## Summary

Two small R4 items from Autumn Garage dogfood, one PR. Stacked on #48.

### A. Registry write is visible

`touchstone new` silently appended to `~/.touchstone-projects` on the opt-in path (default). R2 added a TTY prompt, but on non-TTY + no `--yes` it was still a silent side-effect. Every registry outcome now prints an `==> ` line:

- `==> Registered in ~/.touchstone-projects — opt out next time with --no-register`
- `==> Already registered in ~/.touchstone-projects — opt out next time with --no-register`
- `==> Registry skipped (--no-register)`

Default stays opt-in (no compat break for existing scripts). Only visibility changes.

### B. First-push Codex review exempt

The very first push of a fresh scaffold was reviewing its own AI-generated template files, spending quota on near-zero-signal review. `hooks/codex-review.sh` + `scripts/codex-review.sh` now skip review when the push is a pre-push to the default branch AND `git rev-list --count HEAD` equals 1:

`==> Codex review skipped — first push on a fresh scaffold (HEAD is the initial commit).`

Defensive: if `git rev-list` fails for any reason, falls through to normal review (no silent skip). `CODEX_REVIEW_FORCE=1` still bypasses the exemption.

## Files touched

- `bootstrap/new-project.sh` — add visible lines at the write point, plus the new `--no-register` echo.
- `hooks/codex-review.sh` + `scripts/codex-review.sh` — identical edits (enforced by `tests/test-codex-review-sync.sh`).
- `tests/test-bootstrap.sh` — assert "Registered in" on `--register` and "Registry skipped" on `--no-register`.
- `tests/test-review-hook.sh` — first-push skip test (1-commit repo) + boundary guard that a second commit resumes review.

## Test plan

- [x] `tests/test-codex-review-sync.sh` — hooks/ and scripts/ are byte-identical
- [x] `tests/test-bootstrap.sh` — all assertions pass, including the new visibility assertions
- [x] `tests/test-review-hook.sh` — new first-push skip case + second-commit-does-not-skip boundary guard
- [x] All 9 `tests/test-*.sh` green locally
- [x] Pre-push Codex review passed on this branch

## Dogfood context

- `autumn-garage/TODOS.md` — Touchstone section, two unchecked R4 items.
- `autumn-garage/.cortex/journal/2026-04-18-setup-reflection.md` — original friction writeup.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>