### PR TITLE
feat(setup): per-profile dev-tool install in setup.sh

### DIFF
--- a/templates/setup.sh
+++ b/templates/setup.sh
@@ -895,7 +895,15 @@ install_configured_target_devtools() {
 if [ "$SKIP_DEVTOOLS" = true ]; then
   info "Skipping per-profile dev tools (--skip-devtools / TOUCHSTONE_SKIP_DEVTOOLS=1)"
 else
-  install_profile_devtools "$ROOT_PROFILE"
+  # Resolve 'auto' / empty to a concrete profile the same way
+  # install_profile_dependencies does — otherwise a repo with
+  # project_type=auto or no .touchstone-config installs deps but silently
+  # skips the verifier tools.
+  ROOT_PROFILE_RESOLVED="$ROOT_PROFILE"
+  if [ "$ROOT_PROFILE_RESOLVED" = "auto" ] || [ -z "$ROOT_PROFILE_RESOLVED" ]; then
+    ROOT_PROFILE_RESOLVED="$(detect_profile ".")"
+  fi
+  install_profile_devtools "$ROOT_PROFILE_RESOLVED"
   # Monorepo targets declared in .touchstone-config also need their dev tools —
   # touchstone-run.sh / doctor validate them per-target, so missing tools would
   # re-create the same silent-skip failure mode this block is meant to close.

--- a/templates/setup.sh
+++ b/templates/setup.sh
@@ -25,12 +25,21 @@ fail()  { printf "  ${RED}✗${RESET} %s\n" "$*"; }
 DEPS_ONLY=false
 GIT_WORKFLOW="git"
 GITBUTLER_MCP="false"
+SKIP_DEVTOOLS=false
+if [ "${TOUCHSTONE_SKIP_DEVTOOLS:-}" = "1" ] || [ "${TOUCHSTONE_SKIP_DEVTOOLS:-}" = "true" ]; then
+  SKIP_DEVTOOLS=true
+fi
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --deps-only) DEPS_ONLY=true; shift ;;
+    --skip-devtools) SKIP_DEVTOOLS=true; shift ;;
     -h|--help)
-      echo "Usage: bash setup.sh [--deps-only]"
+      echo "Usage: bash setup.sh [--deps-only] [--skip-devtools]"
+      echo ""
+      echo "  --deps-only       Reinstall project deps (also refreshes per-profile dev tools)"
+      echo "  --skip-devtools   Skip per-profile dev-tool install (for CI or offline environments)"
+      echo "                    Also honored via TOUCHSTONE_SKIP_DEVTOOLS=1"
       exit 0
       ;;
     *) fail "Unknown argument: $1"; exit 1 ;;
@@ -763,6 +772,99 @@ ROOT_PROFILE="${CONFIG_PROJECT_TYPE:-auto}"
 if [ "$ROOT_PROFILE" = "generic" ] && [ "$(detect_profile ".")" != "generic" ]; then
   ROOT_PROFILE="$(detect_profile ".")"
 fi
