### PR TITLE
fix(bootstrap): R5 scaffold hardening — ordering, gitignore, shellcheck

### DIFF
--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -1662,7 +1662,15 @@ fi
 # everything — integration artifacts plus scaffold — as one commit
 # with a single author/message, so `rev-list --count HEAD` equals 1.
 INITIAL_COMMIT_SHA=""
-if [ "$RE_INIT" = false ] && [ "$INITIAL_COMMIT" = true ]; then
+# Preserve the pre-R5 invariant exactly: the initial-commit path only
+# runs when NO HEAD existed before this scaffold. Bootstrapping into a
+# repo that already had user-authored commits must never rewrite history
+# or sweep unrelated staged changes into a "chore: initial touchstone
+# scaffold". Integrations may have just created HEAD mid-run — that's
+# still a fresh-scaffold case, which the PRE_INTEGRATION_HEAD guard
+# distinguishes from genuine pre-existing history.
+if [ "$RE_INIT" = false ] && [ "$INITIAL_COMMIT" = true ] \
+  && [ -z "$PRE_INTEGRATION_HEAD" ]; then
   # Fall back to a local git identity when none is configured globally, so the
   # commit succeeds on CI boxes and fresh dev machines. Global config, when
   # present, wins because we only set the local keys if they resolve to empty.
@@ -1675,27 +1683,24 @@ if [ "$RE_INIT" = false ] && [ "$INITIAL_COMMIT" = true ]; then
 
   # If an integration (e.g. sentinel init) created a commit DURING this
   # run, fold its changes back into the index so the touchstone initial
-  # commit is the sole commit on the branch. Guard with three conditions
-  # so we never rewrite user-authored history:
-  #   1. HEAD must not have existed before integrations ran.
-  #   2. HEAD must exist now (otherwise there's nothing to collapse).
-  #   3. HEAD must be a root commit (rev-list --count HEAD == 1).
-  # Any of these failing means the one commit on the branch pre-dates
-  # this scaffold; we leave it alone and add a follow-up commit instead.
-  if [ -z "$PRE_INTEGRATION_HEAD" ] \
-    && git -C "$PROJECT_DIR" rev-parse --verify HEAD >/dev/null 2>&1; then
+  # commit is the sole commit on the branch. Even inside this block
+  # (PRE_INTEGRATION_HEAD empty), we re-verify that HEAD is a root commit
+  # to be sure we're not about to delete a reference we didn't create.
+  if git -C "$PROJECT_DIR" rev-parse --verify HEAD >/dev/null 2>&1; then
     commits_on_branch="$(git -C "$PROJECT_DIR" rev-list --count HEAD 2>/dev/null || echo 0)"
     if [ "$commits_on_branch" = "1" ]; then
-      # Safe to collapse: delete HEAD (leaves tree + staged files intact
-      # because `reset` below then matches the index to the (empty) tree
-      # at HEAD while preserving the working tree). The next
-      # `git add -A` + `git commit` lands everything as the sole commit.
+      # Delete HEAD — `git reset` below then matches the index to the
+      # now-empty tree at HEAD while preserving the working tree. The
+      # subsequent `git add -A` + `git commit` lands every scaffold file
+      # (integration-authored + base templates) as the sole commit.
       git -C "$PROJECT_DIR" update-ref -d HEAD >/dev/null 2>&1 || true
       git -C "$PROJECT_DIR" reset >/dev/null 2>&1 || true
     fi
   fi
 
   # Stage everything the integrations produced plus the base scaffold.
+  # `git add -A` is safe here because PRE_INTEGRATION_HEAD was empty —
+  # we know the entire working tree was authored by this scaffold run.
   git -C "$PROJECT_DIR" add -A
   if ! git -C "$PROJECT_DIR" diff --cached --quiet 2>/dev/null; then
     if git -C "$PROJECT_DIR" commit -m "chore: initial touchstone scaffold
@@ -1705,10 +1710,6 @@ Touchstone-Version: $TOUCHSTONE_SHA" >/dev/null 2>&1; then
     else
       echo "==> Initial commit skipped (git commit failed; check git identity)"
     fi
-  elif git -C "$PROJECT_DIR" rev-parse --verify HEAD >/dev/null 2>&1; then
-    # Nothing staged and HEAD exists — empty tree edge case (RE_INIT path
-    # never reaches here). Record current HEAD for the summary.
-    INITIAL_COMMIT_SHA="$(git -C "$PROJECT_DIR" rev-parse --short HEAD 2>/dev/null || true)"
   fi
 fi
 

--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -1647,12 +1647,14 @@ fi
 # bootstrap paradox: to commit you need the hooks un-armed; once hooks
 # are armed, you need a commit on the branch to push anything.
 #
-# Note on sentinel's internal gitignore commit: `sentinel init` attempts
-# to commit its own .gitignore edit when it detects a git repo. With the
-# new ordering, HEAD may not exist yet, so sentinel may create the very
-# first commit itself. That's fine — `git add -A` + `git commit` below
-# becomes a no-op if there's nothing left to commit, and $INITIAL_COMMIT_SHA
-# still reflects whatever HEAD points at.
+# Atomicity note: `sentinel init` may have already committed its own
+# .gitignore edit inside `_ensure_gitignore_entries` (it calls
+# `git commit -- .gitignore` when it detects a git repo). To keep the
+# scaffold a single atomic commit as promised, we detect any such
+# pre-existing HEAD and soft-reset it back into the index BEFORE
+# staging the rest of the tree. The final `git commit` then captures
+# everything — integration artifacts plus scaffold — as one commit
+# with a single author/message, so `rev-list --count HEAD` equals 1.
 INITIAL_COMMIT_SHA=""
 if [ "$RE_INIT" = false ] && [ "$INITIAL_COMMIT" = true ]; then
   # Fall back to a local git identity when none is configured globally, so the
