### PR TITLE
docs(git-workflow): name the guardrails that back the no-commit-on-main rule

### DIFF
--- a/principles/git-workflow.md
+++ b/principles/git-workflow.md
@@ -12,6 +12,14 @@ Normal code changes go through a feature branch + PR + merge. Emergency bypasses
 
 **If you've already pushed**, the standard ship path is broken. Don't try to rewrite history on the default branch. Disclose the slip in the next PR (see "Emergency path" below) and carry on — the commit is now part of history, and the audit trail captures what happened.
 
+**The mechanical guardrails** that back this rule (in touchstone and every bootstrapped project):
+
+- The `no-commit-to-branch` hook in `.pre-commit-config.yaml` is configured with `--branch main --branch master`. It runs at `pre-commit` stage and refuses the commit outright. `git commit --no-verify` bypasses it; that's the documented emergency path, not a daily shortcut.
+- GitHub branch protection on the default branch requires the change to go through a PR (`required_pull_request_reviews` with `required_approving_review_count: 0`; direct pushes to `main` are rejected by the server even if the local hook was bypassed). Admin enforcement is left off so the `--no-verify` emergency path remains usable; the audit trail is the backstop.
+- The Codex pre-push hook (when installed) is the last line of defense: it runs on default-branch pushes via `merge-pr.sh` and can block unsafe findings before they land.
+
+The three layers are complementary — the local hook catches the honest mistake before it becomes a commit, branch protection catches the deliberate or hook-bypassing push at the server, and the Codex review catches the class of content we explicitly don't want on main.
+
 ## The lifecycle
 
 1. **Pull.** `git pull --rebase` on the default branch before starting work.


### PR DESCRIPTION
Adds a paragraph to the "Never commit on the default branch" section naming
the three layers that actually enforce the rule:
- local no-commit-to-branch pre-commit hook (already in the template)
- GitHub branch protection on main (just enabled: require PR, 0 reviews,
  admins not enforced so the --no-verify emergency path stays usable)
- Codex pre-push hook on default-branch pushes

Rule + guardrail are now co-located per principles/audit-weak-points.md, so
a reader sees both the expectation and the automated catch in one place.

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