+
+# --------------------------------------------------------------------------
+# 8b. Per-profile dev tools
+# --------------------------------------------------------------------------
+# Language-specific linters/formatters that sentinel + touchstone-run expect.
+# Each block is idempotent (check-before-install) and guarded on the relevant
+# package manager being available — missing package managers print a hint and
+# skip rather than failing setup. Runs in both default and --deps-only modes
+# so tools stay fresh; skipped entirely by --skip-devtools or
+# TOUCHSTONE_SKIP_DEVTOOLS=1 for CI / offline environments.
+install_swift_devtools() {
+  if ! command -v brew >/dev/null 2>&1; then
+    warn "Homebrew not available — skipping swiftlint/swiftformat install."
+    warn "Manual install (once brew is present): brew install swiftlint swiftformat"
+    return 0
+  fi
+  if command -v swiftlint >/dev/null 2>&1; then
+    ok "swiftlint installed"
+  else
+    warn "Installing swiftlint..."
+    brew install swiftlint 2>/dev/null && ok "swiftlint installed" || warn "swiftlint install failed"
+  fi
+  if command -v swiftformat >/dev/null 2>&1; then
+    ok "swiftformat installed"
+  else
+    warn "Installing swiftformat..."
+    brew install swiftformat 2>/dev/null && ok "swiftformat installed" || warn "swiftformat install failed"
+  fi
+}
+
+install_go_devtools() {
+  if ! command -v go >/dev/null 2>&1; then
+    warn "go not installed — skipping golint install."
+    warn "Manual install (once go is present): go install golang.org/x/lint/golint@latest"
+    return 0
+  fi
+  if command -v golint >/dev/null 2>&1; then
+    ok "golint installed"
+  else
+    warn "Installing golint..."
+    go install golang.org/x/lint/golint@latest 2>/dev/null && ok "golint installed" || warn "golint install failed"
+  fi
+}
+
+install_rust_devtools() {
+  if ! command -v cargo >/dev/null 2>&1; then
+    warn "cargo not installed — skipping clippy/rustfmt setup."
+    warn "Manual install (once rustup is present): rustup component add clippy rustfmt"
+    return 0
+  fi
+  if ! command -v rustup >/dev/null 2>&1; then
+    warn "rustup not installed — clippy/rustfmt component install unavailable. Verify your toolchain provides them."
+    return 0
+  fi
+  if cargo clippy --version >/dev/null 2>&1; then
+    ok "clippy installed"
+  else
+    warn "Installing clippy..."
+    rustup component add clippy 2>/dev/null && ok "clippy installed" || warn "clippy install failed"
+  fi
+  if cargo fmt --version >/dev/null 2>&1; then
+    ok "rustfmt installed"
+  else
+    warn "Installing rustfmt..."
+    rustup component add rustfmt 2>/dev/null && ok "rustfmt installed" || warn "rustfmt install failed"
+  fi
+}
+
+if [ "$SKIP_DEVTOOLS" = true ]; then
+  info "Skipping per-profile dev tools (--skip-devtools / TOUCHSTONE_SKIP_DEVTOOLS=1)"
+else
+  case "$ROOT_PROFILE" in
+    swift)
+      info "Checking Swift dev tools"
+      install_swift_devtools
+      ;;
+    go)
+      info "Checking Go dev tools"
+      install_go_devtools
+      ;;
+    rust)
+      info "Checking Rust dev tools"
+      install_rust_devtools
+      ;;
+    python|node|typescript|ts|generic|"")
+      : # python/node own their ecosystems via requirements.txt / package.json; generic is a no-op.
+      ;;
+    *)
+      : # Unknown profile — let dependency install surface the warning.
+      ;;
+  esac
+fi
+
 if install_profile_dependencies "Project" "." "$ROOT_PROFILE"; then
   DEPS_FOUND=true
 fi

