### PR TITLE
chore(2.0): close conductor migration gaps across CLI, hook docs, init wizard, doctor

### DIFF
--- a/bin/touchstone
+++ b/bin/touchstone
@@ -930,10 +930,17 @@ cmd_doctor() {
   done
 
   # Optional tools.
-  if command -v codex >/dev/null 2>&1; then
-    tk_ok "codex: $(command -v codex)"
+  if command -v conductor >/dev/null 2>&1; then
+    # Touchstone 2.0 delegates all review to conductor; richer status
+    # lives in `conductor doctor`.
+    if conductor doctor --json 2>/dev/null | grep -q '"configured"[[:space:]]*:[[:space:]]*true'; then
+      tk_ok "conductor: $(command -v conductor) (at least one provider configured)"
+    else
+      tk_warn "conductor: $(command -v conductor) (no provider configured — run: conductor init)"
+      issues=$((issues + 1))
+    fi
   else
-    tk_dim "codex: not installed (optional — npm install -g @openai/codex)"
+    tk_dim "conductor: not installed (optional — brew install autumngarage/conductor/conductor)"
   fi
   if command -v but >/dev/null 2>&1; then
     tk_ok "but: $(command -v but)"

--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -293,15 +293,12 @@ prompt_yes_no() {
 }
 
 default_reviewer() {
-  if command -v codex >/dev/null 2>&1; then
-    printf 'codex'
-  elif command -v claude >/dev/null 2>&1; then
-    printf 'claude'
-  elif command -v gemini >/dev/null 2>&1; then
-    printf 'gemini'
-  else
-    printf 'codex'
-  fi
+  # Touchstone 2.0: the single reviewer is `conductor`; the underlying
+  # provider is chosen by Conductor's router at runtime. "conductor"
+  # normalizes to "auto" (no pin) via normalize_reviewer — the right
+  # default for a fresh project. Users who want to pin a provider can
+  # pass --reviewer <name> or edit .codex-review.toml afterwards.
+  printf 'conductor'
 }
 
 detect_node_package_manager() {
@@ -1164,38 +1161,36 @@ print_review_setup_hint() {
     return
   fi
 
-  echo "==> AI review configured: routing=$routing reviewer=$reviewer"
-  if [ "$routing" = "small-local" ]; then
-    echo "    Small diffs (<= ${INPUT_SMALL_REVIEW_LINES:-400} lines) try your local reviewer first; larger diffs use the hosted reviewer."
-  fi
-  case "$reviewer" in
-    codex|auto)
-      if ! command -v codex >/dev/null 2>&1; then
-        echo "    Codex is not installed yet. setup.sh will try to install it if npm is available."
-        echo "    Manual install: npm install -g @openai/codex && codex login"
-      fi
-      ;;
-    claude)
-      if ! command -v claude >/dev/null 2>&1; then
-        echo "    Claude CLI is not installed yet. Install and authenticate Claude before relying on review."
-      fi
-      ;;
-    gemini)
-      if ! command -v gemini >/dev/null 2>&1; then
-        echo "    Gemini CLI is not installed yet. Install and authenticate Gemini before relying on review."
-      fi
-      ;;
-    local)
-      if [ -z "$INPUT_LOCAL_REVIEW_COMMAND" ]; then
-        echo "    Add [review.local].command in .codex-review.toml before local review can run."
-      else
-        echo "    Local reviewer command: $INPUT_LOCAL_REVIEW_COMMAND"
-      fi
-      ;;
-  esac
+  local pin
+  pin="$(conductor_with_for "$reviewer")"
 
