### PR TITLE
feat(swift): ship .swiftlint.yml template with build artifact excludes

### DIFF
--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -1588,6 +1588,26 @@ if [ "$RE_INIT" = false ]; then
   append_profile_gitignore_entries "$PROJECT_DIR" "$INPUT_TYPE"
 fi
 
+# Per-profile project-owned templates (e.g. swift's .swiftlint.yml). copy_file
+# is the project-owned semantic — adds when missing, leaves any hand-edited
+# version untouched on re-init. Runs on both fresh and re-init so projects
+# bootstrapped before the swiftlint template existed pick it up the next time
+# they run `touchstone init`.
+copy_profile_templates() {
+  local project_dir="$1" profile="$2"
+  case "$profile" in
+    swift)
+      if [ -f "$TOUCHSTONE_ROOT/templates/swift/.swiftlint.yml" ]; then
+        copy_file "$TOUCHSTONE_ROOT/templates/swift/.swiftlint.yml" "$project_dir/.swiftlint.yml"
+      fi
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+}
+copy_profile_templates "$PROJECT_DIR" "$INPUT_TYPE"
+
 # Optional --scaffold-tests: write one smoke test per profile when no tests
 # exist, so a fresh repo has something for touchstone-run.sh test to find.
 # Off by default — project owners decide their test framework; we just prime