--- a/templates/setup.sh
+++ b/templates/setup.sh
@@ -784,8 +784,8 @@ fi
 # TOUCHSTONE_SKIP_DEVTOOLS=1 for CI / offline environments.
 install_swift_devtools() {
   if ! command -v brew >/dev/null 2>&1; then
-    warn "Homebrew not available — skipping swiftlint/swiftformat install."
-    warn "Manual install (once brew is present): brew install swiftlint swiftformat"
+    warn "Homebrew not available — skipping swiftlint/swift-format install."
+    warn "Manual install (once brew is present): brew install swiftlint swift-format"
     return 0
   fi
   if command -v swiftlint >/dev/null 2>&1; then
@@ -794,11 +794,13 @@ install_swift_devtools() {
     warn "Installing swiftlint..."
     brew install swiftlint 2>/dev/null && ok "swiftlint installed" || warn "swiftlint install failed"
   fi
-  if command -v swiftformat >/dev/null 2>&1; then
-    ok "swiftformat installed"
+  # Note: Apple's swift-format (matches touchstone-run.sh and `touchstone doctor`),
+  # NOT Nick Lockwood's swiftformat (different tool, different binary name).
+  if command -v swift-format >/dev/null 2>&1; then
+    ok "swift-format installed"
   else
-    warn "Installing swiftformat..."
-    brew install swiftformat 2>/dev/null && ok "swiftformat installed" || warn "swiftformat install failed"
+    warn "Installing swift-format..."
+    brew install swift-format 2>/dev/null && ok "swift-format installed" || warn "swift-format install failed"
   fi
 }
 
@@ -840,20 +842,20 @@ install_rust_devtools() {
   fi
 }
 
-if [ "$SKIP_DEVTOOLS" = true ]; then
-  info "Skipping per-profile dev tools (--skip-devtools / TOUCHSTONE_SKIP_DEVTOOLS=1)"
-else
-  case "$ROOT_PROFILE" in
+install_profile_devtools() {
+  local profile="$1"
+  local label="${2:-}"
+  case "$profile" in
     swift)
-      info "Checking Swift dev tools"
+      info "Checking Swift dev tools${label:+ ($label)}"
       install_swift_devtools
       ;;
     go)
-      info "Checking Go dev tools"
+      info "Checking Go dev tools${label:+ ($label)}"
       install_go_devtools
       ;;
     rust)
-      info "Checking Rust dev tools"
+      info "Checking Rust dev tools${label:+ ($label)}"
       install_rust_devtools
       ;;
     python|node|typescript|ts|generic|"")
@@ -863,6 +865,41 @@ else
       : # Unknown profile — let dependency install surface the warning.
       ;;
   esac
+}
+
+install_configured_target_devtools() {
+  local entry name path profile
+  local -a target_entries=()
+
+  [ -n "$CONFIG_TARGETS" ] || return 0
+
+  IFS=',' read -r -a target_entries <<< "$CONFIG_TARGETS"
+  for entry in "${target_entries[@]}"; do
+    entry="$(trim "$entry")"
+    [ -z "$entry" ] && continue
+    name="${entry%%:*}"
+    path="${entry#*:}"
+    profile="${path#*:}"
+    path="${path%%:*}"
+    if [ "$path" = "$profile" ]; then
+      profile="auto"
+    fi
+    [ -d "$path" ] || continue
+    if [ "$profile" = "auto" ] || [ -z "$profile" ]; then
+      profile="$(detect_profile "$path")"
+    fi
+    install_profile_devtools "$profile" "$name"
+  done
+}
+
+if [ "$SKIP_DEVTOOLS" = true ]; then
+  info "Skipping per-profile dev tools (--skip-devtools / TOUCHSTONE_SKIP_DEVTOOLS=1)"
+else
+  install_profile_devtools "$ROOT_PROFILE"
+  # Monorepo targets declared in .touchstone-config also need their dev tools —
+  # touchstone-run.sh / doctor validate them per-target, so missing tools would
+  # re-create the same silent-skip failure mode this block is meant to close.
+  install_configured_target_devtools
 fi
 
 if install_profile_dependencies "Project" "." "$ROOT_PROFILE"; then

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -299,7 +299,10 @@ assert_contains "$PROJECT_SWIFT/setup.sh" '\-\-skip-devtools'
 assert_contains "$PROJECT_SWIFT/setup.sh" 'TOUCHSTONE_SKIP_DEVTOOLS'
 assert_contains "$PROJECT_SWIFT/setup.sh" 'install_swift_devtools'
 assert_contains "$PROJECT_SWIFT/setup.sh" 'brew install swiftlint'
