### PR TITLE
chore(2.0): audit-sweep follow-ups from the conductor UX pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,16 +123,16 @@ bash setup.sh --deps-only
 | `touchstone init [--no-setup]` | Add touchstone to the current project |
 | `touchstone init --no-ship` | When init upgrades an outdated project, open a review branch instead of auto-merging the upgrade PR |
 | `touchstone migrate-from-toolkit` | Migrate a project from the legacy `.toolkit-*` files before re-running `touchstone init` |
-| `touchstone init --reviewer local --local-review-command '<command>'` | Add touchstone with a local reviewer command |
-| `touchstone init --review-routing small-local --reviewer codex --local-review-command '<command>'` | Use local review for small diffs and a hosted reviewer for larger diffs |
+| `touchstone init --review-routing small-local` | Route small diffs through local Ollama, larger diffs through Conductor's auto-router |
+| `touchstone init --reviewer claude` | Pin Conductor to a specific underlying provider (codex / claude / gemini / ollama) |
 | `touchstone init --no-ai-review` | Add touchstone with AI review disabled |
 | `touchstone init --gitbutler` | Add touchstone with optional GitButler workflow setup |
 | `touchstone init --ci github` | Add `.github/workflows/validate.yml` that runs pre-commit hygiene and `touchstone run validate` on every PR |
 | `touchstone init --scaffold-tests` | Write one placeholder smoke test for Python, Node, or Go projects (Rust and Swift already ship scaffolds via `cargo init` / `swift package init`) |
 | `touchstone new <dir>` | Bootstrap a new project with principles, scripts, hooks, and templates |
 | `touchstone new <dir> --type node` | Bootstrap with an explicit Node/TypeScript, Swift, Rust, Go, Python, or generic profile |
-| `touchstone new <dir> --reviewer local --local-review-command '<command>'` | Bootstrap a new project with a local reviewer command |
-| `touchstone new <dir> --review-routing small-local --reviewer codex --local-review-command '<command>'` | Bootstrap with hybrid local/hosted review routing |
+| `touchstone new <dir> --review-routing small-local` | Bootstrap with hybrid routing — small diffs to Ollama, larger to Conductor's auto-router |
+| `touchstone new <dir> --reviewer claude` | Bootstrap pinned to a specific underlying provider |
 | `touchstone new <dir> --no-ai-review` | Bootstrap a new project with AI review disabled |
 | `touchstone new <dir> --gitbutler` | Bootstrap with optional GitButler workflow setup |
 | `touchstone new <dir> --ci github` | Bootstrap with the opt-in GitHub Actions validate workflow |

--- a/hooks/codex-review.config.example.toml
+++ b/hooks/codex-review.config.example.toml
@@ -102,13 +102,17 @@ unsafe_paths = [
 # on large or risky changes. Touchstone-side override of Conductor's knobs
 # per size bucket.
 #
+# Routing uses a single cutoff (small_max_diff_lines): diffs at or below it
+# go through the small_* bucket, everything above through the large_* bucket.
+# There is no separate large_max_diff_lines — setting one would be silently
+# ignored by the parser.
+#
 # [review.routing]
 # enabled = false
-# small_max_diff_lines = 50
+# small_max_diff_lines = 400
 # small_prefer = "cheapest"
 # small_effort = "minimal"
-# # Above small, below large: uses [review.conductor] defaults.
-# large_max_diff_lines = 1000
+# small_with = "ollama"
 # large_prefer = "best"
 # large_effort = "max"
 # large_tags = "code-review,long-context"

--- a/tests/test-migrate-review-config.sh
+++ b/tests/test-migrate-review-config.sh
@@ -94,10 +94,16 @@ echo "==> PASS: full legacy config migrated"
 # ----------------------------------------------------------------------------
 echo "==> Test: idempotent (already-migrated config is a no-op)"
 sha_before="$(shasum "$LEGACY" | awk '{print $1}')"
-bash "$MIGRATE" --file "$LEGACY" 2>&1 | grep -q "already in 2.0 shape" || {
+# Capture first, grep second (same SIGPIPE-under-pipefail race fix as the
+# clean-file assertion below — grep -q exits on first match, the upstream
+# bash process gets SIGPIPE, and pipefail trips the whole pipeline even
+# though the match succeeded).
+idempotent_out="$(bash "$MIGRATE" --file "$LEGACY" 2>&1)"
+if ! printf '%s' "$idempotent_out" | grep -q "already in 2.0 shape"; then
   echo "FAIL: expected 'already in 2.0 shape' on second run" >&2
+  echo "  got: $idempotent_out" >&2
   ERRORS=$((ERRORS + 1))
-}
+fi
 sha_after="$(shasum "$LEGACY" | awk '{print $1}')"
 if [ "$sha_before" != "$sha_after" ]; then
   echo "FAIL: idempotent run modified the file" >&2


### PR DESCRIPTION
Second pass after PRs #55 and #56 to close out the class-level instances
of the two bugs those reviews surfaced.

## Example config: match runtime defaults, drop phantom key

`hooks/codex-review.config.example.toml` is the starter .codex-review.toml
copied into every new project, so stale defaults here propagate to every
downstream. Two bugs, same class as the hooks/README.md issues Conductor
caught on #55:

- small_max_diff_lines shown as 50; runtime default is 400
  (hooks/codex-review.sh:118, bootstrap/review.sh:85)
- large_max_diff_lines documented as a real config key; the hook parser
  has no case for it. Anyone copying this example into a working config
  would get a silently-ignored setting.

Replaces with the correct single-cutoff model and adds an inline note
that setting large_max_diff_lines would be silently ignored.

## README: drop misleading --local-review-command recipes

Lines 126-127 and 134-135 advertised `touchstone init --reviewer local
--local-review-command '<command>'` and the hybrid `--reviewer codex
--local-review-command` combos. The flag still parses for back-compat,
but 2.0 retired [review.local] — the value only ends up as a comment.
Users following these recipes would get no runtime effect.

Replaced with 2.0-native recipes: `--review-routing small-local` for
hybrid routing and `--reviewer claude` for pinning a specific provider
(Conductor routes to the pinned one).

## Test: close out the remaining SIGPIPE race in test-migrate-review-config.sh

PR #56 fixed the race in the clean-file assertion. The idempotent-run
assertion 80 lines earlier uses exactly the same pattern and was
vulnerable to the same intermittent fail. Capture-first/grep-second —
same reasoning, same fix. Three consecutive `touchstone-run.sh validate`
runs confirm both the original and the new fix stick.

Skipped from this pass: the Conductor malformed-sentinel exit seen on
#55 (fail-open let the merge through even with real findings). That's
an upstream Conductor output-contract question; investigate separately
if it recurs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
