### PR TITLE
chore: add scripts/release.sh — uniform release driver wrapper

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# scripts/release.sh — cut a touchstone release.
+#
+# Usage:
+#   scripts/release.sh --patch   # default
+#   scripts/release.sh --minor
+#   scripts/release.sh --major
+#
+# Thin wrapper around `bin/touchstone release` so all four autumn-garage
+# tools expose the same scripts/release.sh interface. Touchstone owns the
+# real release logic in lib/release.sh (VERSION bump, --no-verify commit,
+# tag, push, gh release create, async tap bump via release.yml).
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+bump="${1:---patch}"
+case "$bump" in
+  --major|--minor|--patch) ;;
+  *) echo "ERROR: unknown bump arg: $bump (use --major, --minor, --patch)" >&2; exit 1 ;;
+esac
+
+TOUCHSTONE_NO_AUTO_UPDATE=1 exec bin/touchstone release "$bump"


### PR DESCRIPTION
Thin wrapper around bin/touchstone release so all four autumn-garage
tools expose the same scripts/release.sh interface; the real release
logic stays in lib/release.sh.

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