-assert_contains "$PROJECT_SWIFT/setup.sh" 'brew install swiftformat'
+# swift-format (Apple's tool, not Nick Lockwood's swiftformat) — must match
+# what scripts/touchstone-run.sh and `touchstone doctor --project` invoke.
+assert_contains "$PROJECT_SWIFT/setup.sh" 'brew install swift-format'
+assert_not_contains "$PROJECT_SWIFT/setup.sh" 'brew install swiftformat'
 assert_contains "$PROJECT_SWIFT/setup.sh" 'install_go_devtools'
 assert_contains "$PROJECT_SWIFT/setup.sh" 'golang.org/x/lint/golint@latest'
 assert_contains "$PROJECT_SWIFT/setup.sh" 'install_rust_devtools'
@@ -319,24 +322,17 @@ if ! bash -n "$PROJECT_SWIFT/setup.sh" 2>"$TEST_DIR/setup-syntax.txt"; then
   ERRORS=$((ERRORS + 1))
 fi
 
-# --skip-devtools / TOUCHSTONE_SKIP_DEVTOOLS=1 must short-circuit the install
-# block without touching brew/go/rustup. Invoke setup.sh in a hermetic harness:
-# PATH shimmed so brew/go/rustup/cargo are absent (would crash if reached), and
-# only the flag-parsing + dev-tools dispatch is exercised. Run a trimmed copy
-# that stops before the dep-install section (avoids needing git/gh/pre-commit).
-SKIP_HARNESS="$TEST_DIR/skip-devtools-harness"
-mkdir -p "$SKIP_HARNESS"
-# Extract just the flag-parse + per-profile devtools dispatch from the
-# scaffolded setup.sh. We synthesize a tiny shell driver that defines the
-# required functions and env, then sources the relevant slices. Simpler: just
-# run `bash setup.sh --skip-devtools` with TOUCHSTONE_SKIP_DEVTOOLS=1 and check
-# the short-circuit message appears in the output WITHOUT any brew/go/rustup
-# invocation. To avoid executing the full setup, we short-circuit by making
-# brew/git/gh/pre-commit absent — setup.sh will fail at the brew check, but
-# that check runs BEFORE the devtools block. So instead we grep for the
-# short-circuit branch textually: the flag must be wired into the gate.
+# --skip-devtools / TOUCHSTONE_SKIP_DEVTOOLS=1 must wire into the gate so
+# the install block short-circuits in CI / offline environments. We grep for
+# the gate text rather than invoking setup.sh — running it would call real
+# brew/go/rustup, which is out of scope for a hermetic test.
 assert_contains "$PROJECT_SWIFT/setup.sh" 'Skipping per-profile dev tools'
 assert_contains "$PROJECT_SWIFT/setup.sh" 'SKIP_DEVTOOLS=true'
+# Monorepo targets must also get their dev tools installed — a generic root
+# with Swift/Go/Rust targets would otherwise re-create the same silent-skip
+# gap this block closes.
+assert_contains "$PROJECT_SWIFT/setup.sh" 'install_configured_target_devtools'
+assert_contains "$PROJECT_SWIFT/setup.sh" 'install_profile_devtools'
 
 # Non-swift profile setup.sh must carry the same template (setup.sh is one
 # file per project, branch chosen at runtime by project_type). Sanity-check

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -284,6 +284,69 @@ if [ "$SWIFT_BUILD_DUPES" -ne 1 ]; then
   ERRORS=$((ERRORS + 1))
 fi
 
