### PR TITLE
chore(codex-review): set on_error = fail-closed for touchstone

### DIFF
--- a/.codex-review.toml
+++ b/.codex-review.toml
@@ -9,6 +9,14 @@ max_diff_lines = 5000
 # Auto-fix is safe for most touchstone code.
 safe_by_default = true
 
+# Block the push when the reviewer crashes, times out, or returns malformed
+# output. Touchstone PR #69 shipped a real blocking finding under fail-open
+# because the reviewer hit a malformed-sentinel error mid-output — the
+# finding was in the unparsed tail. Fail-closed errs toward "do not ship
+# what we couldn't read." Emergency path: `git push --no-verify`, disclosed
+# in the next PR per principles/git-workflow.md.
+on_error = "fail-closed"
+
 # Bootstrap and update scripts are high-scrutiny — a bug here propagates
 # to every downstream project.
 unsafe_paths = [


### PR DESCRIPTION
PR #69 demonstrated the failure mode of fail-open: the merge reviewer
correctly identified a blocking issue (cmd_new advertising flags it
doesn't accept) but the hook hit a malformed-sentinel error mid-output
and treated the run as a non-blocking infrastructure error. The finding
was in the unparsed tail. Result: a real bug shipped, hotfixed in #70.

Flipping touchstone's own config to fail-closed errs on the side of
"do not ship what we couldn't parse." The emergency path
(`git push --no-verify` with disclosure) remains open for genuine
infrastructure outages.

Scope is intentionally narrow — touchstone's own .codex-review.toml
only. Propagating the change to downstream projects (either by
flipping the example template or by changing codex-review.sh's
fallback default) belongs with the broader doctor / connection-status
work where we can also detect and migrate existing project configs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