-  if [ "$routing" = "small-local" ] && [ -z "$INPUT_LOCAL_REVIEW_COMMAND" ]; then
-    echo "    Add [review.local].command in .codex-review.toml before local small-diff review can run."
+  if [ -n "$pin" ]; then
+    echo "==> AI review configured: conductor (pinned to $pin) — routing=$routing"
+  else
+    echo "==> AI review configured: conductor (auto-routed) — routing=$routing"
+  fi
+
+  if [ "$routing" = "small-local" ]; then
+    echo "    Small diffs (<= ${INPUT_SMALL_REVIEW_LINES:-400} lines) route to ollama;"
+    echo "    larger diffs use your pinned/auto-routed provider."
+  fi
+
+  if ! command -v conductor >/dev/null 2>&1; then
+    echo "    Conductor is not installed yet. Review will skip until you install it."
+    echo "      brew install autumngarage/conductor/conductor"
+    echo "      conductor init"
+  elif ! conductor doctor --json 2>/dev/null | grep -q '"configured"[[:space:]]*:[[:space:]]*true'; then
+    echo "    Conductor is installed but no provider is configured yet."
+    echo "      conductor doctor    (diagnose what's missing)"
+    echo "      conductor init      (guided provider setup)"
+  elif [ -n "$pin" ]; then
+    echo "    Confirm \`$pin\` is ready: conductor list"
+  fi
+
+  if [ "$reviewer" = "local" ] && [ -n "$INPUT_LOCAL_REVIEW_COMMAND" ]; then
+    echo "    NOTE: --local-review-command \"$INPUT_LOCAL_REVIEW_COMMAND\" is recorded in"
+    echo "    .codex-review.toml as a comment. Touchstone 2.0 retired [review.local];"
+    echo "    register your command as a Conductor custom provider when v0.3 ships."
   fi
 }
 
@@ -1333,11 +1328,11 @@ if [ "$WIZARD_INTERACTIVE" = true ]; then
     else
     echo ""
     echo "==> Configure AI review (press Enter for the default):"
-    echo "   Hosted review: strongest default reviewer for every change."
-    echo "   Local review: private and cheap, but quality depends on your local model."
-    echo "   Hybrid review: local handles small diffs; hosted review handles larger diffs."
+    echo "   Touchstone 2.0 routes every review through Conductor."
+    echo "   Hosted: Conductor auto-picks the best configured provider for each diff."
+    echo "   Local: small diffs go to Ollama (fast/cheap); nothing hosted."
+    echo "   Hybrid: small diffs go to Ollama; larger diffs to Conductor's router."
     if [ "$(prompt_yes_no "Use AI review before code reaches main?" "true")" = "true" ]; then
-      local_default_reviewer="$(default_reviewer)"
       local_review_style=""
       read -r -p "   Review style (hosted, local, hybrid) [hosted]: " local_review_style
       local_review_style="$(normalize_review_routing "${local_review_style:-hosted}")"
@@ -1345,20 +1340,18 @@ if [ "$WIZARD_INTERACTIVE" = true ]; then
       case "$local_review_style" in
         all-hosted)
           INPUT_REVIEW_ROUTING="all-hosted"
-          read -r -p "   Hosted reviewer (codex, claude, gemini, auto) [$local_default_reviewer]: " INPUT_REVIEWER
-          INPUT_REVIEWER="${INPUT_REVIEWER:-$local_default_reviewer}"
+          read -r -p "   Pin a specific provider (e.g. claude, codex, gemini; Enter = Conductor auto-routes): " INPUT_REVIEWER
+          INPUT_REVIEWER="${INPUT_REVIEWER:-conductor}"
           INPUT_REVIEWER="$(normalize_reviewer "$INPUT_REVIEWER")"
           ;;
         all-local)
           INPUT_REVIEW_ROUTING="all-local"
           INPUT_REVIEWER="local"
-          read -r -p "   Local reviewer command (reads prompt on stdin, e.g. 'ollama run MODEL'): " INPUT_LOCAL_REVIEW_COMMAND
           ;;
         small-local)
           INPUT_REVIEW_ROUTING="small-local"