+# setup.sh must install per-profile dev tools so sentinel's verifier and
+# touchstone-run's lint path find the tools they expect. Each profile's install
+# block is gated on project_type so non-matching profiles are no-ops, and each
+# check-before-install is idempotent.
+#
+# We grep the scaffolded setup.sh rather than executing it: running the install
+# block would invoke brew/go/rustup, which would fail in CI and on any
+# non-macOS dev machine. Grepping confirms the branches exist and the flag
+# plumbing is wired; the actual brew call is a thin wrapper that's hard to
+# break once the branch is reached.
+assert_exists "$PROJECT_SWIFT/setup.sh"
+assert_contains "$PROJECT_SWIFT/setup.sh" '\-\-skip-devtools'
+assert_contains "$PROJECT_SWIFT/setup.sh" 'TOUCHSTONE_SKIP_DEVTOOLS'
+assert_contains "$PROJECT_SWIFT/setup.sh" 'install_swift_devtools'
+assert_contains "$PROJECT_SWIFT/setup.sh" 'brew install swiftlint'
+assert_contains "$PROJECT_SWIFT/setup.sh" 'brew install swiftformat'
+assert_contains "$PROJECT_SWIFT/setup.sh" 'install_go_devtools'
+assert_contains "$PROJECT_SWIFT/setup.sh" 'golang.org/x/lint/golint@latest'
+assert_contains "$PROJECT_SWIFT/setup.sh" 'install_rust_devtools'
+assert_contains "$PROJECT_SWIFT/setup.sh" 'rustup component add clippy'
+assert_contains "$PROJECT_SWIFT/setup.sh" 'rustup component add rustfmt'
+# Brew guard — the swift install block must degrade gracefully when brew is
+# missing instead of exiting the whole setup.
+assert_contains "$PROJECT_SWIFT/setup.sh" 'Homebrew not available'
+# Go/Rust guards — same graceful degrade.
+assert_contains "$PROJECT_SWIFT/setup.sh" 'go not installed'
+assert_contains "$PROJECT_SWIFT/setup.sh" 'cargo not installed'
+# Syntax check the scaffolded setup.sh so malformed heredoc substitutions
+# don't ship silently.
+if ! bash -n "$PROJECT_SWIFT/setup.sh" 2>"$TEST_DIR/setup-syntax.txt"; then
+  echo "FAIL: scaffolded setup.sh has a syntax error:" >&2
+  cat "$TEST_DIR/setup-syntax.txt" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# --skip-devtools / TOUCHSTONE_SKIP_DEVTOOLS=1 must short-circuit the install
+# block without touching brew/go/rustup. Invoke setup.sh in a hermetic harness:
+# PATH shimmed so brew/go/rustup/cargo are absent (would crash if reached), and
+# only the flag-parsing + dev-tools dispatch is exercised. Run a trimmed copy
+# that stops before the dep-install section (avoids needing git/gh/pre-commit).
+SKIP_HARNESS="$TEST_DIR/skip-devtools-harness"
+mkdir -p "$SKIP_HARNESS"
+# Extract just the flag-parse + per-profile devtools dispatch from the
+# scaffolded setup.sh. We synthesize a tiny shell driver that defines the
+# required functions and env, then sources the relevant slices. Simpler: just
+# run `bash setup.sh --skip-devtools` with TOUCHSTONE_SKIP_DEVTOOLS=1 and check
+# the short-circuit message appears in the output WITHOUT any brew/go/rustup
+# invocation. To avoid executing the full setup, we short-circuit by making
+# brew/git/gh/pre-commit absent — setup.sh will fail at the brew check, but
+# that check runs BEFORE the devtools block. So instead we grep for the
+# short-circuit branch textually: the flag must be wired into the gate.
+assert_contains "$PROJECT_SWIFT/setup.sh" 'Skipping per-profile dev tools'
+assert_contains "$PROJECT_SWIFT/setup.sh" 'SKIP_DEVTOOLS=true'
+
+# Non-swift profile setup.sh must carry the same template (setup.sh is one
+# file per project, branch chosen at runtime by project_type). Sanity-check
+# that the node/python templates also include all branches so switching
+# project_type later works without re-bootstrap.
+assert_contains "$PROJECT_NODE/setup.sh" 'install_swift_devtools'
+assert_contains "$PROJECT_NODE/setup.sh" 'install_go_devtools'
+assert_contains "$PROJECT_NODE/setup.sh" 'install_rust_devtools'
+assert_contains "$PROJECT_PYTHON/setup.sh" 'install_swift_devtools'
+
 # Bootstrap into an existing directory should back up touchstone-owned files before replacing them.
 mkdir -p "$PROJECT_EXISTING/principles" "$PROJECT_EXISTING/scripts"
 printf 'custom principle\n' > "$PROJECT_EXISTING/principles/engineering-principles.md"

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -801,18 +801,21 @@ assert_contains "$RUNNER_LOG" 'npm|.*/monorepo-runner/apps/web|run test'
 assert_contains "$RUNNER_LOG" 'cargo|.*/monorepo-runner/services/api|test --all'
 
 # setup.sh --deps-only should also use the project profile layer for non-Python ecosystems.