--- a/bootstrap/update-project.sh
+++ b/bootstrap/update-project.sh
@@ -320,6 +320,41 @@ if [ "$PROJECT_TYPE" = "python" ] || [ -f "$PROJECT_DIR/scripts/run-pytest-in-ve
   update_file "$TOUCHSTONE_ROOT/scripts/run-pytest-in-venv.sh" "$PROJECT_DIR/scripts/run-pytest-in-venv.sh"
 fi
 
+# Per-profile project-owned templates (e.g. swift's .swiftlint.yml). These are
+# NOT touchstone-owned: add when missing, never overwrite a hand-edited copy.
+# They stay out of .touchstone-manifest so future `touchstone update` runs do
+# not clobber project-owned customization.
+PROJECT_OWNED_ADDED_PATHS=()
+add_profile_project_template_if_missing() {
+  local src="$1" dst="$2"
+  local rel_path
+  rel_path="$(relative_project_path "$dst")"
+
+  if [ -f "$dst" ]; then
+    # Hand-edited or already-shipped — leave alone. update_file handles
+    # touchstone-owned files; this helper exists precisely so project-owned
+    # additions skip when present, even if the on-disk content differs.
+    return 0
+  fi
+
+  if [ "$DRY_RUN" = true ]; then
+    echo "    + would add (project-owned): $dst"
+    return 0
+  fi
+
+  mkdir -p "$(dirname "$dst")"
+  cp "$src" "$dst"
+  ADDED_PATHS+=("$rel_path")
+  PROJECT_OWNED_ADDED_PATHS+=("$rel_path")
+  echo "    + added (project-owned): $dst"
+}
+
+if [ "$PROJECT_TYPE" = "swift" ] && [ -f "$TOUCHSTONE_ROOT/templates/swift/.swiftlint.yml" ]; then
+  add_profile_project_template_if_missing \
+    "$TOUCHSTONE_ROOT/templates/swift/.swiftlint.yml" \
+    "$PROJECT_DIR/.swiftlint.yml"
+fi
+
 write_touchstone_manifest() {
   local manifest="$PROJECT_DIR/.touchstone-manifest"
   {
@@ -368,6 +403,14 @@ if [ "$DRY_RUN" = false ]; then
   echo "==> Committing touchstone update..."
   git -C "$PROJECT_DIR" add -A -- principles scripts .touchstone-manifest
   git -C "$PROJECT_DIR" add -f -- .touchstone-version
+  # Stage any per-profile project-owned templates added on this run (e.g.
+  # swift's .swiftlint.yml). These are project-owned, but the addition only
+  # makes sense bundled into the same review commit as the rest of the
+  # update — leaving them unstaged would make `touchstone update --ship`
+  # ship an incomplete change.
+  if [ "${#PROJECT_OWNED_ADDED_PATHS[@]}" -gt 0 ]; then
+    git -C "$PROJECT_DIR" add -f -- "${PROJECT_OWNED_ADDED_PATHS[@]}"
+  fi
 
   if git -C "$PROJECT_DIR" diff --cached --quiet; then
     echo "    No file changes to commit."

--- a/templates/swift/.swiftlint.yml
+++ b/templates/swift/.swiftlint.yml
@@ -1,0 +1,38 @@
+# Touchstone-managed default. Customize per-project; touchstone update
+# will not overwrite a hand-edited .swiftlint.yml.
+
+excluded:
+  - .build
+  - .swiftpm
+  - DerivedData
+  - Pods
+  - vendor
+  - .git
+  - node_modules
+
+# Sensible default severity. Tune per-project as needed.
+opt_in_rules:
+  - empty_count
+  - empty_string
+  - first_where
+  - last_where
+  - sorted_first_last
+
+# Allow common short identifier names (i, j, k for indices; x, y for coords)
+identifier_name:
+  min_length: 1
+  excluded:
+    - i
+    - j
+    - k
+    - x
+    - y
+    - z
+    - id
+    - to
+    - of
+
+# Generous line length (200 chars) — matches autumn-mail's historical practice
+line_length:
+  warning: 160
+  error: 200

--- a/templates/swift/.swiftlint.yml
+++ b/templates/swift/.swiftlint.yml
@@ -10,6 +10,11 @@ excluded:
   - .git
   - node_modules
 
+# Trailing commas are common in modern Swift and the touchstone scaffolded
+# Package.swift uses them. Re-enable per-project if your style guide forbids.
+disabled_rules:
+  - trailing_comma
+
 # Sensible default severity. Tune per-project as needed.
 opt_in_rules:
   - empty_count

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -243,6 +243,15 @@ assert_contains "$PROJECT_SWIFT/.gitignore" '^Package\.resolved$'
 assert_contains "$PROJECT_SWIFT/.gitignore" '^DerivedData/$'
 assert_contains "$PROJECT_SWIFT/.gitignore" '^\*\.xcodeproj/$'
 
+# Swift fresh bootstrap ships .swiftlint.yml with build-artifact excludes so
+# `swiftlint --strict` can run against a freshly-built project without choking
+# on SwiftPM-generated files in .build/. Project-owned: copied via copy_file,
+# preserved on re-init / update if the user has hand-edited it.
+assert_exists "$PROJECT_SWIFT/.swiftlint.yml"
+assert_contains "$PROJECT_SWIFT/.swiftlint.yml" '^  - \.build$'
+assert_contains "$PROJECT_SWIFT/.swiftlint.yml" '^  - \.swiftpm$'
+assert_contains "$PROJECT_SWIFT/.swiftlint.yml" '^  - DerivedData$'
+
 # The swift scaffold must skip on a fresh bootstrap when Swift content already
 # exists — _has_any_swift_sources guards against overwriting user code. Simulate
 # the case: a pre-existing Swift project that has never been touchstoned.
@@ -252,6 +261,17 @@ printf 'SENTINEL_PACKAGE\n' > "$PROJECT_SWIFT_EXISTING/Package.swift"
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SWIFT_EXISTING" --no-register --type swift >/dev/null
 assert_contains "$PROJECT_SWIFT_EXISTING/Package.swift" '^SENTINEL_PACKAGE$'
 assert_not_exists "$PROJECT_SWIFT_EXISTING/Sources/ExistingSwiftRepo/ExistingSwiftRepoApp.swift"
+# Existing Swift project still gets the .swiftlint.yml when missing — the
+# template is project-owned and added when absent.
+assert_exists "$PROJECT_SWIFT_EXISTING/.swiftlint.yml"
+
+# A pre-existing hand-edited .swiftlint.yml must NOT be clobbered by --type swift
+# bootstrap. copy_file is the project-owned semantic: skip if exists.
+PROJECT_SWIFT_HAND_EDITED="$TEST_DIR/swift-hand-edited-config"
+mkdir -p "$PROJECT_SWIFT_HAND_EDITED"
+printf 'SENTINEL_HAND_EDITED_CONFIG\n' > "$PROJECT_SWIFT_HAND_EDITED/.swiftlint.yml"
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SWIFT_HAND_EDITED" --no-register --type swift >/dev/null
+assert_contains "$PROJECT_SWIFT_HAND_EDITED/.swiftlint.yml" '^SENTINEL_HAND_EDITED_CONFIG$'
 
 # Non-swift profiles must NOT pick up the Swift-specific .gitignore entries —
 # the append is per-profile and must not bleed across profiles.
@@ -263,6 +283,11 @@ if grep -q '^Package\.resolved$' "$PROJECT_PYTHON/.gitignore" 2>/dev/null; then
   echo "FAIL: python profile .gitignore must not contain Swift entries" >&2
   ERRORS=$((ERRORS + 1))
 fi
+
+# Non-swift profiles must NOT receive .swiftlint.yml — copy_profile_templates
+# is per-profile gated.
+assert_not_exists "$PROJECT_NODE/.swiftlint.yml"
+assert_not_exists "$PROJECT_PYTHON/.swiftlint.yml"
 
 # Swift-specific .gitignore append must be idempotent — even if the entries
 # are already present, a fresh bootstrap must not duplicate them.

--- a/tests/test-swift-swiftlint.sh
+++ b/tests/test-swift-swiftlint.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# tests/test-swift-swiftlint.sh — end-to-end regression for the swift
+# .swiftlint.yml template. Scaffolds a swift project, builds it (which
+# generates .build/), and runs `swiftlint --strict`. Asserts zero
+# violations on a clean scaffold — the template's `excluded:` block must
+# keep SwiftPM-generated build artifacts out of swiftlint's path.
+#
+# Skips gracefully when swift or swiftlint are not installed (Linux CI,
+# bare runners). The unit-level coverage in test-bootstrap.sh and
+# test-update.sh asserts the template lands in the right places without
+# needing the real toolchain — this test is the integration backstop.
+#
+set -euo pipefail
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_DIR="$(mktemp -d -t touchstone-test-swift-swiftlint.XXXXXX)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+echo "==> Test: swift profile ships .swiftlint.yml that survives swift build"
+echo "    Test dir: $TEST_DIR/swift-app"
+
+if ! command -v swift >/dev/null 2>&1; then
+  echo "==> SKIP: swift toolchain not on PATH (Linux CI / bare runner — covered by unit tests)"
+  exit 0
+fi
+
+if ! command -v swiftlint >/dev/null 2>&1; then
+  echo "==> SKIP: swiftlint not installed (covered by unit tests in test-bootstrap.sh / test-update.sh)"
+  exit 0
+fi
+
+PROJECT="$TEST_DIR/swift-app"
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT" --no-register --type swift >/dev/null
+
+# Sanity: scaffold dropped the template.
+if [ ! -f "$PROJECT/.swiftlint.yml" ]; then
+  echo "FAIL: scaffold did not create .swiftlint.yml" >&2
+  exit 1
+fi
+
+# `swift build` populates .build/arm64-apple-macosx/debug/... with derived
+# Swift sources (XCTest runners, LinuxMain shims). Without the template's
+# `excluded:` block, those files would dominate `swiftlint --strict`.
+echo "==> swift build (generates .build/)"
+if ! (cd "$PROJECT" && swift build) >"$TEST_DIR/swift-build.log" 2>&1; then
+  echo "FAIL: swift build failed on a clean touchstone scaffold" >&2
+  echo "---- swift build log ----" >&2
+  cat "$TEST_DIR/swift-build.log" >&2
+  exit 1
+fi
+
+# .build/ must exist after the build — otherwise the regression test isn't
+# actually exercising the case the template guards against.
+if [ ! -d "$PROJECT/.build" ]; then
+  echo "FAIL: swift build did not produce .build/ — regression test cannot exercise the exclude" >&2
+  exit 1
+fi
+
+echo "==> swiftlint --strict (must report zero violations)"
+if ! (cd "$PROJECT" && swiftlint --strict) >"$TEST_DIR/swiftlint.log" 2>&1; then
+  echo "FAIL: swiftlint --strict failed on a clean touchstone scaffold" >&2
+  echo "---- swiftlint log (head 50) ----" >&2
+  head -50 "$TEST_DIR/swiftlint.log" >&2
+  echo "---- (truncated) ----" >&2
+  exit 1
+fi
+
+# Defense in depth: even if `swiftlint --strict` exits 0, surface a warning
+# count > 0 so a future template regression that downgrades violations from
+# error to warning still fails the test.
+if grep -Eq 'Found [1-9][0-9]* (violation|warning)' "$TEST_DIR/swiftlint.log"; then
+  echo "FAIL: swiftlint reported violations/warnings on a clean scaffold:" >&2
+  grep -E 'Found [0-9]+ (violation|warning)' "$TEST_DIR/swiftlint.log" >&2
+  exit 1
+fi
+
+echo "==> PASS: swift scaffold + swift build + swiftlint --strict reports zero violations"

--- a/tests/test-update.sh
+++ b/tests/test-update.sh
@@ -248,6 +248,75 @@ if git -C "$ROLLBACK_PROJECT" branch --list 'chore/touchstone-*' | grep -q .; th
 fi
 
 # --------------------------------------------------------------------------
+# Test 5b: swift profile gains .swiftlint.yml on update without clobbering
+# a hand-edited copy.
+# --------------------------------------------------------------------------
+echo ""
+echo "--- Step 5b: Swift project gains .swiftlint.yml on update ---"
+
+SWIFT_UPDATE_PROJECT="$TEST_DIR/swift-update-project"
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$SWIFT_UPDATE_PROJECT" --no-register --type swift >/dev/null
+configure_git "$SWIFT_UPDATE_PROJECT"
+commit_all "$SWIFT_UPDATE_PROJECT" "initial swift touchstone project"
+
+# Simulate a stale touchstone version + a project that pre-existed the swiftlint
+# template (so .swiftlint.yml was never created at bootstrap time).
+rm -f "$SWIFT_UPDATE_PROJECT/.swiftlint.yml"
+echo "0000000000000000000000000000000000000010" > "$SWIFT_UPDATE_PROJECT/.touchstone-version"
+commit_all "$SWIFT_UPDATE_PROJECT" "simulate pre-swiftlint-template swift project"
+
+(cd "$SWIFT_UPDATE_PROJECT" && bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh") >"$TEST_DIR/swift-update-output.txt" 2>&1
+
+assert_contains "$TEST_DIR/swift-update-output.txt" 'added (project-owned).*\.swiftlint\.yml'
+assert_exists "$SWIFT_UPDATE_PROJECT/.swiftlint.yml"
+assert_contains "$SWIFT_UPDATE_PROJECT/.swiftlint.yml" '^  - \.build$'
+
+# .swiftlint.yml stays out of .touchstone-manifest — it's project-owned, not
+# touchstone-owned. Future updates must not include it in the touchstone-owned
+# overwrite path.
+if grep -qxF '.swiftlint.yml' "$SWIFT_UPDATE_PROJECT/.touchstone-manifest"; then
+  echo "FAIL: .swiftlint.yml must NOT be in .touchstone-manifest (project-owned, not touchstone-owned)" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# The newly added .swiftlint.yml must be staged in the update commit so
+# `--ship` does not leave it behind.
+if git -C "$SWIFT_UPDATE_PROJECT" log -1 --name-only --format='' | grep -qxF '.swiftlint.yml'; then
+  echo "    PASS: .swiftlint.yml committed as part of the update"
+else
+  echo "FAIL: .swiftlint.yml was not committed in the update commit" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# Re-run on a swift project that already has a hand-edited .swiftlint.yml —
+# update must NOT clobber it. Use a sentinel string to verify the original
+# bytes survive.
+SWIFT_HAND_EDITED_PROJECT="$TEST_DIR/swift-hand-edited-update"
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$SWIFT_HAND_EDITED_PROJECT" --no-register --type swift >/dev/null
+configure_git "$SWIFT_HAND_EDITED_PROJECT"
+printf 'SENTINEL_HAND_EDITED_SWIFTLINT\n' > "$SWIFT_HAND_EDITED_PROJECT/.swiftlint.yml"
+commit_all "$SWIFT_HAND_EDITED_PROJECT" "initial swift project with hand-edited swiftlint"
+echo "0000000000000000000000000000000000000011" > "$SWIFT_HAND_EDITED_PROJECT/.touchstone-version"
+commit_all "$SWIFT_HAND_EDITED_PROJECT" "simulate stale touchstone state"
+
+(cd "$SWIFT_HAND_EDITED_PROJECT" && bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh") >/dev/null 2>&1
+
+assert_contains "$SWIFT_HAND_EDITED_PROJECT/.swiftlint.yml" '^SENTINEL_HAND_EDITED_SWIFTLINT$'
+
+# Non-swift profiles must NOT receive .swiftlint.yml on update — the per-profile
+# gate keeps the swift template out of unrelated projects.
+NON_SWIFT_UPDATE_PROJECT="$TEST_DIR/non-swift-update-project"
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$NON_SWIFT_UPDATE_PROJECT" --no-register --type python >/dev/null
+configure_git "$NON_SWIFT_UPDATE_PROJECT"
+commit_all "$NON_SWIFT_UPDATE_PROJECT" "initial python project"
+echo "0000000000000000000000000000000000000012" > "$NON_SWIFT_UPDATE_PROJECT/.touchstone-version"
+commit_all "$NON_SWIFT_UPDATE_PROJECT" "simulate stale python touchstone state"
+
+(cd "$NON_SWIFT_UPDATE_PROJECT" && bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh") >/dev/null 2>&1
+
+assert_not_exists "$NON_SWIFT_UPDATE_PROJECT/.swiftlint.yml"
+
+# --------------------------------------------------------------------------
 # Test 6: check mode and ordinary commands do not print the old startup nag.
 # --------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
New tests/test-swift-swiftlint.sh scaffolds a touchstone swift project,
runs 'swift build' (which generates .build/), then runs 'swiftlint --strict'
and asserts zero violations. Skips gracefully when swift or swiftlint are
not installed (Linux CI / bare runners) — unit-level coverage in
test-bootstrap.sh and test-update.sh asserts placement separately.

While writing the test, swiftlint flagged trailing-comma violations on the
touchstone-generated Package.swift (its Package(...) call ends collections
with trailing commas). Disabling 'trailing_comma' in the shipped template
is the minimal fix: trailing commas are common in modern Swift, the
touchstone scaffold itself uses them, and projects that want strict
trailing-comma enforcement can re-enable per-project.

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
