### PR TITLE
fix(tests): stop test-migrate-review-config.sh racing on SIGPIPE

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -83,15 +83,17 @@ Conductor logs its route decision (provider, cost estimate, token count, wall-cl
 | `[review.conductor].with` | unset | Pin a specific provider (bypasses auto-routing) |
 | `[review.conductor].exclude` | unset | Exclude providers from auto-routing |
 | `[review.routing].enabled` | false | Route by diff size |
-| `[review.routing].small_max_diff_lines` | 50 | Diff cutoff for the small-diff bucket |
+| `[review.routing].small_max_diff_lines` | 400 | Diffs ≤ this use the `small_*` knobs; diffs above use the `large_*` knobs |
 | `[review.routing].small_prefer` | unset | e.g. `"cheapest"` for small diffs |
 | `[review.routing].small_effort` | unset | e.g. `"minimal"` for small diffs |
 | `[review.routing].small_with` | unset | Pin provider for small diffs |
-| `[review.routing].large_max_diff_lines` | 1000 | Diff cutoff for the large-diff bucket |
-| `[review.routing].large_prefer` | unset | e.g. `"best"` for large diffs |
-| `[review.routing].large_effort` | unset | e.g. `"max"` for large diffs |
-| `[review.routing].large_with` | unset | Pin provider for large diffs |
+| `[review.routing].small_tags` | unset | e.g. `"code-review"` for small diffs |
+| `[review.routing].large_prefer` | unset | e.g. `"best"` for larger diffs |
+| `[review.routing].large_effort` | unset | e.g. `"max"` for larger diffs |
+| `[review.routing].large_with` | unset | Pin provider for larger diffs |
 | `[review.routing].large_tags` | unset | e.g. `"code-review,long-context"` |
+
+Routing uses a single cutoff (`small_max_diff_lines`): diffs at or below it go through the `small_*` bucket, everything else through the `large_*` bucket. There is no separate `large_max_diff_lines`.
 
 ### Retired in 2.0
 

--- a/tests/test-migrate-review-config.sh
+++ b/tests/test-migrate-review-config.sh
@@ -171,10 +171,17 @@ max_iterations = 3
 mode = "review-only"
 EOF
 sha_pre="$(shasum "$CLEAN" | awk '{print $1}')"
-bash "$MIGRATE" --file "$CLEAN" 2>&1 | grep -q "no recognizable 1.x markers" || {
+# Capture first, grep second. Piping directly into `grep -q` under `set -o
+# pipefail` occasionally races on SIGPIPE (grep exits on first match, the
+# upstream bash gets SIGPIPE, pipefail trips), which surfaced as an
+# intermittent "FAIL: expected 'no recognizable 1.x markers' message" even
+# though the script emitted the line correctly.
+cleanout="$(bash "$MIGRATE" --file "$CLEAN" 2>&1)"
+if ! printf '%s' "$cleanout" | grep -q "no recognizable 1.x markers"; then
   echo "FAIL: expected 'no recognizable 1.x markers' message" >&2
+  echo "  got: $cleanout" >&2
   ERRORS=$((ERRORS + 1))
-}
+fi
 sha_post="$(shasum "$CLEAN" | awk '{print $1}')"
 if [ "$sha_pre" != "$sha_post" ]; then
   echo "FAIL: no-op run modified the file" >&2


### PR DESCRIPTION
Piping bash's stdout directly into `grep -q` under `set -o pipefail`
intermittently tripped the pipeline: grep exited on first match, the
upstream bash got SIGPIPE, and pipefail flagged the pipeline as failed
even though the match succeeded. Reproduced reliably as every-other-run
under `touchstone-run.sh validate`; passed cleanly when run in
isolation. Symptom was a spurious "FAIL: expected 'no recognizable
1.x markers' message" with PASS immediately after.

Capture the migrate script's output into a variable first, grep it
second. No pipeline, no SIGPIPE race. Also prints the captured output
in the FAIL branch so future failures are easier to diagnose.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