@@ -1665,10 +1667,26 @@ if [ "$RE_INIT" = false ] && [ "$INITIAL_COMMIT" = true ]; then
     git -C "$PROJECT_DIR" config user.name "Touchstone Bootstrap"
   fi
 
+  # If an integration (e.g. sentinel init) already created the first
+  # commit on this branch, fold its changes back into the index so the
+  # touchstone initial commit is the sole commit on the branch. Only
+  # applies when HEAD has exactly one commit AND no parent — amending a
+  # user-authored history would be surprising, so we never touch a repo
+  # that already has >1 commit.
+  if git -C "$PROJECT_DIR" rev-parse --verify HEAD >/dev/null 2>&1; then
+    commits_on_branch="$(git -C "$PROJECT_DIR" rev-list --count HEAD 2>/dev/null || echo 0)"
+    if [ "$commits_on_branch" = "1" ]; then
+      # Safe to collapse: soft-reset to the empty tree preserves every
+      # file as staged. The next `git commit` below lands them as the
+      # sole commit.
+      git -C "$PROJECT_DIR" update-ref -d HEAD >/dev/null 2>&1 || true
+      git -C "$PROJECT_DIR" reset >/dev/null 2>&1 || true
+    fi
+  fi
+
   # Stage everything the integrations produced plus the base scaffold.
   git -C "$PROJECT_DIR" add -A
-  if ! git -C "$PROJECT_DIR" rev-parse --verify HEAD >/dev/null 2>&1; then
-    # No HEAD yet — this is the repo's first commit.
+  if ! git -C "$PROJECT_DIR" diff --cached --quiet 2>/dev/null; then
     if git -C "$PROJECT_DIR" commit -m "chore: initial touchstone scaffold
 
 Touchstone-Version: $TOUCHSTONE_SHA" >/dev/null 2>&1; then
@@ -1676,22 +1694,10 @@ Touchstone-Version: $TOUCHSTONE_SHA" >/dev/null 2>&1; then
     else
       echo "==> Initial commit skipped (git commit failed; check git identity)"
     fi
-  else
-    # HEAD already exists (sentinel init may have created a gitignore
-    # commit). Amend-free follow-up commit if there's anything staged.
-    if ! git -C "$PROJECT_DIR" diff --cached --quiet 2>/dev/null; then
-      if git -C "$PROJECT_DIR" commit -m "chore: initial touchstone scaffold
-
-Touchstone-Version: $TOUCHSTONE_SHA" >/dev/null 2>&1; then
-        INITIAL_COMMIT_SHA="$(git -C "$PROJECT_DIR" rev-parse --short HEAD 2>/dev/null || true)"
-      else
-        echo "==> Initial commit skipped (git commit failed; check git identity)"
-      fi
-    else
-      # Everything was already committed by an integration — record the
-      # current HEAD as the scaffold commit for the summary block.
-      INITIAL_COMMIT_SHA="$(git -C "$PROJECT_DIR" rev-parse --short HEAD 2>/dev/null || true)"
-    fi
+  elif git -C "$PROJECT_DIR" rev-parse --verify HEAD >/dev/null 2>&1; then
+    # Nothing staged and HEAD exists — empty tree edge case (RE_INIT path
+    # never reaches here). Record current HEAD for the summary.
+    INITIAL_COMMIT_SHA="$(git -C "$PROJECT_DIR" rev-parse --short HEAD 2>/dev/null || true)"
   fi
 fi
 

--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -30,6 +30,7 @@ REGISTER=true
 REGISTER_REQUESTED=false       # Doctrine 0002: track whether --register / --no-register was passed.
 INPUT_UNSAFE=""
 INPUT_TYPE=""
+# shellcheck disable=SC2034  # set below, read by future --type-aware branches.
 INPUT_TYPE_REQUESTED=false     # Tracks explicit --type (not the auto-detect fall-through).
 INPUT_REVIEWER=""
 INPUT_REVIEW_ASSIST=""
@@ -733,6 +734,7 @@ while [ "$#" -gt 0 ]; do
     --type)
       [ "$#" -ge 2 ] || { echo "ERROR: --type requires a value (node, python, swift, rust, go, generic, auto)" >&2; exit 1; }
       INPUT_TYPE="$(normalize_project_type "$2")"
+      # shellcheck disable=SC2034  # reserved for --type-aware branches.
       INPUT_TYPE_REQUESTED=true
       shift 2
       ;;
@@ -1205,12 +1207,14 @@ chmod +x "$PROJECT_DIR/scripts/"*.sh
 # Optional CI workflow — opt-in via --ci. Not copied by default because not every
 # project uses GitHub Actions, and shipping a workflow file silently into every
 # bootstrap would force that opinion on GitLab/Bitbucket/self-hosted users.
+# shellcheck disable=SC2034  # reserved for downstream summary printout.
 CI_WORKFLOW_CREATED=false
 if [ "$INPUT_CI" = "github" ]; then
   echo ""
   echo "==> Adding CI workflow (project-owned, won't be auto-updated):"
   copy_file "$TOUCHSTONE_ROOT/templates/ci/github-validate.yml" "$PROJECT_DIR/.github/workflows/validate.yml"
   if [ "$LAST_COPY_CREATED" = true ]; then
