### PR TITLE
fix(touchstone): drop --claude-principles from cmd_new usage

### DIFF
--- a/bin/touchstone
+++ b/bin/touchstone
@@ -77,12 +77,12 @@ escape_sed_replacement() {
 
 cmd_new() {
   if [ "$#" -lt 1 ]; then
-    echo "Usage: touchstone new <project-dir> [--no-register] [--type node|python|swift|rust|go|generic|auto] [--unsafe-paths path1,path2] [--reviewer conductor|none (or legacy: codex|claude|gemini|local|auto)] [--review-routing all-hosted|all-local|small-local] [--gitbutler|--no-gitbutler] [--ci github|--no-ci] [--scaffold-tests] [--claude-principles yes|no|prompt] [--no-claude-principles]" >&2
+    echo "Usage: touchstone new <project-dir> [--no-register] [--type node|python|swift|rust|go|generic|auto] [--unsafe-paths path1,path2] [--reviewer conductor|none (or legacy: codex|claude|gemini|local|auto)] [--review-routing all-hosted|all-local|small-local] [--gitbutler|--no-gitbutler] [--ci github|--no-ci] [--scaffold-tests]" >&2
     exit 1
   fi
   case "${1:-}" in
     -h|--help)
-      echo "Usage: touchstone new <project-dir> [--no-register] [--type node|python|swift|rust|go|generic|auto] [--unsafe-paths path1,path2] [--reviewer conductor|none (or legacy: codex|claude|gemini|local|auto)] [--review-routing all-hosted|all-local|small-local] [--small-review-lines N] [--gitbutler|--no-gitbutler] [--gitbutler-mcp|--no-gitbutler-mcp] [--ci github|--no-ci] [--scaffold-tests] [--claude-principles yes|no|prompt] [--no-claude-principles]"
+      echo "Usage: touchstone new <project-dir> [--no-register] [--type node|python|swift|rust|go|generic|auto] [--unsafe-paths path1,path2] [--reviewer conductor|none (or legacy: codex|claude|gemini|local|auto)] [--review-routing all-hosted|all-local|small-local] [--small-review-lines N] [--gitbutler|--no-gitbutler] [--gitbutler-mcp|--no-gitbutler-mcp] [--ci github|--no-ci] [--scaffold-tests]"
       return 0
       ;;
   esac

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -199,6 +199,28 @@ if [ -d "$TEST_DIR/--help" ]; then
   ERRORS=$((ERRORS + 1))
 fi
 
+# `cmd_new` is a passthrough to new-project.sh, which doesn't accept the
+# init-only --claude-principles flags. Guard against drift between
+# cmd_new's usage string and the flags new-project.sh actually parses —
+# a regression here misleads users into typing flags that error.
+if (cd "$TEST_DIR" && "$TOUCHSTONE_ROOT/bin/touchstone" new --help) >"$TEST_DIR/touchstone-new-help.txt" 2>&1; then
+  if grep -qE -- '--claude-principles|--no-claude-principles' "$TEST_DIR/touchstone-new-help.txt"; then
+    echo "FAIL: 'touchstone new --help' must not advertise --claude-principles flags (cmd_init only)" >&2
+    ERRORS=$((ERRORS + 1))
+  fi
+else
+  echo "FAIL: 'touchstone new --help' must succeed" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+# init must still advertise them, so the symmetric assertion guards the
+# other half of the boundary.
+if (cd "$TEST_DIR" && "$TOUCHSTONE_ROOT/bin/touchstone" init --help) >"$TEST_DIR/touchstone-init-help.txt" 2>&1; then
+  assert_contains "$TEST_DIR/touchstone-init-help.txt" 'claude-principles'
+else
+  echo "FAIL: 'touchstone init --help' must succeed" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
 if TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" init --help >"$TEST_DIR/touchstone-init-help.txt" 2>&1; then
   assert_contains "$TEST_DIR/touchstone-init-help.txt" 'Usage: touchstone init'
   assert_contains "$TEST_DIR/touchstone-init-help.txt" 'reviewer conductor|none'


### PR DESCRIPTION
PR #69 added --claude-principles / --no-claude-principles flags to
cmd_init, but the replace_all edit on the usage strings hit cmd_new's
two usage strings as well. cmd_new is a pure passthrough — it does
`exec bash new-project.sh "$@"`, and new-project.sh has no parser
branch for those flags. So a user who copy-pasted the advertised flags
from `touchstone new --help` would hit `ERROR: unknown argument
'--claude-principles'` straight from new-project.sh.

Conductor's merge review caught this on PR #69 but was set to fail-open,
so the bug landed on main. This patch removes the misleading flag
advertisements from both `cmd_new` usage strings (line 80 and the
--help echo at line 85) and adds a regression test that asserts
`touchstone new --help` does NOT advertise --claude-principles while
`touchstone init --help` still does — guards against the same class of
edit-drift in either direction.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