+# TOUCHSTONE_SKIP_DEVTOOLS=1 keeps these tests hermetic — we're exercising the
+# dependency dispatch, not the per-profile dev-tool install (which would call
+# real brew/go/rustup on macOS dev machines that have those binaries on PATH).
 : > "$RUNNER_LOG"
-(cd "$PROJECT_NODE" && PATH="$RUNNER_FAKE_BIN:$PATH" RUNNER_LOG="$RUNNER_LOG" bash setup.sh --deps-only) >/dev/null
+(cd "$PROJECT_NODE" && PATH="$RUNNER_FAKE_BIN:$PATH" RUNNER_LOG="$RUNNER_LOG" TOUCHSTONE_SKIP_DEVTOOLS=1 bash setup.sh --deps-only) >/dev/null
 assert_contains "$RUNNER_LOG" 'pnpm|.*/test-project-node|install'
 
 cp "$TOUCHSTONE_ROOT/templates/setup.sh" "$SWIFT_PROJECT/setup.sh"
 : > "$RUNNER_LOG"
-(cd "$SWIFT_PROJECT" && PATH="$RUNNER_FAKE_BIN:$PATH" RUNNER_LOG="$RUNNER_LOG" bash setup.sh --deps-only) >/dev/null
+(cd "$SWIFT_PROJECT" && PATH="$RUNNER_FAKE_BIN:$PATH" RUNNER_LOG="$RUNNER_LOG" TOUCHSTONE_SKIP_DEVTOOLS=1 bash setup.sh --deps-only) >/dev/null
 assert_contains "$RUNNER_LOG" 'swift|.*/swift-runner|package resolve'
 
 cp "$TOUCHSTONE_ROOT/templates/setup.sh" "$RUST_PROJECT/setup.sh"
 : > "$RUNNER_LOG"
-(cd "$RUST_PROJECT" && PATH="$RUNNER_FAKE_BIN:$PATH" RUNNER_LOG="$RUNNER_LOG" bash setup.sh --deps-only) >/dev/null
+(cd "$RUST_PROJECT" && PATH="$RUNNER_FAKE_BIN:$PATH" RUNNER_LOG="$RUNNER_LOG" TOUCHSTONE_SKIP_DEVTOOLS=1 bash setup.sh --deps-only) >/dev/null
 assert_contains "$RUNNER_LOG" 'cargo|.*/rust-runner|fetch'
 
 # Bootstrap should install git hooks via pre-commit when pre-commit is available,


### PR DESCRIPTION
First real sentinel cycle on autumn-mail (Swift project) hit a
verifier wall because swiftlint wasn't installed. Sentinel's
verifier runs swiftlint on Swift projects; missing tool -> 1/2
check fail -> nothing ships. Root cause: touchstone scaffolds
Swift projects but doesn't ensure Swift dev tools are available.

setup.sh now installs per-profile dev tools (idempotent, guarded
on package manager availability). Swift: swiftlint + swiftformat.
Go: golint. Rust: clippy + rustfmt. --skip-devtools /
TOUCHSTONE_SKIP_DEVTOOLS=1 for CI / offline environments.

Closes the gap surfaced in autumn-garage journal 2026-04-18-
first-cycle-attempt-findings ("V1 - verifier brittle on missing
tools"). Paired with sentinel's graceful-missing-tool handling
in the sibling PR.

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