+    # shellcheck disable=SC2034  # reserved for downstream summary printout.
     CI_WORKFLOW_CREATED=true
   fi
 fi
@@ -1594,31 +1598,99 @@ fi
 
 write_touchstone_manifest
 
-# Initial commit on fresh scaffold — before hooks are installed, so the
-# "no-commit-to-branch" / default-branch guards in the freshly-installed
-# hooks don't block the user's first commit. Resolves the bootstrap paradox:
-# to commit you need the hooks un-armed; once hooks are armed, you need a
-# commit on the branch to push anything. This ordering solves that.
+# Doctrine 0002 — Cortex / Sentinel init run BEFORE the initial commit so
+# their scaffolded artifacts (.cortex/, .sentinel/, any .gitignore edits)
+# land in the same atom as the rest of the touchstone scaffold. Running
+# these after the commit used to leave the working tree half-committed
+# once hooks armed `no-commit-to-branch`. (R5.1 — see autumn-garage
+# journal/2026-04-18-r5-findings-from-fresh-scaffold.) GitHub repo
+# creation stays after hook install because `gh repo create --push`
+# needs the pre-push gate to exist.
+
+if [ "$WITH_CORTEX" = true ] && [ "$RE_INIT" = false ]; then
+  if command -v cortex >/dev/null 2>&1; then
+    echo ""
+    echo "==> Initializing Cortex ..."
+    if ( cd "$PROJECT_DIR" && cortex init ); then
+      :
+    else
+      echo "==> Cortex init failed (continuing)." >&2
+    fi
+  else
+    echo ""
+    echo "==> Cortex not on PATH — skipping cortex init."
+    echo "    Install: brew install autumngarage/cortex/cortex"
+  fi
+fi
+
+if [ "$WITH_SENTINEL" = true ] && [ "$RE_INIT" = false ]; then
+  if command -v sentinel >/dev/null 2>&1; then
+    echo ""
+    echo "==> Initializing Sentinel ..."
+    if ( cd "$PROJECT_DIR" && sentinel init ); then
+      :
+    else
+      echo "==> Sentinel init failed (continuing)." >&2
+    fi
+  else
+    echo ""
+    echo "==> Sentinel not on PATH — skipping sentinel init."
+    echo "    Install: brew install autumngarage/sentinel/sentinel"
+  fi
+fi
+
+# Initial commit on fresh scaffold — runs AFTER the integration inits
+# (above) so .cortex/, .sentinel/, and any gitignore updates those tools
+# made are captured in one commit, and BEFORE `pre-commit install` below
+# so the "no-commit-to-branch" / default-branch guards in the freshly-
+# installed hooks don't block the user's first commit. Resolves the
+# bootstrap paradox: to commit you need the hooks un-armed; once hooks
+# are armed, you need a commit on the branch to push anything.
+#
+# Note on sentinel's internal gitignore commit: `sentinel init` attempts
+# to commit its own .gitignore edit when it detects a git repo. With the
+# new ordering, HEAD may not exist yet, so sentinel may create the very
+# first commit itself. That's fine — `git add -A` + `git commit` below
+# becomes a no-op if there's nothing left to commit, and $INITIAL_COMMIT_SHA
+# still reflects whatever HEAD points at.
 INITIAL_COMMIT_SHA=""
 if [ "$RE_INIT" = false ] && [ "$INITIAL_COMMIT" = true ]; then
+  # Fall back to a local git identity when none is configured globally, so the
+  # commit succeeds on CI boxes and fresh dev machines. Global config, when
+  # present, wins because we only set the local keys if they resolve to empty.
+  if [ -z "$(git -C "$PROJECT_DIR" config --get user.email 2>/dev/null || true)" ]; then
+    git -C "$PROJECT_DIR" config user.email "touchstone@localhost"
+  fi
+  if [ -z "$(git -C "$PROJECT_DIR" config --get user.name 2>/dev/null || true)" ]; then
+    git -C "$PROJECT_DIR" config user.name "Touchstone Bootstrap"
+  fi
+
+  # Stage everything the integrations produced plus the base scaffold.
+  git -C "$PROJECT_DIR" add -A
   if ! git -C "$PROJECT_DIR" rev-parse --verify HEAD >/dev/null 2>&1; then
-    # Fall back to a local git identity when none is configured globally, so the
-    # commit succeeds on CI boxes and fresh dev machines. Global config, when
-    # present, wins because we only set the local keys if they resolve to empty.
-    if [ -z "$(git -C "$PROJECT_DIR" config --get user.email 2>/dev/null || true)" ]; then
-      git -C "$PROJECT_DIR" config user.email "touchstone@localhost"
-    fi
-    if [ -z "$(git -C "$PROJECT_DIR" config --get user.name 2>/dev/null || true)" ]; then
-      git -C "$PROJECT_DIR" config user.name "Touchstone Bootstrap"
-    fi
-    git -C "$PROJECT_DIR" add -A
-    # No --no-verify needed — hooks are installed after this commit on purpose.
+    # No HEAD yet — this is the repo's first commit.
     if git -C "$PROJECT_DIR" commit -m "chore: initial touchstone scaffold
 
 Touchstone-Version: $TOUCHSTONE_SHA" >/dev/null 2>&1; then
       INITIAL_COMMIT_SHA="$(git -C "$PROJECT_DIR" rev-parse --short HEAD 2>/dev/null || true)"
     else
       echo "==> Initial commit skipped (git commit failed; check git identity)"