-          read -r -p "   Local reviewer command for small diffs (e.g. 'ollama run MODEL'): " INPUT_LOCAL_REVIEW_COMMAND
-          read -r -p "   Hosted reviewer for larger diffs (codex, claude, gemini, auto) [$local_default_reviewer]: " INPUT_REVIEWER
-          INPUT_REVIEWER="${INPUT_REVIEWER:-$local_default_reviewer}"
+          read -r -p "   Pin a provider for larger diffs (e.g. claude, codex, gemini; Enter = Conductor auto-routes): " INPUT_REVIEWER
+          INPUT_REVIEWER="${INPUT_REVIEWER:-conductor}"
           INPUT_REVIEWER="$(normalize_reviewer "$INPUT_REVIEWER")"
           read -r -p "   Small-diff cutoff in changed diff lines [400]: " INPUT_SMALL_REVIEW_LINES
           INPUT_SMALL_REVIEW_LINES="${INPUT_SMALL_REVIEW_LINES:-400}"
@@ -1367,7 +1360,8 @@ if [ "$WIZARD_INTERACTIVE" = true ]; then
       esac
 
       INPUT_REVIEW_AUTOFIX="$(prompt_yes_no "Let the AI auto-fix low-risk issues?" "false")"
-      INPUT_REVIEW_ASSIST="$(prompt_yes_no "Let the AI ask one peer reviewer for larger changes?" "false")"
+      # Peer review is retired in 2.0.0 — returns in 2.1 via `conductor call --exclude`.
+      INPUT_REVIEW_ASSIST=false
 
       if [ "$INPUT_REVIEW_AUTOFIX" = "true" ] && [ -z "$INPUT_UNSAFE" ]; then
         read -r -p "   High-scrutiny paths the AI must never auto-fix (comma-separated, e.g., src/auth/,migrations/): " INPUT_UNSAFE

--- a/bootstrap/review.sh
+++ b/bootstrap/review.sh
@@ -156,6 +156,31 @@ if [ -f "$CONFIG_FILE" ]; then
   done < "$CONFIG_FILE"
 fi
 
+# TOUCHSTONE_REVIEWER is a v1.x-era env var that pinned the named *adapter*
+# (codex / claude / gemini / local). In 2.0 the only adapter is conductor;
+# the underlying provider pin is TOUCHSTONE_CONDUCTOR_WITH. Translate on the
+# fly so --dry-run matches what the pre-push hook will actually do. Mirrors
+# the translation block in hooks/codex-review.sh (keep in sync).
+if [ -n "${TOUCHSTONE_REVIEWER:-}" ]; then
+  case "$TOUCHSTONE_REVIEWER" in
+    auto|conductor) ;;
+    local)
+      echo "==> NOTE: TOUCHSTONE_REVIEWER=local is deprecated in 2.0.0." >&2
+      echo "    Migrating to: TOUCHSTONE_CONDUCTOR_WITH=ollama (the closest 2.0 analog)." >&2
+      [ -z "${TOUCHSTONE_CONDUCTOR_WITH:-}" ] && export TOUCHSTONE_CONDUCTOR_WITH="ollama"
+      ;;
+    codex|claude|gemini|ollama)
+      echo "==> NOTE: TOUCHSTONE_REVIEWER=$TOUCHSTONE_REVIEWER is deprecated in 2.0.0." >&2
+      echo "    Pin an underlying provider with: TOUCHSTONE_CONDUCTOR_WITH=$TOUCHSTONE_REVIEWER" >&2
+      [ -z "${TOUCHSTONE_CONDUCTOR_WITH:-}" ] && export TOUCHSTONE_CONDUCTOR_WITH="$TOUCHSTONE_REVIEWER"
+      ;;
+    *)
+      echo "==> WARNING: TOUCHSTONE_REVIEWER=$TOUCHSTONE_REVIEWER is not a known legacy value." >&2
+      echo "    Ignoring. Pin an underlying provider with TOUCHSTONE_CONDUCTOR_WITH=<provider>." >&2
+      ;;
+  esac
+fi
+
 # Env overrides win.
 CONDUCTOR_WITH="${TOUCHSTONE_CONDUCTOR_WITH:-${CONDUCTOR_WITH:-}}"
 CONDUCTOR_PREFER="${TOUCHSTONE_CONDUCTOR_PREFER:-${CONDUCTOR_PREFER:-best}}"

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,18 +1,20 @@
 # AI Review Hook
 
