### PR TITLE
feat: migrate homebrew tap bump to shared GH Actions workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+# Release workflow — auto-bumps the homebrew-touchstone tap Formula
+# whenever a GitHub Release is published in this repo.
+#
+# Two-step flow (machine handles only the deterministic half):
+#   1. Human runs `bin/touchstone release --patch | --minor | --major` on
+#      main, which bumps VERSION, commits, tags, pushes, and creates the
+#      GitHub Release.
+#   2. The `release.published` event below fires; the shared workflow in
+#      autumngarage/autumn-garage rewrites Formula/touchstone.rb's `url`
+#      + `sha256` and commits to the tap's main directly. Users running
+#      `brew upgrade touchstone` get the new version once the workflow
+#      completes (~30s after the release is published).
+#
+# Manual escape hatch: trigger via the GitHub UI's `Run workflow` button
+# (or `gh workflow run release.yml -f tag_name=vX.Y.Z`) to re-bump for a
+# tag whose original release event is gone or failed.
+#
+# Required secret on this repo: HOMEBREW_TAP_PAT — classic PAT with
+# `repo` scope on autumngarage/homebrew-touchstone (a fine-grained token
+# with contents:write on that one repo also works).
+
+name: release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Tag to bump the formula to (e.g. v2.1.2). Required for manual runs."
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  bump-tap:
+    # On the auto-trigger, skip prereleases — they shouldn't land in the
+    # tap. Manual dispatch always runs so we can re-bump on demand.
+    if: github.event_name == 'workflow_dispatch' || !github.event.release.prerelease
+    uses: autumngarage/autumn-garage/.github/workflows/homebrew-bump.yml@v1
+    with:
+      formula-name: touchstone
+      tap-repo: autumngarage/homebrew-touchstone
+      tag-name: ${{ inputs.tag_name || github.event.release.tag_name }}
+    secrets:
+      HOMEBREW_TAP_PAT: ${{ secrets.HOMEBREW_TAP_PAT }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,13 +102,16 @@ Touchstone ships through GitHub Releases and the `autumngarage/homebrew-touchsto
 Release flow:
 
 1. Merge code to `main`.
-2. Run `TOUCHSTONE_NO_AUTO_UPDATE=1 bin/touchstone release --patch` or `--minor` / `--major`.
+2. Run `TOUCHSTONE_NO_AUTO_UPDATE=1 bin/touchstone release --patch` or `--minor` / `--major`. The helper bumps `VERSION`, commits, tags, pushes `main` and the tag, and runs `gh release create`.
 3. Verify the release helper pushed the release commit to `origin/main` and pushed the matching tag.
-4. Verify the shipped artifact:
+4. The release-published event triggers `.github/workflows/release.yml`, which calls the shared `homebrew-bump.yml` reusable workflow in `autumngarage/autumn-garage` (pinned `@v1`) to rewrite the tap formula's `url` + `sha256` and commit directly to the tap's `main` — no hand-editing, no local tap clone. Watch with `gh run list --workflow=release.yml --repo autumngarage/touchstone`. Manual escape hatch: `gh workflow run release.yml -f tag_name=vX.Y.Z` re-bumps for an existing tag.
+5. Verify the shipped artifact (after the workflow completes, ~30s):
    - `git status --short --branch` is clean and not ahead of `origin/main`
    - `gh release view vX.Y.Z`
    - the Homebrew formula points at `vX.Y.Z` with the expected SHA
    - `brew update && brew upgrade touchstone`
    - `TOUCHSTONE_NO_AUTO_UPDATE=1 touchstone version` reports `touchstone vX.Y.Z`
+
+Required repo secret: `HOMEBREW_TAP_PAT` (classic PAT with `repo` scope on the tap, or fine-grained with `contents:write` on `autumngarage/homebrew-touchstone`).
 
 Do not call a Touchstone release complete until GitHub Releases, the Homebrew formula, `origin/main`, and the local brew install all agree on the same version.

--- a/lib/release.sh
+++ b/lib/release.sh
@@ -2,22 +2,16 @@
 #
 # lib/release.sh — automate the Touchstone release cycle.
 #
-# Bumps VERSION, commits, tags, pushes main, creates GitHub release, computes SHA,
-# clones the homebrew tap to a temp dir, updates the formula, pushes, cleans up.
+# Bumps VERSION, commits, tags, pushes main, creates the GitHub release.
+# The Homebrew tap formula is bumped asynchronously by
+# .github/workflows/release.yml (which calls the shared homebrew-bump
+# reusable workflow in autumngarage/autumn-garage) — no local tap clone.
 #
 set -euo pipefail
 
 source "${TOUCHSTONE_ROOT}/lib/colors.sh"
 
 TOUCHSTONE_ROOT="${TOUCHSTONE_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
-TOUCHSTONE_RELEASE_TAP_TMP=""
-
-cleanup_tap_tmp() {
-  if [ -n "${TOUCHSTONE_RELEASE_TAP_TMP:-}" ]; then
-    rm -rf "$TOUCHSTONE_RELEASE_TAP_TMP"
-    TOUCHSTONE_RELEASE_TAP_TMP=""
-  fi
-}
 
 touchstone_release() {
   local bump_type="${1:-minor}"
@@ -68,52 +62,21 @@ touchstone_release() {
   git -C "$TOUCHSTONE_ROOT" push --no-verify origin main "v${new_version}"
   tk_ok "Committed, tagged, pushed main and v${new_version}"
 
-  # Create GitHub release.
+  # Create GitHub release. The release.published event triggers
+  # .github/workflows/release.yml, which calls the shared homebrew-bump
+  # reusable workflow in autumngarage/autumn-garage — the tap formula's
+  # `url` + `sha256` get rewritten and committed to the tap's `main`
+  # automatically (no local clone, no manual SHA computation).
   gh release create "v${new_version}" \
     --repo autumngarage/touchstone \
     --title "v${new_version}" \
     --generate-notes
   tk_ok "GitHub release created"
 
-  # Compute SHA256 of the release tarball.
-  local tarball_url="https://github.com/autumngarage/touchstone/archive/refs/tags/v${new_version}.tar.gz"
-  local sha256
-  sha256="$(curl -fsSL "$tarball_url" | shasum -a 256 | awk '{print $1}')"
-  tk_ok "SHA256: ${sha256}"
-
-  # Update homebrew formula — clone tap to temp dir, update, push, clean up.
-  local tap_tmp
-  TOUCHSTONE_RELEASE_TAP_TMP="$(mktemp -d -t touchstone-tap.XXXXXX)"
-  tap_tmp="$TOUCHSTONE_RELEASE_TAP_TMP"
-  trap cleanup_tap_tmp EXIT
-
-  tk_dim "Cloning tap repo..."
-  if gh repo clone autumngarage/homebrew-touchstone "$tap_tmp" -- --depth=1 2>/dev/null; then
-    local formula="$tap_tmp/Formula/touchstone.rb"
-    if [ -f "$formula" ]; then
-      sed -i '' "s|url \"https://github.com/autumngarage/touchstone/archive/refs/tags/v[^\"]*\.tar\.gz\"|url \"${tarball_url}\"|" "$formula"
-      sed -i '' "s|sha256 \"[a-f0-9]*\"|sha256 \"${sha256}\"|" "$formula"
-
-      git -C "$tap_tmp" add Formula/touchstone.rb
-      git -C "$tap_tmp" commit -m "Bump formula to v${new_version}"
-      git -C "$tap_tmp" push
-      tk_ok "Homebrew formula updated and pushed"
-    else
-      tk_warn "Formula not found — update manually"
-      tk_dim "  URL: $tarball_url"
-      tk_dim "  SHA: $sha256"
-    fi
-  else
-    tk_warn "Could not clone tap repo — update formula manually"
-    tk_dim "  URL: $tarball_url"
-    tk_dim "  SHA: $sha256"
-  fi
-
   echo ""
   tk_ok "Released v${new_version}"
-  tk_dim "Users can upgrade with: brew update && brew upgrade touchstone"
+  tk_dim "Tap formula bump is in flight via .github/workflows/release.yml"
+  tk_dim "  watch: gh run list --workflow=release.yml --repo autumngarage/touchstone"
+  tk_dim "Users can upgrade with: brew update && brew upgrade touchstone (after the workflow completes, ~30s)"
   echo ""
-
-  cleanup_tap_tmp
-  trap - EXIT
 }


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml` — same 22-line wrapper as conductor / cortex / sentinel, calling the shared `homebrew-bump.yml` reusable workflow in `autumngarage/autumn-garage` (pinned `@v1`).
- **Removes** the local tap-bump block from `lib/release.sh` (~30 lines: mktemp + clone tap + sed-edit + commit + push, plus the `cleanup_tap_tmp` trap and TAP_TMP variable).
- Updates CLAUDE.md release section with the new step ordering.

## Why
Touchstone was the last of the four autumn-garage tools doing its tap bump bespoke. Conductor, cortex, and sentinel all use the shared GH Action now — this PR brings touchstone into line. One source of truth for "tag a release → bump the tap formula" across the org.

## What `bin/touchstone release` still does (unchanged)
- Bumps `VERSION` (and `.touchstone-version` dogfood stamp) per `--patch` / `--minor` / `--major`
- Commits, tags, pushes `main` and the tag
- Runs `gh release create`

What it no longer does locally: clone the tap, sed-edit `Formula/touchstone.rb`, push to the tap. That happens automatically via the GH Action when the release is published.

## UX shift to flag
The helper used to print `✓ Homebrew formula updated and pushed` synchronously. Now it points the user at:
```
gh run list --workflow=release.yml --repo autumngarage/touchstone
```
and notes the ~30s async window before `brew upgrade touchstone` returns the new version. Same outcome, different feedback timing.

## Required setup
Add `HOMEBREW_TAP_PAT` repo secret on this repo — classic PAT with `repo` scope on `autumngarage/homebrew-touchstone`, or fine-grained with `contents:write`.

## Test plan
- [ ] Add `HOMEBREW_TAP_PAT` secret post-merge.
- [ ] Cut next release via `bin/touchstone release --patch` and verify the tap auto-bumps within ~30s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)