### PR TITLE
fix(codex-review): disable SC2120 on parse_primary_provider

### DIFF
--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -1706,6 +1706,8 @@ print_route_log() {
 # Reads the route-log line from REVIEW_STDERR_FILE. Returns the provider
 # name on stdout, or empty if not found. Tolerates both real conductor's
 # unicode arrow and ASCII-fallback shapes.
+#
+# shellcheck disable=SC2120  # $1 is intentionally optional with a default.
 parse_primary_provider() {
   local stderr_file="${1:-$REVIEW_STDERR_FILE}"
   [ -f "$stderr_file" ] || { printf ''; return; }

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -1706,6 +1706,8 @@ print_route_log() {
 # Reads the route-log line from REVIEW_STDERR_FILE. Returns the provider
 # name on stdout, or empty if not found. Tolerates both real conductor's
 # unicode arrow and ASCII-fallback shapes.
+#
+# shellcheck disable=SC2120  # $1 is intentionally optional with a default.
 parse_primary_provider() {
   local stderr_file="${1:-$REVIEW_STDERR_FILE}"
   [ -f "$stderr_file" ] || { printf ''; return; }


### PR DESCRIPTION
When sentinel tried to ship its touchstone 2.3.0 update, the synced
scripts/codex-review.sh failed pre-push shellcheck:

  scripts/codex-review.sh:1709 SC2120 (warning): parse_primary_provider
  references arguments, but none are ever passed.

The function is intentionally designed to take an optional argument
(`local stderr_file="${1:-$REVIEW_STDERR_FILE}"` — file path can be
overridden, defaults to the global). Add an inline disable so the
intent is preserved across shellcheck versions.

Why touchstone's own validate didn't catch this:
- Touchstone tests with /opt/homebrew/bin/shellcheck (system, v0.11.0).
- Downstream projects use shellcheck-py v0.10.0.1 (pinned in
  templates/pre-commit-config.yaml), which wraps shellcheck v0.10.0.
- SC2120's default severity differs between the two versions:
  v0.10 emits it at --severity=warning, v0.11 emits it lower.
- Touchstone's own .pre-commit-config.yaml does not include shellcheck
  at all, so this never fires here.

Net: synced scripts can pass touchstone's tests but fail downstream's.
The inline disable is robust to either version. The deeper fix —
making touchstone test with the same shellcheck-py version downstream
projects use — deserves its own PR with proper drift coverage.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