+    fi
+  else
+    # HEAD already exists (sentinel init may have created a gitignore
+    # commit). Amend-free follow-up commit if there's anything staged.
+    if ! git -C "$PROJECT_DIR" diff --cached --quiet 2>/dev/null; then
+      if git -C "$PROJECT_DIR" commit -m "chore: initial touchstone scaffold
+
+Touchstone-Version: $TOUCHSTONE_SHA" >/dev/null 2>&1; then
+        INITIAL_COMMIT_SHA="$(git -C "$PROJECT_DIR" rev-parse --short HEAD 2>/dev/null || true)"
+      else
+        echo "==> Initial commit skipped (git commit failed; check git identity)"
+      fi
+    else
+      # Everything was already committed by an integration — record the
+      # current HEAD as the scaffold commit for the summary block.
+      INITIAL_COMMIT_SHA="$(git -C "$PROJECT_DIR" rev-parse --short HEAD 2>/dev/null || true)"
     fi
   fi
 fi
@@ -1665,41 +1737,10 @@ else
   printf '    registry: skipped (--no-register)\n'
 fi
 
-# Doctrine 0002 — Cortex / Sentinel / GitHub integrations. These all run after
-# the touchstone scaffold is on disk so a failure in any one leaves the core
-# project usable. Each prints a one-line success or skip message.
-
-if [ "$WITH_CORTEX" = true ] && [ "$RE_INIT" = false ]; then
-  if command -v cortex >/dev/null 2>&1; then
-    echo ""
-    echo "==> Initializing Cortex ..."
-    if ( cd "$PROJECT_DIR" && cortex init ); then
-      :
-    else
-      echo "==> Cortex init failed (continuing)." >&2
-    fi
-  else
-    echo ""
-    echo "==> Cortex not on PATH — skipping cortex init."
-    echo "    Install: brew install autumngarage/cortex/cortex"
-  fi
-fi
-
-if [ "$WITH_SENTINEL" = true ] && [ "$RE_INIT" = false ]; then
-  if command -v sentinel >/dev/null 2>&1; then
-    echo ""
-    echo "==> Initializing Sentinel ..."
-    if ( cd "$PROJECT_DIR" && sentinel init ); then
-      :
-    else
-      echo "==> Sentinel init failed (continuing)." >&2
-    fi
-  else
-    echo ""
-    echo "==> Sentinel not on PATH — skipping sentinel init."
-    echo "    Install: brew install autumngarage/sentinel/sentinel"
-  fi
-fi
+# Doctrine 0002 — GitHub repo creation runs after hook install so the
+# `gh repo create --push` goes through the pre-push gate. Cortex and
+# Sentinel init already ran above (before the initial commit) so their
+# artifacts are captured in the scaffold commit.
 
 if { [ "$GITHUB_MODE" = "private" ] || [ "$GITHUB_MODE" = "public" ]; } && [ "$RE_INIT" = false ]; then
   if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then

--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -1606,6 +1606,12 @@ write_touchstone_manifest
 # journal/2026-04-18-r5-findings-from-fresh-scaffold.) GitHub repo
 # creation stays after hook install because `gh repo create --push`
 # needs the pre-push gate to exist.
+#
+# Capture pre-integration HEAD state so the post-integration commit logic
+# can safely distinguish an integration-authored commit (created just now,
+# safe to collapse) from a pre-existing user commit (touchstone must never
+# rewrite). Empty string = no HEAD existed before integrations ran.
+PRE_INTEGRATION_HEAD="$(git -C "$PROJECT_DIR" rev-parse --verify HEAD 2>/dev/null || true)"
 
 if [ "$WITH_CORTEX" = true ] && [ "$RE_INIT" = false ]; then
   if command -v cortex >/dev/null 2>&1; then
@@ -1667,18 +1673,23 @@ if [ "$RE_INIT" = false ] && [ "$INITIAL_COMMIT" = true ]; then
     git -C "$PROJECT_DIR" config user.name "Touchstone Bootstrap"
   fi
 
-  # If an integration (e.g. sentinel init) already created the first
-  # commit on this branch, fold its changes back into the index so the
-  # touchstone initial commit is the sole commit on the branch. Only
-  # applies when HEAD has exactly one commit AND no parent — amending a
-  # user-authored history would be surprising, so we never touch a repo
-  # that already has >1 commit.
-  if git -C "$PROJECT_DIR" rev-parse --verify HEAD >/dev/null 2>&1; then
+  # If an integration (e.g. sentinel init) created a commit DURING this
+  # run, fold its changes back into the index so the touchstone initial
+  # commit is the sole commit on the branch. Guard with three conditions
+  # so we never rewrite user-authored history:
+  #   1. HEAD must not have existed before integrations ran.
+  #   2. HEAD must exist now (otherwise there's nothing to collapse).
+  #   3. HEAD must be a root commit (rev-list --count HEAD == 1).
+  # Any of these failing means the one commit on the branch pre-dates
+  # this scaffold; we leave it alone and add a follow-up commit instead.
+  if [ -z "$PRE_INTEGRATION_HEAD" ] \
+    && git -C "$PROJECT_DIR" rev-parse --verify HEAD >/dev/null 2>&1; then
     commits_on_branch="$(git -C "$PROJECT_DIR" rev-list --count HEAD 2>/dev/null || echo 0)"
     if [ "$commits_on_branch" = "1" ]; then
