### PR TITLE
chore(pre-commit): run shellcheck-py 0.11.0.1 on touchstone itself

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,21 @@ repos:
         args: ['--branch', 'main', '--branch', 'master']
         stages: [pre-commit]
 
+  # Run the same shellcheck-py the downstream `templates/pre-commit-config.yaml`
+  # pins, so any warning that would block a fresh scaffold's first push also
+  # blocks ours. This closes the gap that bit us when sentinel's
+  # `touchstone update --ship` hit SC2120 in a script touchstone had just
+  # synced — touchstone's own tests use system shellcheck (a different
+  # version) and silently passed. completions/ and prototypes/ aren't shipped
+  # to downstream, so they're excluded from this hook (zsh syntax, prototype
+  # color constants).
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck
+        args: ['--severity=warning']
+        exclude: ^(completions/|prototypes/)
+
   # Codex review for direct pushes to the default branch
   - repo: local
     hooks:

--- a/templates/pre-commit-config.yaml
+++ b/templates/pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
 
   # ── Shell script quality ───────────────────────────────────────────────
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.10.0.1
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
         args: ['--severity=warning']


### PR DESCRIPTION
Sentinel's `touchstone update --ship` was blocked today by SC2120 in
scripts/codex-review.sh — a warning that touchstone's own validate had
silently passed. Root cause: tooling-version drift.

- tests/test-shellcheck.sh runs the system shellcheck (currently 0.11.0).
- Downstream projects pin shellcheck-py 0.10.0.1 in their bootstrapped
  .pre-commit-config.yaml. SC2120 is a default warning in 0.10 but
  not in 0.11.
- Touchstone's own .pre-commit-config.yaml had NO shellcheck hook at all.
  So the exact lint downstream runs on every push never fired here.

Two changes:

1. templates/pre-commit-config.yaml: bump shellcheck-py from v0.10.0.1
   to v0.11.0.1. New projects align with the system shellcheck (matches
   the brew default), and bug fixes between the two versions flow.

2. .pre-commit-config.yaml (touchstone's own): add the same shellcheck-py
   v0.11.0.1 hook with --severity=warning. Touchstone's pre-push will
   now run the *exact same* shell linter downstream projects do, so any
   warning that would block a fresh scaffold's first push also blocks
   ours. exclude=^(completions/|prototypes/) — completions/touchstone.zsh
   uses zsh-only syntax that bash shellcheck flags spuriously, and
   prototypes/ui-banners.sh has SC2034 on intentionally-unused color
   constants. Neither is shipped to downstream, so neither is in scope.

tests/test-shellcheck.sh is intentionally left alone: it uses a different
shellcheck (system 0.11.0 directly, no pre-commit env), giving us
defense-in-depth across two versions. Both must pass before ship.

Verified: pre-commit run --all-files shellcheck passes; all 17
tests/test-*.sh (minus the flaky perf budget) pass.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
