### PR TITLE
feat(init): prompt to add @principles/* to existing CLAUDE.md

### DIFF
--- a/bin/touchstone
+++ b/bin/touchstone
@@ -40,6 +40,7 @@ export TOUCHSTONE_ROOT
 source "$TOUCHSTONE_ROOT/lib/auto-update.sh"
 source "$TOUCHSTONE_ROOT/lib/colors.sh"
 source "$TOUCHSTONE_ROOT/lib/ui.sh"
+source "$TOUCHSTONE_ROOT/lib/claude-md-principles-ref.sh"
 
 # Auto-update check (throttled, non-blocking on failure).
 touchstone_auto_update || true
@@ -76,12 +77,12 @@ escape_sed_replacement() {
 
 cmd_new() {
   if [ "$#" -lt 1 ]; then
-    echo "Usage: touchstone new <project-dir> [--no-register] [--type node|python|swift|rust|go|generic|auto] [--unsafe-paths path1,path2] [--reviewer conductor|none (or legacy: codex|claude|gemini|local|auto)] [--review-routing all-hosted|all-local|small-local] [--gitbutler|--no-gitbutler] [--ci github|--no-ci] [--scaffold-tests]" >&2
+    echo "Usage: touchstone new <project-dir> [--no-register] [--type node|python|swift|rust|go|generic|auto] [--unsafe-paths path1,path2] [--reviewer conductor|none (or legacy: codex|claude|gemini|local|auto)] [--review-routing all-hosted|all-local|small-local] [--gitbutler|--no-gitbutler] [--ci github|--no-ci] [--scaffold-tests] [--claude-principles yes|no|prompt] [--no-claude-principles]" >&2
     exit 1
   fi
   case "${1:-}" in
     -h|--help)
-      echo "Usage: touchstone new <project-dir> [--no-register] [--type node|python|swift|rust|go|generic|auto] [--unsafe-paths path1,path2] [--reviewer conductor|none (or legacy: codex|claude|gemini|local|auto)] [--review-routing all-hosted|all-local|small-local] [--small-review-lines N] [--gitbutler|--no-gitbutler] [--gitbutler-mcp|--no-gitbutler-mcp] [--ci github|--no-ci] [--scaffold-tests]"
+      echo "Usage: touchstone new <project-dir> [--no-register] [--type node|python|swift|rust|go|generic|auto] [--unsafe-paths path1,path2] [--reviewer conductor|none (or legacy: codex|claude|gemini|local|auto)] [--review-routing all-hosted|all-local|small-local] [--small-review-lines N] [--gitbutler|--no-gitbutler] [--gitbutler-mcp|--no-gitbutler-mcp] [--ci github|--no-ci] [--scaffold-tests] [--claude-principles yes|no|prompt] [--no-claude-principles]"
       return 0
       ;;
   esac
@@ -93,6 +94,7 @@ cmd_init() {
   local run_setup=true
   local setup_existed=false
   local ship_upgrade=true
+  local claude_principles_mode="prompt"
   local args=()
 
   while [ "$#" -gt 0 ]; do
@@ -110,7 +112,7 @@ cmd_init() {
         shift
         ;;
       -h|--help)
-        echo "Usage: touchstone init [--no-setup] [--no-ship] [--type node|python|swift|rust|go|generic|auto] [--no-register] [--unsafe-paths path1,path2] [--reviewer conductor|none (or legacy: codex|claude|gemini|local|auto)] [--review-routing all-hosted|all-local|small-local] [--small-review-lines N] [--gitbutler|--no-gitbutler] [--gitbutler-mcp|--no-gitbutler-mcp] [--ci github|--no-ci] [--scaffold-tests]"
+        echo "Usage: touchstone init [--no-setup] [--no-ship] [--type node|python|swift|rust|go|generic|auto] [--no-register] [--unsafe-paths path1,path2] [--reviewer conductor|none (or legacy: codex|claude|gemini|local|auto)] [--review-routing all-hosted|all-local|small-local] [--small-review-lines N] [--gitbutler|--no-gitbutler] [--gitbutler-mcp|--no-gitbutler-mcp] [--ci github|--no-ci] [--scaffold-tests] [--claude-principles yes|no|prompt] [--no-claude-principles]"
         return 0
         ;;
       --type)
@@ -155,9 +157,27 @@ cmd_init() {
         args+=("$1")
         shift
         ;;
+      --claude-principles)
+        if [ "$#" -lt 2 ]; then
+          echo "ERROR: --claude-principles requires a value (yes, no, or prompt)" >&2
+          exit 1
+        fi
+        case "$2" in
+          yes|no|prompt) claude_principles_mode="$2" ;;
+          *)
+            echo "ERROR: --claude-principles must be 'yes', 'no', or 'prompt' (got '$2')" >&2
+            exit 1
+            ;;
+        esac
+        shift 2
+        ;;
+      --no-claude-principles)
+        claude_principles_mode="no"
+        shift
+        ;;
       *)
         echo "ERROR: unknown argument '$1'" >&2
-        echo "Usage: touchstone init [--no-setup] [--no-ship] [--type node|python|swift|rust|go|generic|auto] [--no-register] [--unsafe-paths path1,path2] [--reviewer conductor|none (or legacy: codex|claude|gemini|local|auto)] [--review-routing all-hosted|all-local|small-local] [--gitbutler|--no-gitbutler] [--ci github|--no-ci] [--scaffold-tests]" >&2
+        echo "Usage: touchstone init [--no-setup] [--no-ship] [--type node|python|swift|rust|go|generic|auto] [--no-register] [--unsafe-paths path1,path2] [--reviewer conductor|none (or legacy: codex|claude|gemini|local|auto)] [--review-routing all-hosted|all-local|small-local] [--gitbutler|--no-gitbutler] [--ci github|--no-ci] [--scaffold-tests] [--claude-principles yes|no|prompt] [--no-claude-principles]" >&2
         exit 1
         ;;
     esac
@@ -207,6 +227,11 @@ cmd_init() {
         tk_info "Delegating to 'touchstone update' (branch + commit so the upgrade is reviewable)"
       fi
       echo ""
+      # The CLAUDE.md connection check is intentionally skipped on the
+      # outdated path: update-project.sh requires a clean worktree, and
+      # injecting the imports here would dirty it before update runs.
+      # After the update completes (project moves to `current` state),
+      # the user can re-run `touchstone init` to migrate CLAUDE.md.
       exec bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh" "${update_args[@]}"
       ;;
   esac
@@ -215,6 +240,13 @@ cmd_init() {
   tk_hero "setting up this project"
 
   bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$project_dir" "${args[@]}"
+
+  # Connect CLAUDE.md (or record that we already are). new-project.sh's
+  # template copy plants the imports on a fresh init, so this normally
+  # records `connected` without prompting. The interesting case is `current`
+  # state on a project whose user wrote their own CLAUDE.md without imports
+  # — then we prompt.
+  ensure_claude_principles_ref "$project_dir" "$claude_principles_mode"
 
   # Only fresh init runs setup.sh automatically. Reconciling an existing repo
   # must not re-trigger machine-wide dev-tool installs or interactive prompts

--- a/lib/claude-md-principles-ref.sh
+++ b/lib/claude-md-principles-ref.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+#
+# lib/claude-md-principles-ref.sh — plant the @principles/* import block in
+# a project's CLAUDE.md so Claude Code loads the touchstone engineering
+# principles every session.
+#
+# Why this exists:
+#   touchstone init can run on a repo that already has its own CLAUDE.md
+#   (the user wrote one before adopting touchstone). We don't want to
+#   silently overwrite that — but without the @principles/* imports, the
+#   project's Claude sessions never load the engineering principles, even
+#   after `touchstone update` syncs the principles/*.md files into the repo.
+#
+#   This helper is invoked at init time (one-shot, with consent). It plants
+#   a small block of @-imports near the top of CLAUDE.md. Once planted, the
+#   *content* behind those imports flows automatically — every `touchstone
+#   update` refreshes principles/*.md, and every Claude session re-reads
+#   the imports. We never touch CLAUDE.md again after init.
+#
+# Public surface:
+#   claude_md_has_principles_ref <path>     — exit 0 if @principles/ is present
+#   claude_md_render_principles_block       — print the block to stdout
+#   claude_md_inject_principles_block <path> — append/inject the block once
+#
+# Exit codes for claude_md_inject_principles_block:
+#   0 — block injected (or already present; idempotent)
+#   1 — file missing or write failed
+#   2 — file already has @principles/ references; no change made (caller's
+#       cue to skip the prompt entirely)
+
+# Marker is sourced into bin/touchstone and may be referenced by future
+# doctor / connection-status checks; export-shaped for that consumer.
+# shellcheck disable=SC2034
+CLAUDE_MD_PRINCIPLES_MARKER='<!-- touchstone:claude-principles-ref -->'
+
+# Read the recorded init-time decision from .touchstone-config.
+# Echoes one of: connected | skipped | "" (unset).
+# Always returns 0 so callers under `set -euo pipefail` can use
+# `prior="$(claude_md_principles_ref_decision ...)"` without aborting on a
+# missing config or unmatched grep.
+claude_md_principles_ref_decision() {
+  local config="$1/.touchstone-config"
+  [ -f "$config" ] || { printf ''; return 0; }
+  local val
+  val="$(grep -E '^claude_principles_ref=' "$config" 2>/dev/null \
+         | tail -n1 \
+         | cut -d= -f2- \
+         | tr -d '[:space:]' || true)"
+  printf '%s' "$val"
+  return 0
+}
+
+# Persist the init-time decision to .touchstone-config (idempotent rewrite).
+# Caller passes the project dir and one of: connected | skipped.
+claude_md_principles_ref_record() {
+  local project_dir="$1"
+  local value="$2"
+  local config="$project_dir/.touchstone-config"
+  case "$value" in
+    connected|skipped) ;;
+    *) return 1 ;;
+  esac
+
+  if [ ! -f "$config" ]; then
+    printf '# touchstone project profile.\nclaude_principles_ref=%s\n' "$value" > "$config"
+    return 0
+  fi
+
+  if grep -qE '^claude_principles_ref=' "$config"; then
+    local tmp
+    tmp="$(mktemp -t touchstone-config.XXXXXX)"
+    awk -v v="$value" '
+      /^claude_principles_ref=/ { print "claude_principles_ref=" v; next }
+      { print }
+    ' "$config" > "$tmp"
+    cat "$tmp" > "$config"
+    rm -f "$tmp"
+  else
+    printf 'claude_principles_ref=%s\n' "$value" >> "$config"
+  fi
+}
+
+claude_md_has_principles_ref() {
+  local target="$1"
+  [ -f "$target" ] || return 1
+  grep -qE '^@principles/' "$target"
+}
+
+claude_md_render_principles_block() {
+  cat <<'BLOCK'
+<!-- touchstone:claude-principles-ref -->
+## Touchstone — Shared Engineering Principles
+
+These imports load every Claude Code session in this repo. The files behind
+them are touchstone-owned and refresh on every `touchstone update`.
+
+@principles/pre-implementation-checklist.md
+@principles/documentation-ownership.md
+@principles/git-workflow.md
+
+---
+BLOCK
+}
+
+claude_md_inject_principles_block() {
+  local target="$1"
+
+  if [ -z "$target" ] || [ ! -f "$target" ]; then
+    return 1
+  fi
+
+  if claude_md_has_principles_ref "$target"; then
+    return 2
+  fi
+
+  local block_file out_file
+  block_file="$(mktemp -t claude-md-principles.XXXXXX)"
+  out_file="$(mktemp -t claude-md-principles-out.XXXXXX)"
+  claude_md_render_principles_block > "$block_file"
+
+  local first_line
+  first_line="$(head -n 1 "$target" || true)"
+  if [[ "$first_line" =~ ^\#\  ]]; then
+    printf '%s\n' "$first_line" >> "$out_file"
+    printf '\n' >> "$out_file"
+    cat "$block_file" >> "$out_file"
+    printf '\n' >> "$out_file"
+    tail -n +2 "$target" >> "$out_file"
+  else
+    cat "$block_file" >> "$out_file"
+    printf '\n' >> "$out_file"
+    cat "$target" >> "$out_file"
+  fi
+
+  cat "$out_file" > "$target"
+  rm -f "$block_file" "$out_file"
+  return 0
+}
+
+# ensure_claude_principles_ref <project_dir> <mode>
+#
+# Plant the touchstone @principles/* import block in the project's CLAUDE.md
+# so Claude Code loads the engineering principles every session. Idempotent:
+# never asks twice, never overwrites an already-connected file.
+#
+# Modes:
+#   yes     — inject without asking (still no-op if already connected).
+#   no      — skip and record `claude_principles_ref=skipped` so future
+#             touchstone init runs respect the decision.
+#   prompt  — TTY: ask [Y/n], record the decision.
+#             Non-TTY: skip, do NOT record (a later interactive run can prompt).
+#
+# Callers may shadow tk_ok / tk_warn / tk_dim / tk_header with their own
+# implementations; this helper falls back to plain echo if they aren't defined.
+ensure_claude_principles_ref() {
+  local project_dir="$1"
+  local mode="${2:-prompt}"
+  local claude_md="$project_dir/CLAUDE.md"
+
+  _epr_say()  { if command -v tk_dim   >/dev/null 2>&1; then tk_dim   "$@"; else echo "$@";   fi; }
+  _epr_ok()   { if command -v tk_ok    >/dev/null 2>&1; then tk_ok    "$@"; else echo "OK: $*"; fi; }
+  _epr_warn() { if command -v tk_warn  >/dev/null 2>&1; then tk_warn  "$@"; else echo "WARN: $*" >&2; fi; }
+  _epr_head() { if command -v tk_header >/dev/null 2>&1; then tk_header "$@"; else echo "==> $*"; fi; }
+
+  # Respect a prior decision. Once recorded, init never re-prompts —
+  # the user said yes (already injected) or no (skipped on purpose).
+  local prior
+  prior="$(claude_md_principles_ref_decision "$project_dir")"
+  case "$prior" in
+    connected|skipped) return 0 ;;
+  esac
+
+  # Nothing to connect to — no CLAUDE.md means new-project.sh will copy the
+  # template (which already has the @-imports baked in), or the user opted
+  # out of having a CLAUDE.md altogether.
+  if [ ! -f "$claude_md" ]; then
+    return 0
+  fi
+
+  # Already connected via the template (fresh init) or a hand-written
+  # equivalent — record the state and move on. No prompt needed.
+  if claude_md_has_principles_ref "$claude_md"; then
+    claude_md_principles_ref_record "$project_dir" connected
+    return 0
+  fi
+
+  case "$mode" in
+    yes)
+      claude_md_inject_principles_block "$claude_md" || return 0
+      claude_md_principles_ref_record "$project_dir" connected
+      _epr_ok "Added @principles/* imports to CLAUDE.md."
+      ;;
+    no)
+      claude_md_principles_ref_record "$project_dir" skipped
+      _epr_say "Skipped Touchstone principles in CLAUDE.md (recorded in .touchstone-config)."
+      ;;
+    prompt|*)
+      if [ ! -t 0 ] || [ ! -t 1 ]; then
+        _epr_warn "CLAUDE.md exists but does not import touchstone principles."
+        _epr_say  "Re-run interactively, or pass --no-claude-principles to skip permanently."
+        return 0
+      fi
+      _epr_head "Touchstone — connect CLAUDE.md to engineering principles"
+      _epr_say "Found CLAUDE.md without @principles/* imports. Adding them lets every"
+      _epr_say "Claude Code session in this repo load the touchstone principles, and"
+      _epr_say "lets future touchstone updates ship principle changes automatically."
+      echo ""
+      echo "  Will inject after the H1:"
+      echo "    @principles/pre-implementation-checklist.md"
+      echo "    @principles/documentation-ownership.md"
+      echo "    @principles/git-workflow.md"
+      echo ""
+      local answer=""
+      printf "  Add the imports to CLAUDE.md? [Y/n] "
+      read -r answer || answer=""
+      case "$answer" in
+        n|N|no|NO|No)
+          claude_md_principles_ref_record "$project_dir" skipped
+          _epr_say "Skipped. Re-run touchstone init to opt in later."
+          ;;
+        *)
+          if claude_md_inject_principles_block "$claude_md"; then
+            claude_md_principles_ref_record "$project_dir" connected
+            _epr_ok "Added @principles/* imports to CLAUDE.md."
+          else
+            _epr_warn "Failed to inject imports into CLAUDE.md (file unreadable or write failed)."
+          fi
+          ;;
+      esac
+      ;;
+  esac
+}

--- a/tests/test-claude-md-principles-ref.sh
+++ b/tests/test-claude-md-principles-ref.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+#
+# tests/test-claude-md-principles-ref.sh — verify the CLAUDE.md @principles
+# import-block helper and its end-to-end use through `touchstone init`.
+#
+# Covers:
+#   1. has_principles_ref detection (positive/negative)
+#   2. inject_principles_block on a CLAUDE.md without imports
+#   3. inject is a no-op when imports already exist (returns 2)
+#   4. decision record/read round-trip via .touchstone-config
+#   5. end-to-end: --claude-principles=yes plants imports + records connected
+#   6. end-to-end: --no-claude-principles records skipped
+#   7. end-to-end: a prior recorded decision is respected (no re-prompt path)
+#   8. end-to-end: existing CLAUDE.md with @principles/ already records `connected`
+#
+set -euo pipefail
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_DIR="$(mktemp -d -t touchstone-test-claude-md-principles.XXXXXX)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+# shellcheck source=../lib/claude-md-principles-ref.sh
+source "$TOUCHSTONE_ROOT/lib/claude-md-principles-ref.sh"
+
+ERRORS=0
+fail() { echo "FAIL: $*" >&2; ERRORS=$((ERRORS + 1)); }
+assert_contains() {
+  local file="$1" needle="$2"
+  if ! grep -qF "$needle" "$file"; then
+    fail "expected $file to contain '$needle'"
+  fi
+}
+assert_not_contains() {
+  local file="$1" needle="$2"
+  if grep -qF "$needle" "$file"; then
+    fail "expected $file to NOT contain '$needle'"
+  fi
+}
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  [ "$expected" = "$actual" ] || fail "$label: expected '$expected', got '$actual'"
+}
+
+# --- 1. Detection (positive/negative) ---------------------------------------
+echo "==> 1. has_principles_ref detection"
+mkdir -p "$TEST_DIR/case-detect"
+cat > "$TEST_DIR/case-detect/CLAUDE.md" <<'EOF'
+# Project
+
+@principles/git-workflow.md
+EOF
+if ! claude_md_has_principles_ref "$TEST_DIR/case-detect/CLAUDE.md"; then
+  fail "should detect @principles/ when present"
+fi
+cat > "$TEST_DIR/case-detect/CLAUDE.md" <<'EOF'
+# Project
+
+No imports here, just plain text.
+EOF
+if claude_md_has_principles_ref "$TEST_DIR/case-detect/CLAUDE.md"; then
+  fail "should NOT detect @principles/ when absent"
+fi
+
+# --- 2. Inject when imports missing -----------------------------------------
+echo "==> 2. inject after H1 when imports missing"
+mkdir -p "$TEST_DIR/case-inject"
+cat > "$TEST_DIR/case-inject/CLAUDE.md" <<'EOF'
+# My Project
+
+Some intro text.
+
+## Architecture
+
+Stuff.
+EOF
+claude_md_inject_principles_block "$TEST_DIR/case-inject/CLAUDE.md"
+rc=$?
+assert_eq "inject rc" 0 "$rc"
+assert_contains "$TEST_DIR/case-inject/CLAUDE.md" "@principles/pre-implementation-checklist.md"
+assert_contains "$TEST_DIR/case-inject/CLAUDE.md" "@principles/documentation-ownership.md"
+assert_contains "$TEST_DIR/case-inject/CLAUDE.md" "@principles/git-workflow.md"
+# H1 must remain on line 1.
+first_line="$(head -n 1 "$TEST_DIR/case-inject/CLAUDE.md")"
+assert_eq "H1 preserved" "# My Project" "$first_line"
+# Project content must survive.
+assert_contains "$TEST_DIR/case-inject/CLAUDE.md" "Some intro text."
+assert_contains "$TEST_DIR/case-inject/CLAUDE.md" "## Architecture"
+
+# --- 3. Inject is a no-op (rc=2) when already connected ---------------------
+echo "==> 3. inject is no-op when imports already present"
+sha_before="$(shasum -a 256 "$TEST_DIR/case-inject/CLAUDE.md" | awk '{print $1}')"
+set +e
+claude_md_inject_principles_block "$TEST_DIR/case-inject/CLAUDE.md"
+rc=$?
+set -e
+assert_eq "second-inject rc (already connected)" 2 "$rc"
+sha_after="$(shasum -a 256 "$TEST_DIR/case-inject/CLAUDE.md" | awk '{print $1}')"
+assert_eq "second-inject sha (untouched)" "$sha_before" "$sha_after"
+
+# --- 4. Decision record/read round-trip -------------------------------------
+echo "==> 4. .touchstone-config decision round-trip"
+DEC_DIR="$TEST_DIR/case-decision"
+mkdir -p "$DEC_DIR"
+# Empty config: read returns "".
+got="$(claude_md_principles_ref_decision "$DEC_DIR")"
+assert_eq "no-config decision" "" "$got"
+# Record connected, read it back.
+claude_md_principles_ref_record "$DEC_DIR" connected
+got="$(claude_md_principles_ref_decision "$DEC_DIR")"
+assert_eq "after record connected" "connected" "$got"
+# Update to skipped, read it back.
+claude_md_principles_ref_record "$DEC_DIR" skipped
+got="$(claude_md_principles_ref_decision "$DEC_DIR")"
+assert_eq "after rewrite skipped" "skipped" "$got"
+# Make sure we didn't duplicate the line.
+count="$(grep -cE '^claude_principles_ref=' "$DEC_DIR/.touchstone-config")"
+assert_eq "no duplicate keys" "1" "$count"
+
+# --- end-to-end via ensure_claude_principles_ref ---------------------------
+# Drive the function directly. The bin/touchstone init wrapper calls this
+# same function on every init path, so this exercises the real behavior the
+# user sees — without dragging in new-project.sh's interactive wizard.
+
+setup_existing_repo() {
+  local dir="$1" with_imports="${2:-no}"
+  mkdir -p "$dir"
+  if [ "$with_imports" = yes ]; then
+    cat > "$dir/CLAUDE.md" <<'EOF'
+# My Project
+
+@principles/git-workflow.md
+EOF
+  else
+    cat > "$dir/CLAUDE.md" <<'EOF'
+# My Project
+
+Some intro text. No imports.
+EOF
+  fi
+}
+
+# --- 5. mode=yes injects + records connected -------------------------------
+echo "==> 5. ensure_claude_principles_ref yes plants imports"
+E5="$TEST_DIR/e2e-yes"
+setup_existing_repo "$E5" no
+ensure_claude_principles_ref "$E5" yes >/dev/null
+assert_contains "$E5/CLAUDE.md" "@principles/pre-implementation-checklist.md"
+assert_contains "$E5/.touchstone-config" "claude_principles_ref=connected"
+
+# --- 6. mode=no records skipped --------------------------------------------
+echo "==> 6. ensure_claude_principles_ref no records skipped"
+E6="$TEST_DIR/e2e-no"
+setup_existing_repo "$E6" no
+ensure_claude_principles_ref "$E6" no >/dev/null
+assert_not_contains "$E6/CLAUDE.md" "@principles/pre-implementation-checklist.md"
+assert_contains "$E6/.touchstone-config" "claude_principles_ref=skipped"
+
+# --- 7. prior recorded decision is respected --------------------------------
+echo "==> 7. prior recorded decision is respected"
+E7="$TEST_DIR/e2e-respect"
+setup_existing_repo "$E7" no
+# Pre-record a "skipped" decision before the helper runs.
+printf 'claude_principles_ref=skipped\n' > "$E7/.touchstone-config"
+# Caller passes mode=yes, but the prior `skipped` decision wins — the user
+# already opted out and the helper must not re-prompt or silently flip the
+# answer.
+ensure_claude_principles_ref "$E7" yes >/dev/null
+assert_not_contains "$E7/CLAUDE.md" "@principles/pre-implementation-checklist.md"
+assert_contains "$E7/.touchstone-config" "claude_principles_ref=skipped"
+
+# --- 8. existing @principles/ records connected without modification -------
+echo "==> 8. existing @principles/ records connected without modification"
+E8="$TEST_DIR/e2e-already-connected"
+setup_existing_repo "$E8" yes
+sha_before="$(shasum -a 256 "$E8/CLAUDE.md" | awk '{print $1}')"
+ensure_claude_principles_ref "$E8" prompt >/dev/null
+sha_after="$(shasum -a 256 "$E8/CLAUDE.md" | awk '{print $1}')"
+assert_eq "no modification when already connected" "$sha_before" "$sha_after"
+assert_contains "$E8/.touchstone-config" "claude_principles_ref=connected"
+
+# --- 9. mode=prompt with no TTY warns and does NOT record -------------------
+echo "==> 9. prompt mode in non-TTY does not record (allows later interactive)"
+E9="$TEST_DIR/e2e-prompt-noniteractive"
+setup_existing_repo "$E9" no
+# This script's stdin is non-TTY when run as part of the test suite, so
+# prompt mode should warn-and-skip without recording.
+ensure_claude_principles_ref "$E9" prompt >/dev/null 2>&1
+assert_not_contains "$E9/CLAUDE.md" "@principles/pre-implementation-checklist.md"
+if [ -f "$E9/.touchstone-config" ] && grep -qE '^claude_principles_ref=' "$E9/.touchstone-config"; then
+  fail "prompt mode in non-TTY should not record a decision (file may be re-prompted later)"
+fi
+
+# --- Done -------------------------------------------------------------------
+if [ "$ERRORS" -gt 0 ]; then
+  echo ""
+  echo "==> FAIL: $ERRORS check(s) failed"
+  exit 1
+fi
+echo ""
+echo "==> PASS: claude-md-principles-ref behaves correctly across 9 cases"


### PR DESCRIPTION
Existing repos that adopt touchstone often already have a hand-written
CLAUDE.md. new-project.sh's copy_file skips it (project-owned), so the
@principles/* imports never land — Claude Code sessions in that repo
never load the engineering principles, and `touchstone update` can't
help because update doesn't touch CLAUDE.md by design.

This PR plants the connection at init time, with consent. Once present,
the principles content flows automatically forever: every Claude session
re-reads the imports, and every `touchstone update` keeps principles/*.md
fresh on disk.

What it does:
- Detects when CLAUDE.md exists but lacks any @principles/ reference.
- TTY: prompts [Y/n] (default Y), inject + record connected on yes,
  record skipped on no. Either decision is final — `.touchstone-config`
  remembers it, future inits respect it.
- Non-TTY: prints a warning and does NOT record, so a later interactive
  run can still prompt. `--no-claude-principles` records skipped on
  purpose; `--claude-principles=yes` injects without asking.
- Skips the connection check on the `outdated` init path: update-project
  requires a clean worktree, so injecting first would dirty it. The user
  re-runs `touchstone init` after upgrade lands to migrate.

Files:
- lib/claude-md-principles-ref.sh: render + inject + decision-record
  helpers, plus ensure_claude_principles_ref() that orchestrates them.
- bin/touchstone: source the helper, wire ensure_claude_principles_ref
  into cmd_init's fresh/current paths, expose --claude-principles and
  --no-claude-principles flags.
- tests/test-claude-md-principles-ref.sh: 9 cases — detection, inject,
  idempotence, decision round-trip, mode=yes, mode=no, prior-decision
  respected, already-connected no-op, non-TTY prompt skip-without-record.

Migration path for the existing portfolio:
  1. `touchstone sync` (already auto-fixes AGENTS.md from PR #68).
  2. `touchstone status` to see which projects need CLAUDE.md migration.
  3. `cd <project> && touchstone init` for each one — answer Y.

Closes the headline ask in feedback/2026-04-25-vesper.md.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