-      # Safe to collapse: soft-reset to the empty tree preserves every
-      # file as staged. The next `git commit` below lands them as the
-      # sole commit.
+      # Safe to collapse: delete HEAD (leaves tree + staged files intact
+      # because `reset` below then matches the index to the (empty) tree
+      # at HEAD while preserving the working tree). The next
+      # `git add -A` + `git commit` lands everything as the sole commit.
       git -C "$PROJECT_DIR" update-ref -d HEAD >/dev/null 2>&1 || true
       git -C "$PROJECT_DIR" reset >/dev/null 2>&1 || true
     fi

--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -1554,6 +1554,8 @@ print_summary() {
 }
 
 # Colors (respect NO_COLOR).
+# shellcheck disable=SC2034  # C_GREEN / C_CYAN kept for palette parity;
+# other color vars are referenced in printf statements above and below.
 if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
   C_DIM='\033[2m' C_GREEN='\033[0;32m'
   C_YELLOW='\033[0;33m' C_RED='\033[0;31m' C_CYAN='\033[0;36m' C_RESET='\033[0m'

--- a/lib/colors.sh
+++ b/lib/colors.sh
@@ -4,6 +4,8 @@
 #
 
 # Disable colors if stdout isn't a terminal or NO_COLOR is set.
+# shellcheck disable=SC2034  # BLUE kept for palette parity (exported to sourcing
+# callers); tk_* helpers below use RED/GREEN/YELLOW/BOLD/DIM/RESET directly.
 if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
   RED='\033[0;31m'
   GREEN='\033[0;32m'

--- a/lib/ui.sh
+++ b/lib/ui.sh
@@ -66,7 +66,7 @@ _tk_paint() {
 # Renders the Option E double-rail verdict signed "touchstone".
 tk_verdict() {
   local state="$1" headline="$2" subtitle="${3:-}"
-  local rail mark version_line sig
+  local rail mark sig
   rail="$(_tk_rail)"
 
   case "$state" in

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -1554,6 +1554,8 @@ print_summary() {
 }
 
 # Colors (respect NO_COLOR).
+# shellcheck disable=SC2034  # C_GREEN / C_CYAN kept for palette parity;
+# other color vars are referenced in printf statements above and below.
 if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
   C_DIM='\033[2m' C_GREEN='\033[0;32m'
   C_YELLOW='\033[0;33m' C_RED='\033[0;31m' C_CYAN='\033[0;36m' C_RESET='\033[0m'

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -1460,6 +1460,123 @@ assert_not_exists "$REGISTRY_SKIP_TMP/.touchstone-projects"
 assert_contains "$TEST_DIR/register-skip.txt" '==> Registry skipped (--no-register)'
 rm -rf "$REGISTRY_SKIP_TMP"
 
+# --------------------------------------------------------------------------
+# R5.1 — `--with-cortex --with-sentinel` must fold integration artifacts
+# into the same initial commit as the base scaffold. Before R5.1, cortex
+# and sentinel init ran AFTER the initial commit, leaving .cortex/ and
+# .sentinel/ uncommitted and the user forced to make a second commit on
+# main (which `no-commit-to-branch` then blocks). This test stubs both
+# CLIs with deterministic behavior and asserts the resulting repo has
+# exactly ONE commit that captures every integration-authored file.
+#
+# R5.2 — the touchstone-shipped .gitignore must NOT blanket-ignore
+# .sentinel/ at the project root. Sentinel's own .sentinel/.gitignore
+# (written by `sentinel init`) handles the ephemeral state/ exclusion;
+# blanket-ignoring defeats that design. The test asserts `.claude/` is
+# still ignored (it's Claude Code's per-user cache).
+# --------------------------------------------------------------------------
+
+echo ""
+echo "==> R5.1/R5.2: --with-cortex --with-sentinel ordering + gitignore scope"
+
+PROJECT_R5="$TEST_DIR/test-project-r5"
+R5_STUBDIR="$(mktemp -d -t touchstone-r5-stubs.XXXXXX)"
+
+# Fake cortex CLI: creates `.cortex/` with a tracked marker file, exactly the
+# shape the R5.1 fix needs captured in the initial commit.
+cat > "$R5_STUBDIR/cortex" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  init)
+    mkdir -p .cortex/doctrine .cortex/plans .cortex/journal
+    : > .cortex/state.md
+    : > .cortex/README.md
+    echo "cortex init (stub): created .cortex/"
+    ;;
+  *)
+    echo "cortex stub: unrecognized arg '${1:-}'" >&2; exit 2 ;;
+esac
+STUB
+chmod +x "$R5_STUBDIR/cortex"
+
+# Fake sentinel CLI: creates `.sentinel/` with a config + its own gitignore,
+# and appends a sentinel-artifacts block to the project's root .gitignore —
+# mirrors what real sentinel init does. Deliberately includes `.sentinel/` in
+# the block so the R5.2 assertion below fails if touchstone ever starts
+# writing that line itself (or if the stub drift-mirrors a broken upstream).
+cat > "$R5_STUBDIR/sentinel" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  init)
+    mkdir -p .sentinel
+    : > .sentinel/config.toml
+    printf 'state/\n' > .sentinel/.gitignore
+    # Note: we intentionally do NOT append `.sentinel/` to the root
+    # .gitignore here — R5.2 says touchstone must not blanket-ignore
+    # .sentinel/ at the root. Touchstone itself never writes that block
+    # (sentinel does, in its own init), so the stub mirrors that split.
+    if [ -f .gitignore ] && ! grep -q '^\.claude/$' .gitignore 2>/dev/null; then
+      printf '\n# sentinel artifacts — generated per-run, not source\n.claude/\n' >> .gitignore
+    fi
+    echo "sentinel init (stub): created .sentinel/"
+    ;;
+  *)
+    echo "sentinel stub: unrecognized arg '${1:-}'" >&2; exit 2 ;;
+esac
+STUB
+chmod +x "$R5_STUBDIR/sentinel"
+
+PATH="$R5_STUBDIR:$PATH" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" \
+  "$PROJECT_R5" --no-register --with-cortex --with-sentinel \
+  </dev/null >"$TEST_DIR/r5-bootstrap.txt" 2>&1 \
+  || { echo "FAIL: bootstrap with --with-cortex --with-sentinel exited non-zero"; cat "$TEST_DIR/r5-bootstrap.txt"; ERRORS=$((ERRORS+1)); }
+
+# R5.1 assertions: the integration outputs and the scaffold land in one commit.
+assert_exists "$PROJECT_R5/.cortex"
+assert_exists "$PROJECT_R5/.sentinel"
+
+if [ -d "$PROJECT_R5/.git" ]; then
+  # Exactly one commit on the branch — no "half-committed" follow-up.
+  commit_count="$(git -C "$PROJECT_R5" rev-list --count HEAD 2>/dev/null || echo 0)"
+  if [ "$commit_count" != "1" ]; then
+    echo "FAIL: expected 1 commit after --with-cortex --with-sentinel scaffold, got $commit_count" >&2
+    git -C "$PROJECT_R5" log --oneline >&2 || true
+    ERRORS=$((ERRORS+1))
+  fi
+
+  # Every integration-authored file must be in the initial commit's tree.
+  # `git log --all --raw` on a one-commit repo shows every path touched.
+  tracked="$(git -C "$PROJECT_R5" log --all --name-only --pretty=format: 2>/dev/null | sort -u)"
+  for path in .cortex/state.md .cortex/README.md .sentinel/config.toml .sentinel/.gitignore .gitignore; do
+    if ! printf '%s\n' "$tracked" | grep -qxF "$path"; then
+      echo "FAIL: expected $path to be tracked in the initial commit; got:" >&2
+      printf '%s\n' "$tracked" >&2
+      ERRORS=$((ERRORS+1))
+    fi
+  done
+
+  # Working tree must be clean — no leftover untracked artifacts.
+  if [ -n "$(git -C "$PROJECT_R5" status --porcelain 2>/dev/null)" ]; then
+    echo "FAIL: working tree dirty after scaffold:" >&2
+    git -C "$PROJECT_R5" status --porcelain >&2
+    ERRORS=$((ERRORS+1))
+  fi
+fi
+
+# R5.2 assertions: the root .gitignore must NOT blanket-ignore .sentinel/.
+# `.claude/` should still be present (the stub mirrors sentinel's real write).
+if [ -f "$PROJECT_R5/.gitignore" ]; then
+  if grep -qxF '.sentinel/' "$PROJECT_R5/.gitignore"; then
+    echo "FAIL: root .gitignore contains '.sentinel/' — R5.2 regression" >&2
+    ERRORS=$((ERRORS+1))
+  fi
+  assert_contains "$PROJECT_R5/.gitignore" '^\.claude/$'
+fi
+
+rm -rf "$R5_STUBDIR"
+
 echo ""
 if [ "$ERRORS" -eq 0 ]; then
   echo "==> PASS: all assertions passed"

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -1579,9 +1579,11 @@ fi
 
 # R5.1 regression guard: running the scaffold against a directory that
 # ALREADY has a git repo + user-authored commit must never rewrite that
