### PR TITLE
feat(agents): synced shared-principles block in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,35 @@
 # AGENTS.md — AI Reviewer Guide for Touchstone
 
+<!-- touchstone:shared-principles:start -->
+## Shared Engineering Principles (apply these first)
+
+These principles are touchstone-owned and shared across every project. Apply them as the **primary review criteria** before any project-specific rule below — a reviewer that lets a band-aid or a silent failure through has missed the point of this gate.
+
+- **No band-aids** — fix the root cause; if patching a symptom, say so explicitly and name the root cause.
+- **Keep interfaces narrow** — expose the smallest stable contract; don't leak storage shape, vendor SDKs, or workflow sequencing.
+- **Derive limits from domain** — thresholds and sizes come from input/config/named constants; test at small, typical, and large scales.
+- **Derive, don't persist** — compute from the source of truth; persist derived state only with a documented invalidation + rebuild path.
+- **No silent failures** — every exception is re-raised or logged with debug context. No `except: pass`, no swallowed errors.
+- **Every fix gets a test** — bug fix includes a regression test that runs in CI and fails on the old code.
+- **Think in invariants** — name and assert at least one invariant for nontrivial logic.
+- **One code path** — share business logic across modes; confine mode-specific differences to adapters, config, or the I/O boundary.
+- **Version your data boundaries** — when a model/algorithm/source change affects decisions, version the boundary; don't aggregate across.
+- **Separate behavior changes from tidying** — never mix functional changes with broad renames, formatting sweeps, or unrelated refactors.
+- **Make irreversible actions recoverable** — destructive operations need a dry-run, backup, idempotency, rollback, or forward-fix plan before they run.
+- **Preserve compatibility at boundaries** — public API/config/schema/CLI/hook/template changes need a compatibility or migration plan.
+- **Audit weak-point classes** — when a structural bug is found, audit the class and add a guardrail; don't fix only the one instance.
+
+Full rationale, worked examples, and the *why* behind each rule:
+
+- `principles/engineering-principles.md`
+- `principles/pre-implementation-checklist.md`
+- `principles/documentation-ownership.md`
+- `principles/git-workflow.md`
+
+This block is managed by `touchstone` and refreshes on `touchstone update` / `touchstone init`. Edit content **outside** the markers to add project-specific reviewer guidance — touchstone will not touch it.
+<!-- touchstone:shared-principles:end -->
+
+
 You are reviewing pull requests for the **touchstone** repo — a shared engineering platform whose files propagate to all downstream projects. A bug here becomes a bug everywhere.
 
 ---

--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -26,6 +26,8 @@ set -euo pipefail
 TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # shellcheck source=../lib/install-hooks.sh
 source "$TOUCHSTONE_ROOT/lib/install-hooks.sh"
+# shellcheck source=../lib/agents-principles-block.sh
+source "$TOUCHSTONE_ROOT/lib/agents-principles-block.sh"
 REGISTER=true
 REGISTER_REQUESTED=false       # Doctrine 0002: track whether --register / --no-register was passed.
 INPUT_UNSAFE=""
@@ -1199,6 +1201,11 @@ echo "==> Copying templates (project-owned, won't be auto-updated):"
 copy_file "$TOUCHSTONE_ROOT/templates/CLAUDE.md" "$PROJECT_DIR/CLAUDE.md"
 CLAUDE_MD_CREATED="$LAST_COPY_CREATED"
 copy_file "$TOUCHSTONE_ROOT/templates/AGENTS.md" "$PROJECT_DIR/AGENTS.md"
+# AGENTS.md is project-owned (copy_file skips when present), but the shared-
+# engineering-principles block inside it is touchstone-owned. Apply or refresh
+# the block so non-Claude reviewers (Codex/Gemini) see the principles too —
+# this is the only path that reaches an existing project-owned AGENTS.md.
+agents_principles_block_apply "$PROJECT_DIR/AGENTS.md" || true
 copy_file "$TOUCHSTONE_ROOT/templates/pre-commit-config.yaml" "$PROJECT_DIR/.pre-commit-config.yaml"
 copy_file "$TOUCHSTONE_ROOT/templates/gitignore" "$PROJECT_DIR/.gitignore"
 copy_file "$TOUCHSTONE_ROOT/templates/pull_request_template.md" "$PROJECT_DIR/.github/pull_request_template.md"