-Reviews your code with the configured AI reviewer before it reaches the default branch. Normal feature-branch pushes stay fast; review runs from `scripts/merge-pr.sh` and from the pre-push hook only when pushing directly to the default branch.
+Reviews your code with an AI reviewer before it reaches the default branch. Normal feature-branch pushes stay fast; review runs from `scripts/merge-pr.sh` and from the pre-push hook only when pushing directly to the default branch.
+
+Touchstone 2.0 delegates all LLM access to [Conductor](https://github.com/autumngarage/conductor). The hook declares *what it needs* (review mode → tool access + sandbox, effort budget, routing preference) and Conductor picks *how* to satisfy it (provider, model, auth, cost tracking).
 
 ## Setup
 
-### 1. Pick a reviewer
+### 1. Install Conductor
 
-Run `touchstone new` or `touchstone init` interactively and answer the AI review prompts. You can choose:
-- hosted review — Codex, Claude, Gemini, or `auto` for every change
-- local review — a local model or wrapper command that reads the review prompt from stdin
-- hybrid review — small diffs try local first; larger diffs go to a hosted reviewer
-- no review — leave the hook installed but disabled
+```bash
+brew install autumngarage/conductor/conductor
+conductor init          # guided provider setup (auth, model defaults)
+conductor doctor        # confirm at least one provider is ready
+```
 
-Edit `.codex-review.toml` later if you change your mind.
+A Touchstone review needs exactly one configured provider. `conductor list` shows which ones are ready, which are missing credentials, and which can't satisfy the requested tool set.
 
 ### 2. Install pre-commit
 
@@ -23,44 +25,46 @@ brew install pre-commit
 
 ### 3. Wire the hook
 
-The touchstone's `.pre-commit-config.yaml` template already includes the AI review hook. Just install the hooks:
+Touchstone's `.pre-commit-config.yaml` template already includes the AI review hook. Install:
 
 ```bash
 pre-commit install --install-hooks
 ```
 
-For project validation, prefer the Touchstone runner so hooks use the repo's `.touchstone-config` profile instead of hardcoding an ecosystem command:
+### 4. Configure per-project behavior (optional)
 
-```yaml
-entry: /usr/bin/env bash scripts/touchstone-run.sh validate
-```
+The defaults in `.codex-review.toml` (written by `touchstone init`) work for most projects:
 
-### 4. Configure per-project behavior
+```toml
+[review]
+reviewer = "conductor"      # the only supported value in 2.0
 
-Copy or edit `.codex-review.toml` at your repo root:
-
-```bash
-cp .codex-review.toml.example .codex-review.toml
-# Edit reviewers, unsafe_paths, safe_by_default, max_iterations as needed
+[review.conductor]
+prefer = "best"             # best | cheapest | fastest | balanced
+effort = "max"              # minimal | low | medium | high | max | <int tokens>
+tags   = "code-review"
+# with = "claude"           # pin a specific provider (bypasses auto-routing)
+# exclude = "gemini"        # exclude providers from auto-routing
 ```
 
 ### 5. Write your review rubric
 
-Fill in `AGENTS.md` at the repo root with your project-specific review priorities. The hook tells the reviewer to read this file for the review rubric. See `templates/AGENTS.md` for the skeleton.
+Fill in `AGENTS.md` at the repo root with your project-specific review priorities. The hook tells the reviewer to read this file as the rubric. See `templates/AGENTS.md` for the skeleton.
 
 ## How it works
 
 When the review runs, the hook:
 
 1. Computes the diff between your branch and the default branch
-2. Skips review if the exact same diff and review inputs already passed cleanly
-3. Sends the diff to the selected reviewer with the review prompt + your AGENTS.md rubric
-4. If peer assistance is enabled and the primary reviewer asks for help on a larger change, the hook asks one helper reviewer for a read-only second opinion
-5. The reviewer outputs one of three sentinels:
-   - `CODEX_REVIEW_CLEAN` — no issues, operation proceeds
-   - `CODEX_REVIEW_FIXED` — the reviewer applied auto-fixes, the hook commits them and re-reviews
-   - `CODEX_REVIEW_BLOCKED` — the reviewer found issues it won't auto-fix, push is blocked
-6. The loop repeats up to `max_iterations` times (default 3)
+2. Skips review if the exact same diff and review inputs already passed cleanly (cache key includes the Conductor knobs, so changing `prefer`/`effort`/`with` invalidates)
+3. Invokes Conductor with the review prompt + AGENTS.md rubric, the requested tool set, and the requested sandbox
+4. Reads one of three sentinels from the reviewer's output:
+   - `CODEX_REVIEW_CLEAN` — no issues, push proceeds
+   - `CODEX_REVIEW_FIXED` — the reviewer applied auto-fixes; the hook commits them and re-reviews
+   - `CODEX_REVIEW_BLOCKED` — the reviewer found issues it won't auto-fix; push is blocked
+5. The loop repeats up to `max_iterations` times (default 3)
+
+Conductor logs its route decision (provider, cost estimate, token count, wall-clock time) into the pre-push transcript.
 
 ## Configuration reference
 
@@ -68,21 +72,30 @@ When the review runs, the hook:
 |---------|---------|-------------|
 | `max_iterations` | 3 | Max review-fix-review loops before aborting |
 | `max_diff_lines` | 5000 | Skip review if diff exceeds this |
-| `cache_clean_reviews` | true | Cache exact-input clean reviews under `.git/` to avoid repeat Codex calls |
+| `cache_clean_reviews` | true | Cache clean reviews under `.git/` to skip repeat calls on the same diff |
 | `safe_by_default` | false | Whether unlisted paths allow auto-fix |
 | `unsafe_paths` | [] | Paths where auto-fix is never allowed |
 | `[review].enabled` | true | Set false to skip AI review without removing the hook |
-| `[review].reviewers` | `["codex"]` | Reviewer cascade, e.g. `["claude", "codex", "gemini", "local"]` |
-| `[review.routing].enabled` | false | Route reviews by diff size |
-| `[review.routing].small_max_diff_lines` | 400 | Diff-line cutoff for the small-reviewer route |
-| `[review.routing].small_reviewers` | unset | Reviewers to try for small diffs, e.g. `["local", "codex"]` |
-| `[review.routing].large_reviewers` | unset | Reviewers to try for larger diffs, e.g. `["codex"]` |
-| `[review.local].command` | empty | Local reviewer command; receives the prompt on stdin |
-| `[review.local].auth_command` | empty | Optional local command that must pass before review runs |
-| `[review.assist].enabled` | false | Allow the primary reviewer to request one peer second opinion |
-| `[review.assist].helpers` | `["codex", "gemini", "claude"]` | Helper reviewers to try, skipping the active primary reviewer |
-| `[review.assist].timeout` | 60 | Timeout in seconds for the helper reviewer |
-| `[review.assist].max_rounds` | 1 | Max helper calls per review run |
+| `[review].reviewer` | `"conductor"` | The only supported value in 2.0 |
+| `[review.conductor].prefer` | `"best"` | `best` \| `cheapest` \| `fastest` \| `balanced` |
+| `[review.conductor].effort` | `"max"` | `minimal` \| `low` \| `medium` \| `high` \| `max` \| integer thinking-token budget |
+| `[review.conductor].tags` | `"code-review"` | Capability tags passed to the router |
+| `[review.conductor].with` | unset | Pin a specific provider (bypasses auto-routing) |
+| `[review.conductor].exclude` | unset | Exclude providers from auto-routing |
+| `[review.routing].enabled` | false | Route by diff size |
+| `[review.routing].small_max_diff_lines` | 50 | Diff cutoff for the small-diff bucket |
+| `[review.routing].small_prefer` | unset | e.g. `"cheapest"` for small diffs |
+| `[review.routing].small_effort` | unset | e.g. `"minimal"` for small diffs |
+| `[review.routing].small_with` | unset | Pin provider for small diffs |
+| `[review.routing].large_max_diff_lines` | 1000 | Diff cutoff for the large-diff bucket |
+| `[review.routing].large_prefer` | unset | e.g. `"best"` for large diffs |
+| `[review.routing].large_effort` | unset | e.g. `"max"` for large diffs |
+| `[review.routing].large_with` | unset | Pin provider for large diffs |
+| `[review.routing].large_tags` | unset | e.g. `"code-review,long-context"` |
+
+### Retired in 2.0
+
+`[review].reviewers = [...]` cascade, `[review.local]`, `[review.assist]`, `[review.routing].small_reviewers/large_reviewers`. Legacy configs auto-migrate at push time with a one-time hint. Run `touchstone migrate-review-config` to silence the hint and rewrite your file in place. `[review.assist]` (peer second-opinion) returns in 2.1 via `conductor call --exclude <primary>`.
 
 ## Environment overrides
 
@@ -90,30 +103,44 @@ When the review runs, the hook:
 |----------|-------------|
 | `CODEX_REVIEW_ENABLED` | Overrides `[review].enabled` |
 | `CODEX_REVIEW_BASE` | Base ref to diff against (default: `origin/<default-branch>`) |
-| `CODEX_REVIEW_MAX_ITERATIONS` | Overrides config file's `max_iterations` |
-| `CODEX_REVIEW_MAX_DIFF_LINES` | Overrides config file's `max_diff_lines` |
+| `CODEX_REVIEW_MODE` | Override review mode: `fix` \| `review-only` \| `diff-only` \| `no-tests` |
+| `CODEX_REVIEW_MAX_ITERATIONS` | Overrides `max_iterations` |
+| `CODEX_REVIEW_MAX_DIFF_LINES` | Overrides `max_diff_lines` |
 | `CODEX_REVIEW_CACHE_CLEAN` | Overrides `cache_clean_reviews` |
-| `CODEX_REVIEW_DISABLE_CACHE` | Set to `1`/`true` to force a fresh Codex review |
-| `CODEX_REVIEW_FORCE` | Set to `1`/`true` to run on non-default-branch pushes |
-| `CODEX_REVIEW_NO_AUTOFIX` | Set to `1`/`true` for review-only mode |
-| `CODEX_REVIEW_ASSIST` | Set to `1`/`true` to allow peer assistance for one run |
-| `CODEX_REVIEW_ASSIST_TIMEOUT` | Overrides helper reviewer timeout |
-| `CODEX_REVIEW_ASSIST_MAX_ROUNDS` | Overrides max helper calls per review run |
-| `TOUCHSTONE_LOCAL_REVIEWER_COMMAND` | Overrides `[review.local].command` |
-| `TOUCHSTONE_LOCAL_REVIEWER_AUTH_COMMAND` | Overrides `[review.local].auth_command` |
+| `CODEX_REVIEW_DISABLE_CACHE` | `1` forces a fresh review for one push |
+| `CODEX_REVIEW_FORCE` | `1` runs on feature-branch pushes too |
+| `CODEX_REVIEW_NO_AUTOFIX` | `1` switches to `review-only` mode for one run |
+| `CODEX_REVIEW_ON_ERROR` | `fail-open` (default) \| `fail-closed` |
+| `CODEX_REVIEW_TIMEOUT` | Wall-clock timeout per reviewer invocation (seconds) |
+| `CODEX_REVIEW_SUPPRESS_LEGACY_WARNINGS` | `1` silences the one-time 1.x → 2.0 migration hint |
+| `TOUCHSTONE_CONDUCTOR_WITH` | Pin Conductor to a specific provider |
+| `TOUCHSTONE_CONDUCTOR_PREFER` | Override `[review.conductor].prefer` |
+| `TOUCHSTONE_CONDUCTOR_EFFORT` | Override `[review.conductor].effort` |
+| `TOUCHSTONE_CONDUCTOR_TAGS` | Override `[review.conductor].tags` |
+| `TOUCHSTONE_CONDUCTOR_EXCLUDE` | Override `[review.conductor].exclude` |
+| `TOUCHSTONE_REVIEWER` | Deprecated in 2.0 — auto-translates to `TOUCHSTONE_CONDUCTOR_WITH=<provider>` with a one-time hint |
 
 ## Graceful behavior
 
-- If AI review is disabled: skips review, operation proceeds
-- If no configured reviewer is installed/authenticated: skips review, operation proceeds
+- If AI review is disabled: skips review, push proceeds
+- If the `conductor` CLI is missing: prints `brew install …` + `conductor init` hints, skips review, push proceeds
+- If Conductor is installed but no provider is configured: prints `conductor doctor` + `conductor init` hints, skips review, push proceeds
 - If pushing a feature branch: skips review, push proceeds
-- If a reviewer fails (network, auth, quota, local command error): skips review, operation proceeds
-- If diff exceeds `max_diff_lines`: skips review, operation proceeds
-- If the exact diff and review inputs already passed cleanly: skips repeat review, operation proceeds
+- If Conductor fails (network, quota, sandbox denial): skips review per `on_error = "fail-open"` (default); set `fail-closed` to block instead
+- If diff exceeds `max_diff_lines`: skips review, push proceeds
+- If the exact diff and review inputs already passed cleanly: skips repeat review, push proceeds
 - If reviewer output doesn't match the sentinel contract: skips review, push proceeds
 - If `.codex-review.toml` is missing: all paths treated as unsafe (no auto-fix)
 
-The hook never blocks a push for infrastructure reasons — only for actual code review findings.
+The hook's default is fail-open on infrastructure errors and block on actual review findings. Flip to `fail-closed` in CI or for strict review gates.
+
+## Preview without spending tokens
+
+```bash
+touchstone review --dry-run
+```
+
+Shows which provider auto-routing would pick for the next push, the route ranking, tool set, and sandbox — no upstream calls made.
 
 ## Emergency bypass
 

--- a/tests/test-review-dry-run.sh
+++ b/tests/test-review-dry-run.sh
@@ -185,6 +185,66 @@ else
 fi
 
 # ----------------------------------------------------------------------------
+echo "==> Test: TOUCHSTONE_REVIEWER=<legacy> translates to --with pin + deprecation note"
+: > "$ARGS_FILE"
+set +e
+out="$(
+  cd "$REPO_AUTO"
+  PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    ARGS_FILE="$ARGS_FILE" \
+    TOUCHSTONE_REVIEWER=codex \
+    TOUCHSTONE_NO_AUTO_UPDATE=1 \
+    bash "$TOUCHSTONE_BIN" review --dry-run --base HEAD~1 2>&1
+)"
+set -e
+if echo "$out" | grep -q 'TOUCHSTONE_REVIEWER=codex is deprecated' \
+  && echo "$out" | grep -q 'pinned via --with=codex'; then
+  echo "==> PASS: TOUCHSTONE_REVIEWER=codex → deprecation note + --with=codex"
+else
+  echo "FAIL: legacy TOUCHSTONE_REVIEWER value was silently ignored (regression of bug #13)" >&2
+  echo "out: $out" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# TOUCHSTONE_REVIEWER=local must map to ollama, not crash or no-op.
+: > "$ARGS_FILE"
+out="$(
+  cd "$REPO_AUTO"
+  PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    ARGS_FILE="$ARGS_FILE" \
+    TOUCHSTONE_REVIEWER=local \
+    TOUCHSTONE_NO_AUTO_UPDATE=1 \
+    bash "$TOUCHSTONE_BIN" review --dry-run --base HEAD~1 2>&1
+)"
+if echo "$out" | grep -q 'TOUCHSTONE_REVIEWER=local is deprecated' \
+  && echo "$out" | grep -q 'pinned via --with=ollama'; then
+  echo "==> PASS: TOUCHSTONE_REVIEWER=local → ollama (closest 2.0 analog)"
+else
+  echo "FAIL: TOUCHSTONE_REVIEWER=local did not translate to --with=ollama" >&2
+  echo "out: $out" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# Unknown value warns but does not pin (must not silently succeed with junk).
+: > "$ARGS_FILE"
+out="$(
+  cd "$REPO_AUTO"
+  PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    ARGS_FILE="$ARGS_FILE" \
+    TOUCHSTONE_REVIEWER=bogus \
+    TOUCHSTONE_NO_AUTO_UPDATE=1 \
+    bash "$TOUCHSTONE_BIN" review --dry-run --base HEAD~1 2>&1
+)"
+if echo "$out" | grep -q 'TOUCHSTONE_REVIEWER=bogus is not a known legacy value' \
+  && ! echo "$out" | grep -q 'pinned via --with=bogus'; then
+  echo "==> PASS: unknown TOUCHSTONE_REVIEWER value warns and auto-routes"
+else
+  echo "FAIL: unknown legacy value silently pinned or skipped warning" >&2
+  echo "out: $out" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ----------------------------------------------------------------------------
 if [ "$ERRORS" -gt 0 ]; then
   echo "==> FAIL: $ERRORS assertion(s) failed"
   exit 1


### PR DESCRIPTION
UX-testing pass over the v2.0 Conductor integration surfaced one bug and
three pockets of stale 1.x surface still leaking through. Fixing all in
one commit since they're interlocked (the init wizard and doctor changes
both depend on the 2.0-normalized default_reviewer behavior).

## Bug fix: review --dry-run was lying about env-pinned provider

`hooks/codex-review.sh` translates `TOUCHSTONE_REVIEWER={codex,claude,
gemini,local,...}` → `TOUCHSTONE_CONDUCTOR_WITH=<provider>` with a
deprecation hint at push time. `bootstrap/review.sh` (the `touchstone
review --dry-run` path) had no such handling, so the preview silently
disagreed with what a real push would do — a textbook "no silent
failures" + "one code path" violation. Mirrors the translation block
in-place (with a keep-in-sync comment) rather than extracting to a
shared lib, which would have required changing the hook's distribution
manifest for ~25 lines of duplication.

Adds three regression tests to tests/test-review-dry-run.sh covering
the known-legacy translation, local→ollama mapping, and unknown-value
warning paths.

## Docs: hooks/README.md rewritten for 2.0

The old README documented the entire retired 1.x config surface
(`[review].reviewers`, `[review.local]`, `[review.assist]`,
`small_reviewers`/`large_reviewers`) with zero mentions of Conductor.
Rewrote around the 2.0 contract: single `reviewer = "conductor"`,
`[review.conductor]` knobs, 2.0 `[review.routing]` shape, retired-in-2.0
callout, Conductor-first setup, pointer to `touchstone review --dry-run`.

## Init wizard: stop leaking 1.x provider choice onto fresh projects

- `default_reviewer()` previously probed for `codex`/`claude`/`gemini`
  binaries and pinned whichever was found first — silently bypassing
  Conductor's router on every `--yes` init. Now returns "conductor"
  which normalizes to "auto" (no pin).
- "Hosted reviewer (codex, claude, gemini, auto)" prompt reframed as
  "Pin a specific provider (Enter = Conductor auto-routes)".
- Dropped the "Local reviewer command" prompts — the captured value
  was only used as a comment since [review.local] is retired. The
  --local-review-command CLI flag still works for back-compat.
- Dropped the peer-review prompt (disabled in 2.0).
- `print_review_setup_hint` rewritten to point at `brew install
  autumngarage/conductor/conductor` + `conductor init` instead of
  `npm install -g @openai/codex` etc.

## Doctor: probe conductor instead of codex

`touchstone doctor` probed `codex` as the optional AI tool, but in
2.0 the codex CLI is Conductor's concern, not Touchstone's. Swapped
to probe `conductor` and, when present, check `conductor doctor
--json` for at least one configured provider (warns with remediation
if none).

## Tests

13/13 self-tests green. test-review-dry-run.sh gains three new
assertions for the TOUCHSTONE_REVIEWER regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