-# commit. The collapse-to-one-commit path is scoped to integration-authored
-# commits only — if HEAD pre-dates this scaffold, touchstone appends
-# instead of collapsing, even under --with-sentinel.
+# commit, never sweep unrelated pending changes into a touchstone commit,
+# and never create a "chore: initial touchstone scaffold" commit at all.
+# The initial-commit path is scoped to fresh scaffolds — the
+# PRE_INTEGRATION_HEAD capture gates it, so an existing repo gets no
+# auto-commit from touchstone (same as pre-R5 behavior).
 PROJECT_R5_EXISTING="$TEST_DIR/test-project-r5-existing-history"
 mkdir -p "$PROJECT_R5_EXISTING"
 ( cd "$PROJECT_R5_EXISTING" \
@@ -1590,7 +1592,8 @@ mkdir -p "$PROJECT_R5_EXISTING"
   && git config user.name "User" \
   && echo "# prior work" > README.md \
   && git add README.md \
-  && git commit -q -m "feat: user's own initial commit" ) \
+  && git commit -q -m "feat: user's own initial commit" \
+  && echo "dirty-unrelated" > WIP.txt ) \
   >/dev/null 2>&1
 USER_HEAD_BEFORE="$(git -C "$PROJECT_R5_EXISTING" rev-parse HEAD 2>/dev/null || echo missing)"
 USER_SUBJECT_BEFORE="$(git -C "$PROJECT_R5_EXISTING" log -1 --pretty=%s HEAD 2>/dev/null || echo missing)"
@@ -1612,6 +1615,28 @@ if [ "$first_subject" != "$USER_SUBJECT_BEFORE" ]; then
   echo "FAIL: first commit subject changed from '$USER_SUBJECT_BEFORE' to '$first_subject'" >&2
   ERRORS=$((ERRORS+1))
 fi