--- a/bootstrap/update-project.sh
+++ b/bootstrap/update-project.sh
@@ -20,6 +20,8 @@ set -euo pipefail
 TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # shellcheck source=../lib/install-hooks.sh
 source "$TOUCHSTONE_ROOT/lib/install-hooks.sh"
+# shellcheck source=../lib/agents-principles-block.sh
+source "$TOUCHSTONE_ROOT/lib/agents-principles-block.sh"
 PROJECT_DIR="$(pwd)"
 DRY_RUN=false
 CHECK_ONLY=false
@@ -419,6 +421,21 @@ if [ "$PROJECT_TYPE" = "swift" ] && [ -f "$TOUCHSTONE_ROOT/templates/swift/.swif
     "$PROJECT_DIR/.swiftlint.yml"
 fi
 
+# Refresh the touchstone-managed shared-principles block inside AGENTS.md.
+# AGENTS.md itself is project-owned, but the sentinel-delimited block is
+# touchstone-owned so non-Claude reviewers (Codex/Gemini) get the engineering
+# principles that CLAUDE.md gets for free via @-imports.
+AGENTS_PRINCIPLES_TOUCHED=false
+if [ "$DRY_RUN" = false ] && [ -f "$PROJECT_DIR/AGENTS.md" ]; then
+  agents_md_before_sha="$(shasum -a 256 "$PROJECT_DIR/AGENTS.md" | awk '{print $1}')"
+  agents_principles_block_apply "$PROJECT_DIR/AGENTS.md" || true
+  agents_md_after_sha="$(shasum -a 256 "$PROJECT_DIR/AGENTS.md" | awk '{print $1}')"
+  if [ "$agents_md_before_sha" != "$agents_md_after_sha" ]; then
+    AGENTS_PRINCIPLES_TOUCHED=true
+    echo "    refreshed (project-owned, managed block): AGENTS.md"
+  fi
+fi
+
 write_touchstone_manifest() {
   local manifest="$PROJECT_DIR/.touchstone-manifest"
   {
@@ -493,6 +510,12 @@ if [ "$DRY_RUN" = false ]; then
   # ship an incomplete change.
   if [ "${#PROJECT_OWNED_ADDED_PATHS[@]}" -gt 0 ]; then
     git -C "$PROJECT_DIR" add -f -- "${PROJECT_OWNED_ADDED_PATHS[@]}"
+  fi
+  # The shared-principles block inside AGENTS.md is touchstone-managed even
+  # though the file is project-owned. Stage it so a refresh ships in this
+  # update commit rather than dangling as an unstaged diff.
+  if [ "$AGENTS_PRINCIPLES_TOUCHED" = true ] && [ -f "$PROJECT_DIR/AGENTS.md" ]; then
+    git -C "$PROJECT_DIR" add -f -- AGENTS.md
   fi
 
   if git -C "$PROJECT_DIR" diff --cached --quiet; then

--- a/feedback/2026-04-25-vesper.md
+++ b/feedback/2026-04-25-vesper.md
@@ -1,0 +1,107 @@
+# Touchstone Feedback
+
+**From:** vesper, mid-session use (post-bootstrap, working in a touchstone-managed repo)
+**Touchstone version:** 2.2.1 (brew)
+**Date:** 2026-04-25
+**Context:** Real work session — shipped two PRs through the standard `open-pr.sh --auto-merge` path, then the user asked "is touchstone fully initialized in this repo?" The friction below came from trying to answer that question and from things I noticed while answering it.
+
+---
+
+## Headline ask: AGENTS.md should import the principles, same as CLAUDE.md
+
+Today, `CLAUDE.md` (in a touchstone-managed project) opens with:
+
+```markdown
+## Engineering Principles
+
+@principles/engineering-principles.md
+@principles/pre-implementation-checklist.md
+@principles/audit-weak-points.md
+@principles/documentation-ownership.md
+
+## Git Workflow
+
+@principles/git-workflow.md
+```
+
+…so every Claude Code session in the repo loads them. Good.
+
+`AGENTS.md` does not. It's a custom per-project reviewer guide. In vesper's case it covers Swift/SwiftUI specifics, the design system, and high-scrutiny path lists — useful, project-specific stuff. But it makes **no reference to `principles/`**. So a Codex / Gemini / Conductor-routed-to-non-Claude reviewer running on this repo silently misses every touchstone engineering principle: no band-aids, one code path, version your data boundaries, audit weak-point classes, etc.
+
+This is the kind of gap that's invisible until it bites — the merge reviewer just doesn't flag a band-aid because nobody told it band-aids are flag-worthy.
+
+**Proposal:** `touchstone init` (or the bootstrap step that writes AGENTS.md) should ensure AGENTS.md begins with a "Shared Engineering Principles" section that points at or imports `principles/*.md`, with the same authority as CLAUDE.md's section. The project-specific reviewer guidance stays after it. Two ways:
+
+1. **Markdown link block** (no agent-specific syntax): "Apply the principles in `principles/engineering-principles.md`, `principles/pre-implementation-checklist.md`, etc., as primary review criteria. Project-specific rules below."
+2. **Imported-on-load convention** (if a reviewer respects it): same `@principles/...` pattern as CLAUDE.md.
+
+Either way, the goal is: the principles flow to **whoever is reading AGENTS.md**, not just to Claude.
+
+---
+
+## Specific friction observed
+
+### 1. `touchstone status` and `touchstone doctor` overlap without a clear "use this one when…"
+
+Both commands surface project sync state. From a vesper working directory, `touchstone status` shows:
+
+```
+✓ vesper               synced  clean (main)
+```
+
+…and `touchstone doctor` shows:
+
+```
+✓ vesper — up to date
+```
+
+Same fact, different shape, different command. `doctor` adds tool-presence checks and a "Latest release" line. Not obvious which to reach for. A new user would probably try `status` first (more common name), miss the tool checks, and never run `doctor`.
+
+**Suggestion:** either fold one into the other (`status --health` for the doctor view) or print a one-liner at the end of `status` saying "Tool installation: run `touchstone doctor`."
+
+### 2. "needs sync" on other projects is noise from this directory
+
+`touchstone status` lists every registered project. From inside vesper, the report includes:
+
+```
+✓ portfolio_new        needs sync  dirty (main)
+✓ sigint               needs sync  clean (main)
+✓ vesper               synced  clean (main)
+✓ cortex               needs sync  dirty (feat/cortex-doctor-orphan-deferrals)
+... (8 more)
+```
+
+Eight of the eleven entries say "needs sync" — but from vesper's working directory, none of those are actionable. The current project's status (`vesper synced clean`) is buried in the middle of the list.
+
+This isn't *broken* — the dashboard view is genuinely useful when you want a portfolio overview. But the default `touchstone status` invocation from inside a project would benefit from foregrounding the current project's state, e.g.:
+
+```
+Current project: vesper — synced, clean (main)
+
+Other registered projects:
+  ! portfolio_new — needs sync
+  ! sigint — needs sync
+  ...
+```
+
+### 3. `.touchstone-manifest` and `.touchstone-version` are opaque without context
+
+Both files live at the repo root, both are checked in. The manifest says "Managed by touchstone. These paths may be updated by `touchstone update`." which is enough context to *not edit it*, but doesn't answer:
+
+- Is the manifest the source of truth (touchstone reads it to know what to manage), or a record (touchstone writes it after acting)?
+- If a project wants to opt **out** of having touchstone manage a file (e.g. they want a custom `scripts/codex-review.sh`), where do they signal that? The manifest doesn't seem editable.
+- What does `.touchstone-version` do besides record the version? Does `touchstone update` use it to decide what migrations to apply?
+
+A `principles/touchstone-files.md` (or similar) explaining the file's role would help. Or even a comment header on each file: `# This file is auto-managed by touchstone. To opt a path out of management, see <link>.`
+
+### 4. The `migrate-from-toolkit` and `migrate-review-config` commands clutter `touchstone help`
+
+Both are one-shot legacy migrations from pre-1.0.0 / 1.x → 2.x. Useful for a year-old project, noise for everyone else. Could be moved to `touchstone migrate <name>` with a sub-help, or hidden behind `touchstone help --legacy`.
+
+---
+
+## What worked well
+
+- The standing path `scripts/open-pr.sh --auto-merge` is the single command users rely on, and it just works. It pushed two PRs through review + squash-merge + remote cleanup with zero ceremony in this session. This is the hero feature; the friction above is around the edges.
+- `.pre-commit-config.yaml` plus the `branch-guard.sh` hook caught zero violations during the session because the workflow rules embedded in the principles are now muscle memory — but the safety net is real, which lets the user delegate confidently.
+- The principles files in CLAUDE.md actively shape session behavior. I quoted "audit one weak-point class at a time" without prompting today — they're not just documentation, they're load-bearing context.

--- a/lib/agents-principles-block.sh
+++ b/lib/agents-principles-block.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#
+# lib/agents-principles-block.sh — manage the touchstone-owned shared-engineering-
+# principles block inside a project's AGENTS.md.
+#
+# Why this exists:
+#   AGENTS.md is project-owned: copied once at bootstrap and then maintained by
+#   the project's authors. CLAUDE.md imports the principles via @principles/...
+#   so every Claude Code session loads them. AGENTS.md historically did not —
+#   so a Codex / Gemini / non-Claude reviewer running on a touchstone repo had
+#   no exposure to the engineering principles. That's a silent failure of the
+#   merge gate itself: the reviewer can't flag a band-aid if nobody told it
+#   band-aids are flag-worthy.
+#
+#   This helper inserts (and refreshes) a sentinel-delimited block at the top
+#   of AGENTS.md that lists the principles in a format any reviewer can read.
+#   The block is touchstone-owned; everything outside the markers is project-
+#   owned and never touched.
+#
+# Public surface:
+#   agents_principles_block_render               — print the current block to stdout
+#   agents_principles_block_apply <agents_md>    — apply (inject or refresh) in place
+#
+# Exit codes for agents_principles_block_apply:
+#   0 — file exists and is now current (may or may not have changed on disk)
+#   1 — file is malformed (one sentinel without its pair); refused to touch
+#   2 — file does not exist (caller decides whether to copy a template first)
+
+AGENTS_PRINCIPLES_BLOCK_BEGIN='<!-- touchstone:shared-principles:start -->'
+AGENTS_PRINCIPLES_BLOCK_END='<!-- touchstone:shared-principles:end -->'
+
+agents_principles_block_render() {
+  cat <<'BLOCK'
+<!-- touchstone:shared-principles:start -->
+## Shared Engineering Principles (apply these first)
+
+These principles are touchstone-owned and shared across every project. Apply them as the **primary review criteria** before any project-specific rule below — a reviewer that lets a band-aid or a silent failure through has missed the point of this gate.
+
+- **No band-aids** — fix the root cause; if patching a symptom, say so explicitly and name the root cause.
+- **Keep interfaces narrow** — expose the smallest stable contract; don't leak storage shape, vendor SDKs, or workflow sequencing.
+- **Derive limits from domain** — thresholds and sizes come from input/config/named constants; test at small, typical, and large scales.
+- **Derive, don't persist** — compute from the source of truth; persist derived state only with a documented invalidation + rebuild path.
+- **No silent failures** — every exception is re-raised or logged with debug context. No `except: pass`, no swallowed errors.
+- **Every fix gets a test** — bug fix includes a regression test that runs in CI and fails on the old code.
+- **Think in invariants** — name and assert at least one invariant for nontrivial logic.
+- **One code path** — share business logic across modes; confine mode-specific differences to adapters, config, or the I/O boundary.
+- **Version your data boundaries** — when a model/algorithm/source change affects decisions, version the boundary; don't aggregate across.
+- **Separate behavior changes from tidying** — never mix functional changes with broad renames, formatting sweeps, or unrelated refactors.
+- **Make irreversible actions recoverable** — destructive operations need a dry-run, backup, idempotency, rollback, or forward-fix plan before they run.
+- **Preserve compatibility at boundaries** — public API/config/schema/CLI/hook/template changes need a compatibility or migration plan.
+- **Audit weak-point classes** — when a structural bug is found, audit the class and add a guardrail; don't fix only the one instance.
+
+Full rationale, worked examples, and the *why* behind each rule:
+
+- `principles/engineering-principles.md`
+- `principles/pre-implementation-checklist.md`
+- `principles/documentation-ownership.md`
+- `principles/git-workflow.md`
+
+This block is managed by `touchstone` and refreshes on `touchstone update` / `touchstone init`. Edit content **outside** the markers to add project-specific reviewer guidance — touchstone will not touch it.
+<!-- touchstone:shared-principles:end -->
+BLOCK
+}
+
+agents_principles_block_apply() {
+  local target="$1"
+
+  if [ -z "$target" ]; then
+    echo "ERROR: agents_principles_block_apply requires a path argument" >&2
+    return 1
+  fi
+
+  if [ ! -f "$target" ]; then
+    return 2
+  fi
+
+  local has_begin has_end
+  has_begin=0
+  has_end=0
+  grep -qF "$AGENTS_PRINCIPLES_BLOCK_BEGIN" "$target" && has_begin=1
+  grep -qF "$AGENTS_PRINCIPLES_BLOCK_END" "$target" && has_end=1
+
+  if [ "$has_begin" != "$has_end" ]; then
+    echo "ERROR: $target has an orphaned shared-principles sentinel — refusing to touch." >&2
+    echo "       Inspect both '$AGENTS_PRINCIPLES_BLOCK_BEGIN' and '$AGENTS_PRINCIPLES_BLOCK_END' and reconcile manually." >&2
+    return 1
+  fi
+
+  local block_file out_file
+  block_file="$(mktemp -t agents-principles-block.XXXXXX)"
+  out_file="$(mktemp -t agents-principles-out.XXXXXX)"
+  agents_principles_block_render > "$block_file"
+
+  if [ "$has_begin" = 1 ]; then
+    # Refresh: copy lines, but when we hit the start marker, splice the current
+    # block in and skip until the end marker. Idempotent on a current file.
+    local in_block=0 spliced=0
+    while IFS= read -r line || [ -n "$line" ]; do
+      if [ "$in_block" = 1 ]; then
+        if [ "$line" = "$AGENTS_PRINCIPLES_BLOCK_END" ]; then
+          in_block=0
+        fi
+        continue
+      fi
+      if [ "$line" = "$AGENTS_PRINCIPLES_BLOCK_BEGIN" ]; then
+        if [ "$spliced" = 0 ]; then
+          cat "$block_file" >> "$out_file"
+          spliced=1
+        fi
+        in_block=1
+        continue
+      fi
+      printf '%s\n' "$line" >> "$out_file"
+    done < "$target"
+  else
+    # Inject at top, after the first H1 if there is one — otherwise at line 1.
+    local first_line
+    first_line="$(head -n 1 "$target" || true)"
+    if [[ "$first_line" =~ ^\#\  ]]; then
+      printf '%s\n' "$first_line" >> "$out_file"
+      printf '\n' >> "$out_file"
+      cat "$block_file" >> "$out_file"
+      printf '\n' >> "$out_file"
+      tail -n +2 "$target" >> "$out_file"
+    else
+      cat "$block_file" >> "$out_file"
+      printf '\n' >> "$out_file"
+      cat "$target" >> "$out_file"
+    fi
+  fi
+
+  if cmp -s "$out_file" "$target"; then
+    rm -f "$block_file" "$out_file"
+    return 0
+  fi
+
+  # Atomic replace; preserve the file's permissions.
+  cat "$out_file" > "$target"
+  rm -f "$block_file" "$out_file"
+  return 0
+}

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -4,6 +4,35 @@ You are reviewing pull requests for **{{PROJECT_NAME}}**. Optimize your review f
 
 This file is the source of truth for how AI reviewers (Codex, Claude, etc.) should think about a PR. The companion file `CLAUDE.md` is for the *author* writing the code; this file is for the *reviewer*.
 
+<!-- touchstone:shared-principles:start -->
+## Shared Engineering Principles (apply these first)
+
+These principles are touchstone-owned and shared across every project. Apply them as the **primary review criteria** before any project-specific rule below — a reviewer that lets a band-aid or a silent failure through has missed the point of this gate.
+
+- **No band-aids** — fix the root cause; if patching a symptom, say so explicitly and name the root cause.
+- **Keep interfaces narrow** — expose the smallest stable contract; don't leak storage shape, vendor SDKs, or workflow sequencing.
+- **Derive limits from domain** — thresholds and sizes come from input/config/named constants; test at small, typical, and large scales.
+- **Derive, don't persist** — compute from the source of truth; persist derived state only with a documented invalidation + rebuild path.
+- **No silent failures** — every exception is re-raised or logged with debug context. No `except: pass`, no swallowed errors.
+- **Every fix gets a test** — bug fix includes a regression test that runs in CI and fails on the old code.
+- **Think in invariants** — name and assert at least one invariant for nontrivial logic.
+- **One code path** — share business logic across modes; confine mode-specific differences to adapters, config, or the I/O boundary.
+- **Version your data boundaries** — when a model/algorithm/source change affects decisions, version the boundary; don't aggregate across.
+- **Separate behavior changes from tidying** — never mix functional changes with broad renames, formatting sweeps, or unrelated refactors.
+- **Make irreversible actions recoverable** — destructive operations need a dry-run, backup, idempotency, rollback, or forward-fix plan before they run.
+- **Preserve compatibility at boundaries** — public API/config/schema/CLI/hook/template changes need a compatibility or migration plan.
+- **Audit weak-point classes** — when a structural bug is found, audit the class and add a guardrail; don't fix only the one instance.
+
+Full rationale, worked examples, and the *why* behind each rule:
+
+- `principles/engineering-principles.md`
+- `principles/pre-implementation-checklist.md`
+- `principles/documentation-ownership.md`
+- `principles/git-workflow.md`
+
+This block is managed by `touchstone` and refreshes on `touchstone update` / `touchstone init`. Edit content **outside** the markers to add project-specific reviewer guidance — touchstone will not touch it.
+<!-- touchstone:shared-principles:end -->
+
 ---
 
 ## What to prioritize (in order)

--- a/tests/test-agents-principles-block.sh
+++ b/tests/test-agents-principles-block.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+#
+# tests/test-agents-principles-block.sh — verify the shared-principles block
+# helper for AGENTS.md.
+#
+# Covers:
+#   1. No file → returns 2 (caller decides).
+#   2. File without sentinels → block injected after the H1.
+#   3. File without H1 → block injected at the very top.
+#   4. File with current block → no diff (idempotent).
+#   5. File with stale block → block refreshed in place.
+#   6. File with project-specific content after the block → preserved verbatim.
+#   7. Orphaned start sentinel without end → returns 1, file untouched.
+#
+set -euo pipefail
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_DIR="$(mktemp -d -t touchstone-test-agents-principles.XXXXXX)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+# shellcheck source=../lib/agents-principles-block.sh
+source "$TOUCHSTONE_ROOT/lib/agents-principles-block.sh"
+
+ERRORS=0
+fail() {
+  echo "FAIL: $*" >&2
+  ERRORS=$((ERRORS + 1))
+}
+
+assert_contains() {
+  local file="$1" needle="$2"
+  if ! grep -qF "$needle" "$file"; then
+    fail "expected $file to contain '$needle'"
+  fi
+}
+
+assert_not_contains() {
+  local file="$1" needle="$2"
+  if grep -qF "$needle" "$file"; then
+    fail "expected $file to NOT contain '$needle'"
+  fi
+}
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" != "$actual" ]; then
+    fail "$label: expected '$expected', got '$actual'"
+  fi
+}
+
+# --- 1. Missing file → exit 2 ----------------------------------------------
+echo "==> missing file returns 2"
+set +e
+agents_principles_block_apply "$TEST_DIR/does-not-exist.md"
+rc=$?
+set -e
+assert_eq "missing file rc" 2 "$rc"
+
+# --- 2. Inject into a file with an H1 --------------------------------------
+echo "==> inject block after H1"
+target="$TEST_DIR/case-h1.md"
+cat > "$target" <<'EOF'
+# AGENTS.md — AI Reviewer Guide for Foo
+
+You are reviewing pull requests for **Foo**.
+
+## What to prioritize (in order)
+
+1. Data integrity.
+EOF
+agents_principles_block_apply "$target"
+assert_contains "$target" "$AGENTS_PRINCIPLES_BLOCK_BEGIN"
+assert_contains "$target" "$AGENTS_PRINCIPLES_BLOCK_END"
+assert_contains "$target" "Shared Engineering Principles"
+assert_contains "$target" "No band-aids"
+# H1 must remain on line 1.
+first_line="$(head -n 1 "$target")"
+assert_eq "h1 first line" "# AGENTS.md — AI Reviewer Guide for Foo" "$first_line"
+# Project-specific content must be preserved.
+assert_contains "$target" "1. Data integrity."
+
+# --- 3. Inject when no H1 ---------------------------------------------------
+echo "==> inject block when no H1"
+target="$TEST_DIR/case-no-h1.md"
+cat > "$target" <<'EOF'
+This file has no H1.
+
+Some body.
+EOF
+agents_principles_block_apply "$target"
+first_line="$(head -n 1 "$target")"
+assert_eq "no-h1 first line" "$AGENTS_PRINCIPLES_BLOCK_BEGIN" "$first_line"
+assert_contains "$target" "This file has no H1."
+
+# --- 4. Idempotent on a current file ----------------------------------------
+echo "==> idempotent on current block"
+target="$TEST_DIR/case-current.md"
+cat > "$target" <<'EOF'
+# AGENTS.md
+
+EOF
+agents_principles_block_apply "$target"
+sha_before="$(shasum -a 256 "$target" | awk '{print $1}')"
+agents_principles_block_apply "$target"
+sha_after="$(shasum -a 256 "$target" | awk '{print $1}')"
+assert_eq "idempotent sha" "$sha_before" "$sha_after"
+
+# --- 5. Refresh a stale block ----------------------------------------------
+echo "==> refresh stale block"
+target="$TEST_DIR/case-stale.md"
+cat > "$target" <<EOF
+# AGENTS.md
+
+$AGENTS_PRINCIPLES_BLOCK_BEGIN
+## Old Principles
+- This is a stale block from an older touchstone version.
+- It should be replaced wholesale.
+$AGENTS_PRINCIPLES_BLOCK_END
+
+## Project-specific section
+The project-specific guidance below MUST survive a refresh.
+EOF
+agents_principles_block_apply "$target"
+assert_contains "$target" "No band-aids"
+assert_not_contains "$target" "Old Principles"
+assert_not_contains "$target" "stale block from an older"
+# The project-specific content after the block must survive.
+assert_contains "$target" "## Project-specific section"
+assert_contains "$target" "MUST survive a refresh"
+
+# --- 6. Orphaned sentinel → refuses, file untouched -------------------------
+echo "==> orphaned sentinel refuses"
+target="$TEST_DIR/case-orphan.md"
+cat > "$target" <<EOF
+# AGENTS.md
+
+$AGENTS_PRINCIPLES_BLOCK_BEGIN
+Someone deleted the end marker by accident.
+
+## Project content still here.
+EOF
+sha_before="$(shasum -a 256 "$target" | awk '{print $1}')"
+set +e
+agents_principles_block_apply "$target" 2>/dev/null
+rc=$?
+set -e
+assert_eq "orphan rc" 1 "$rc"
+sha_after="$(shasum -a 256 "$target" | awk '{print $1}')"
+assert_eq "orphan untouched" "$sha_before" "$sha_after"
+
+# --- 7. Block lands BEFORE existing project content (top-of-file priority) --
+echo "==> block lands at top, ahead of project content"
+target="$TEST_DIR/case-ordering.md"
+cat > "$target" <<'EOF'
+# AGENTS.md — AI Reviewer Guide for Foo
+
+Project-specific intro.
+
+## Priorities
+EOF
+agents_principles_block_apply "$target"
+# Line numbers: H1 is line 1, blank line 2, BEGIN sentinel on line 3.
+sentinel_line="$(grep -nF "$AGENTS_PRINCIPLES_BLOCK_BEGIN" "$target" | head -1 | cut -d: -f1)"
+project_line="$(grep -nF 'Project-specific intro.' "$target" | head -1 | cut -d: -f1)"
+if [ "$sentinel_line" -ge "$project_line" ]; then
+  fail "block (line $sentinel_line) must precede project content (line $project_line)"
+fi
+
+# --- Done -------------------------------------------------------------------
+if [ "$ERRORS" -gt 0 ]; then
+  echo ""
+  echo "==> FAIL: $ERRORS check(s) failed"
+  exit 1
+fi
+echo ""
+echo "==> PASS: agents-principles-block helper behaves correctly across 7 cases"

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -177,6 +177,10 @@ if grep -q '{{PROJECT_NAME}}' "$PROJECT/AGENTS.md" 2>/dev/null; then
 fi
 assert_contains "$PROJECT/CLAUDE.md" "test-project"
 assert_contains "$PROJECT/AGENTS.md" "test-project"
+# Shared engineering principles must reach non-Claude reviewers via AGENTS.md.
+assert_contains "$PROJECT/AGENTS.md" "touchstone:shared-principles:start"
+assert_contains "$PROJECT/AGENTS.md" "touchstone:shared-principles:end"
+assert_contains "$PROJECT/AGENTS.md" "No band-aids"
 
 # Help flags should print usage instead of bootstrapping a project named --help.
 if (cd "$TEST_DIR" && bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" --help) >"$TEST_DIR/new-project-help.txt" 2>&1; then

--- a/tests/test-update.sh
+++ b/tests/test-update.sh
@@ -179,6 +179,48 @@ fi
 assert_not_exists "$PROJECT/CLAUDE.md.bak"
 
 # --------------------------------------------------------------------------
+# Test 3b: pre-existing AGENTS.md without the shared-principles block gets
+# the touchstone-managed block injected on update. This is the migration
+# path for projects bootstrapped before the shared-principles block existed —
+# without it, non-Claude reviewers (Codex/Gemini) silently miss every
+# engineering principle.
+# --------------------------------------------------------------------------
+echo ""
+echo "--- Step 4b: AGENTS.md without principles block gets backfilled on update ---"
+
+cat > "$PROJECT/AGENTS.md" <<'EOF'
+# AGENTS.md — AI Reviewer Guide for Test Project
+
+You are reviewing PRs for Test Project.
+
+## Specific review rules
+
+- Project-specific rule that must survive the update.
+EOF
+echo "0000000000000000000000000000000000000002" > "$PROJECT/.touchstone-version"
+commit_all "$PROJECT" "simulate pre-block AGENTS.md state"
+
+(cd "$PROJECT" && bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh") >/dev/null 2>&1
+
+assert_contains "$PROJECT/AGENTS.md" "touchstone:shared-principles:start"
+assert_contains "$PROJECT/AGENTS.md" "touchstone:shared-principles:end"
+assert_contains "$PROJECT/AGENTS.md" "No band-aids"
+# Project-specific content must survive injection.
+assert_contains "$PROJECT/AGENTS.md" "Project-specific rule that must survive the update."
+# H1 must remain on line 1.
+first_line="$(head -n 1 "$PROJECT/AGENTS.md")"
+if [ "$first_line" != "# AGENTS.md — AI Reviewer Guide for Test Project" ]; then
+  echo "FAIL: AGENTS.md H1 not preserved on line 1: '$first_line'" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+# The update commit must include AGENTS.md (so the block ships in the same
+# review boundary as the rest of the touchstone update).
+if ! git -C "$PROJECT" log -1 --name-only --pretty=format: | grep -qx 'AGENTS.md'; then
+  echo "FAIL: update commit must include AGENTS.md when the block was refreshed" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# --------------------------------------------------------------------------
 # Test 4: dirty worktrees fail before branching or patching.
 # --------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
AGENTS.md is project-owned, so projects bootstrapped before today never
received the engineering principles that CLAUDE.md gets via @-imports.
A Codex / Gemini / non-Claude reviewer running on a touchstone repo
silently missed every principle — no band-aids, no silent failures, etc.
That's a silent failure of the merge gate itself: the reviewer can't
flag a band-aid if nobody told it band-aids are flag-worthy.

Fix: a sentinel-delimited block at the top of AGENTS.md that lists the
principles plain (no @-imports — Codex doesn't expand them) and points
at the synced principles/*.md files. The block is touchstone-managed
and refreshes on `touchstone update` / `touchstone init`; everything
outside the markers is project-owned and never touched.

- lib/agents-principles-block.sh: render + apply (inject/refresh) the
  managed block. Refuses orphaned sentinels rather than overwriting.
- templates/AGENTS.md: ships with the block at the top of the template.
- bootstrap/new-project.sh + update-project.sh: source the helper and
  call apply on every bootstrap and update — including existing repos
  whose AGENTS.md was bootstrapped pre-block.
- tests/test-agents-principles-block.sh: 7 cases covering inject,
  refresh, idempotence, orphaned sentinel, and ordering.
- tests/test-bootstrap.sh + test-update.sh: assert the block lands on
  fresh bootstrap and gets backfilled on update of a pre-block repo.
- AGENTS.md (touchstone's own): dogfooded — the block is now at top.

Closes the headline ask in feedback/2026-04-25-vesper.md.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