+
+# No "chore: initial touchstone scaffold" commit should exist — that message
+# is reserved for fresh scaffolds. Touchstone files are simply added to the
+# worktree; the user commits them when they're ready.
+if git -C "$PROJECT_R5_EXISTING" log --pretty=%s 2>/dev/null | grep -qxF 'chore: initial touchstone scaffold'; then
+  echo "FAIL: touchstone created an initial-scaffold commit on a pre-existing repo" >&2
+  git -C "$PROJECT_R5_EXISTING" log --oneline >&2 || true
+  ERRORS=$((ERRORS+1))
+fi
+
+# The user's pre-existing WIP file must still be untracked-and-unstaged —
+# i.e., touchstone must not have silently `git add -A`'d it into any index.
+# (Cortex/sentinel stubs may have made their own commits; that's their
+# contract. What touchstone itself must not do is sweep the user's tree.)
+wip_status="$(git -C "$PROJECT_R5_EXISTING" status --porcelain WIP.txt 2>/dev/null || true)"
+case "$wip_status" in
+  '?? WIP.txt') : ;;                         # correct — still untracked
+  *)
+    echo "FAIL: touchstone staged/committed user's WIP.txt (status: '$wip_status')" >&2
+    ERRORS=$((ERRORS+1))
+    ;;
+esac
 
 # R5.2 assertions: the root .gitignore must NOT blanket-ignore .sentinel/.
 # `.claude/` should still be present (the stub mirrors sentinel's real write).

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -1577,6 +1577,42 @@ if [ -d "$PROJECT_R5/.git" ]; then
   fi
 fi
 
+# R5.1 regression guard: running the scaffold against a directory that
+# ALREADY has a git repo + user-authored commit must never rewrite that
+# commit. The collapse-to-one-commit path is scoped to integration-authored
+# commits only — if HEAD pre-dates this scaffold, touchstone appends
+# instead of collapsing, even under --with-sentinel.
+PROJECT_R5_EXISTING="$TEST_DIR/test-project-r5-existing-history"
+mkdir -p "$PROJECT_R5_EXISTING"
+( cd "$PROJECT_R5_EXISTING" \
+  && git init -q -b main \
+  && git config user.email "u@test" \
+  && git config user.name "User" \
+  && echo "# prior work" > README.md \
+  && git add README.md \
+  && git commit -q -m "feat: user's own initial commit" ) \
+  >/dev/null 2>&1
+USER_HEAD_BEFORE="$(git -C "$PROJECT_R5_EXISTING" rev-parse HEAD 2>/dev/null || echo missing)"
+USER_SUBJECT_BEFORE="$(git -C "$PROJECT_R5_EXISTING" log -1 --pretty=%s HEAD 2>/dev/null || echo missing)"
+
+PATH="$R5_STUBDIR:$PATH" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" \
+  "$PROJECT_R5_EXISTING" --no-register --with-cortex --with-sentinel \
+  </dev/null >"$TEST_DIR/r5-existing-bootstrap.txt" 2>&1 \
+  || { echo "FAIL: bootstrap into existing git repo exited non-zero"; cat "$TEST_DIR/r5-existing-bootstrap.txt"; ERRORS=$((ERRORS+1)); }
+
+# The user's commit SHA must still be reachable (not rewritten).
+if ! git -C "$PROJECT_R5_EXISTING" cat-file -e "$USER_HEAD_BEFORE" 2>/dev/null; then
+  echo "FAIL: touchstone scaffold rewrote user's pre-existing commit $USER_HEAD_BEFORE" >&2
+  ERRORS=$((ERRORS+1))
+fi
+
+# The user's commit must still be the first commit on the branch.
+first_subject="$(git -C "$PROJECT_R5_EXISTING" log --reverse --pretty=%s 2>/dev/null | head -1)"
+if [ "$first_subject" != "$USER_SUBJECT_BEFORE" ]; then
+  echo "FAIL: first commit subject changed from '$USER_SUBJECT_BEFORE' to '$first_subject'" >&2
+  ERRORS=$((ERRORS+1))
+fi
+
 # R5.2 assertions: the root .gitignore must NOT blanket-ignore .sentinel/.
 # `.claude/` should still be present (the stub mirrors sentinel's real write).
 if [ -f "$PROJECT_R5/.gitignore" ]; then

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -1501,10 +1501,12 @@ STUB
 chmod +x "$R5_STUBDIR/cortex"
 
 # Fake sentinel CLI: creates `.sentinel/` with a config + its own gitignore,
-# and appends a sentinel-artifacts block to the project's root .gitignore —
-# mirrors what real sentinel init does. Deliberately includes `.sentinel/` in
-# the block so the R5.2 assertion below fails if touchstone ever starts
-# writing that line itself (or if the stub drift-mirrors a broken upstream).
+# appends a `.claude/` entry to the project's root .gitignore (NOT `.sentinel/`
+# — that's R5.2), AND attempts its own `git commit -- .gitignore` when inside
+# a git repo. The real sentinel init does this to survive `sentinel work`'s
+# between-item `git reset --hard`; the stub mirrors it so the R5.1
+# atomicity assertion below properly exercises the "sentinel committed
+# first" code path in bootstrap/new-project.sh.
 cat > "$R5_STUBDIR/sentinel" <<'STUB'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -1519,6 +1521,16 @@ case "${1:-}" in
     # (sentinel does, in its own init), so the stub mirrors that split.
     if [ -f .gitignore ] && ! grep -q '^\.claude/$' .gitignore 2>/dev/null; then
       printf '\n# sentinel artifacts — generated per-run, not source\n.claude/\n' >> .gitignore
+      # Mirror real sentinel's `_commit_gitignore_if_in_repo` so the
+      # touchstone bootstrap is tested against the "integration already
+      # made a commit" shape, not just the "integration dirtied the
+      # working tree" shape.
+      if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        git add -- .gitignore >/dev/null 2>&1 || true
+        git -c user.email=sentinel@test -c user.name=sentinel \
+          commit -m "chore: gitignore sentinel artifacts (.claude/)" \
+          -- .gitignore >/dev/null 2>&1 || true
+      fi
     fi
     echo "sentinel init (stub): created .sentinel/"
     ;;

--- a/tests/test-shellcheck.sh
+++ b/tests/test-shellcheck.sh
@@ -25,7 +25,14 @@ fi
 # coverage legible — if a new directory starts shipping .sh files, it has to
 # be added here explicitly, which is the prompt to think about downstream
 # propagation.
-mapfile -t SCRIPTS < <(
+#
+# Uses a portable while-read loop instead of `mapfile` because macOS ships
+# /bin/bash 3.2, where `mapfile` is a missing builtin. The find + sort + loop
+# combo works identically on macOS stock bash and Homebrew bash.
+SCRIPTS=()
+while IFS= read -r script; do
+  [ -n "$script" ] && SCRIPTS+=("$script")
+done < <(
   find \
     "$TOUCHSTONE_ROOT/hooks" \
     "$TOUCHSTONE_ROOT/scripts" \

--- a/tests/test-shellcheck.sh
+++ b/tests/test-shellcheck.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# tests/test-shellcheck.sh — run the shell linter on every script Touchstone
+# ships or uses internally. This closes the R5.3 gap: before this test
+# existed, SC2034 warnings on scripts/codex-review.sh passed Touchstone's
+# own CI but failed downstream projects' pre-push hooks (which lint the
+# synced copy at --severity=warning). Any future SC2034-class bug should
+# now fail Touchstone's release flow before shipping instead of surfacing
+# in a fresh downstream scaffold.
+#
+# Severity matches the downstream scaffold's templates/pre-commit-config.yaml
+# (--severity=warning) so this test's bar is exactly what autumn-mail and
+# every touchstone-bootstrapped project enforces on push.
+#
+set -euo pipefail
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+if ! command -v shellcheck >/dev/null 2>&1; then
+  echo "==> SKIP: shellcheck not installed (brew install shellcheck)"
+  exit 0
+fi
+
+# Collect every shell script under the load-bearing directories. Keeps the
+# coverage legible — if a new directory starts shipping .sh files, it has to
+# be added here explicitly, which is the prompt to think about downstream
+# propagation.
+mapfile -t SCRIPTS < <(
+  find \
+    "$TOUCHSTONE_ROOT/hooks" \
+    "$TOUCHSTONE_ROOT/scripts" \
+    "$TOUCHSTONE_ROOT/bootstrap" \
+    "$TOUCHSTONE_ROOT/lib" \
+    "$TOUCHSTONE_ROOT/tests" \
+    -maxdepth 1 -type f -name '*.sh' -print 2>/dev/null | sort
+)
+
+if [ "${#SCRIPTS[@]}" -eq 0 ]; then
+  echo "FAIL: no shell scripts found under hooks/, scripts/, bootstrap/, lib/, tests/" >&2
+  exit 1
+fi
+
+echo "==> Test: shellcheck --severity=warning on ${#SCRIPTS[@]} shipped shell scripts"
+
+if ! shellcheck --severity=warning "${SCRIPTS[@]}"; then
+  echo "" >&2
+  echo "FAIL: shellcheck flagged warnings in touchstone-shipped scripts." >&2
+  echo "      Downstream projects run shellcheck at this same severity on" >&2
+  echo "      their pre-push hook (templates/pre-commit-config.yaml), so" >&2
+  echo "      any warning here will block a fresh scaffold's first push." >&2
+  echo "      Fix the warning or add an inline '# shellcheck disable=<code>'" >&2
+  echo "      with a short comment explaining why the exception is safe." >&2
+  exit 1
+fi
+
+echo "==> PASS: shellcheck clean at --severity=warning"


### PR DESCRIPTION
Three findings surfaced by autumn-mail's fresh scaffold (see
autumn-garage journal 2026-04-18-r5-findings-from-fresh-scaffold):

- R5.1: initial commit now runs AFTER --with-cortex and --with-sentinel
  so their artifacts are captured in one atom. Resolves the bootstrap
  paradox introduced by R2 flags running after R1's initial-commit.
- R5.2: --with-sentinel no longer blanket-ignores .sentinel/ at root.
  Sentinel's own .sentinel/.gitignore (shipped by sentinel init) handles
  the state/ exclusion. Blanket-ignoring defeated that design. Note:
  the code that writes the root .gitignore block lives in sentinel's
  init_cmd.py; touchstone-side tests here pin the expected end-state
  (no .sentinel/ in root .gitignore, .claude/ still ignored) and a
  companion sentinel PR removes the offending line there.
- R5.3: SC2034 warnings on C_GREEN/C_CYAN in codex-review.sh fixed
  (both hooks/ and scripts/ kept byte-parity). Added shellcheck to
  touchstone's own CI so this class of bug fails the release flow
  before shipping.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
