### PR TITLE
fix(init): guard empty-array expansions for bash 3.2

### DIFF
--- a/bin/touchstone
+++ b/bin/touchstone
@@ -232,14 +232,14 @@ cmd_init() {
       # injecting the imports here would dirty it before update runs.
       # After the update completes (project moves to `current` state),
       # the user can re-run `touchstone init` to migrate CLAUDE.md.
-      exec bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh" "${update_args[@]}"
+      exec bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh" ${update_args[@]+"${update_args[@]}"}
       ;;
   esac
 
   # Fresh init: greet with the branded hero so setup feels like setup.
   tk_hero "setting up this project"
 
-  bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$project_dir" "${args[@]}"
+  bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$project_dir" ${args[@]+"${args[@]}"}
 
   # Connect CLAUDE.md (or record that we already are). new-project.sh's
   # template copy plants the imports on a fresh init, so this normally

--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -1562,7 +1562,7 @@ if [ -n "$INPUT_NAME" ] || [ -n "$INPUT_DESC" ] || [ -n "$INPUT_TEST" ] || [ -n 
     unsafe_paths_input=()
     local_unsafe_paths=()
     IFS=',' read -r -a unsafe_paths_input <<< "$INPUT_UNSAFE"
-    for unsafe_path in "${unsafe_paths_input[@]}"; do
+    for unsafe_path in "${unsafe_paths_input[@]}"; do  # empty-array-guard: safe — populated by IFS-split of non-empty INPUT_UNSAFE
       unsafe_path="$(trim "$unsafe_path")"
       [ -z "$unsafe_path" ] && continue
       local_unsafe_paths+=("$unsafe_path")

--- a/bootstrap/review.sh
+++ b/bootstrap/review.sh
@@ -277,4 +277,4 @@ if [ -z "$json_flag" ]; then
 fi
 
 # Hand off to conductor for the actual routing decision + cost estimate.
-exec conductor route "${args[@]}"
+exec conductor route ${args[@]+"${args[@]}"}

--- a/bootstrap/update-project.sh
+++ b/bootstrap/update-project.sh
@@ -173,7 +173,7 @@ rollback_failed_update() {
   restore_touchstone_metadata
 
   local rel
-  for rel in "${ADDED_PATHS[@]}"; do
+  for rel in ${ADDED_PATHS[@]+"${ADDED_PATHS[@]}"}; do
     rm -f "$PROJECT_DIR/$rel" 2>/dev/null || true
   done
 

--- a/feedback/2026-04-27-init-empty-args-bash3.md
+++ b/feedback/2026-04-27-init-empty-args-bash3.md
@@ -1,0 +1,151 @@
+# Bug: `touchstone init` (no flags) fails with `args[@]: unbound variable` on macOS bash 3.2
+
+**From:** Claude Code (Opus 4.7), end-to-end install of touchstone + cortex into a fresh repo
+**Touchstone version:** 2.3.1 (brew, `autumngarage/touchstone`)
+**Platform:** macOS 26 (Darwin 25.4.0, arm64), system bash `GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)`
+**Date:** 2026-04-27
+**Severity:** High — affects every fresh `touchstone init` on stock macOS when the user passes no flags. This is the documented "Get started" command in the brew caveats.
+
+---
+
+## Summary
+
+Running `touchstone init` with no arguments in a fresh repo aborts before scaffolding any files:
+
+```
+==> touchstone v2.3.1 — setting up this project
+/opt/homebrew/bin/touchstone: line 242: args[@]: unbound variable
+```
+
+Exit code is non-zero; nothing is written. The brewed binary's "Start in a repo: `touchstone init`" caveat is therefore broken out of the box on every macOS install whose default shell is the system bash 3.2.
+
+The bug is latent — has been present since `ae9340b Add toolkit init for existing projects` (2026-04-09) — and shipped through every release since. It went unnoticed because **no test invokes `touchstone init` with zero flags**; every test passes at least one flag (`--help`, `--no-register`, `--no-setup`, etc.) which incidentally populates the `args` array and bypasses the empty-array expansion.
+
+## Repro
+
+```bash
+mkdir -p /tmp/tsbug && cd /tmp/tsbug && git init -q
+touchstone init
+# → /opt/homebrew/bin/touchstone: line 242: args[@]: unbound variable
+echo $?
+# → 1
+```
+
+Or in isolation, the underlying bash quirk:
+
+```bash
+/bin/bash -c 'set -euo pipefail; foo=(); echo "${foo[@]}"'
+# → /bin/bash: foo[@]: unbound variable
+```
+
+## Root cause
+
+`bin/touchstone` runs under `set -euo pipefail` (line 24). `cmd_init` declares an array of forwarded flags at line 98:
+
+```bash
+local args=()
+```
+
+…populates it conditionally via the flag-parsing loop, then expands it unconditionally at line 242:
+
+```bash
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$project_dir" "${args[@]}"
+```
+
+Bash 3.2 (the macOS system bash, frozen at 3.2.57 since 2007 for licensing reasons) treats `"${arr[@]}"` on an empty array as referencing an unset variable when `set -u` is active. Bash 4.4+ fixes this; macOS will not ship 4.x. So the expansion blows up the moment `args` is empty — i.e., whenever the user passes none of the flags that `cmd_init` recognizes.
+
+Confirmed by inspection: every test that exercises `cmd_init` in `tests/test-bootstrap.sh` and `tests/test-claude-md-principles-ref.sh` passes at least one flag, which is why CI is green.
+
+## The same pattern exists at line 235
+
+```bash
+exec bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh" "${update_args[@]}"
+```
+
+`update_args` is also declared `local update_args=()` (line 222) and expanded with the same shape. It happens not to fire today because the `case` arm that reaches line 235 only runs in the `outdated` init-state branch, and that branch's flag-parsing loop populates `update_args` for at least the `--ship`/`--no-ship` decision. But it's the same hazard one refactor away from biting again. Worth fixing both expansions in the same patch.
+
+The for-loops elsewhere in `bin/touchstone` (`for entry in "${entries[@]}"`, etc.) and in `bootstrap/new-project.sh` are also potential sites — but most of them iterate over arrays that are populated unconditionally, so they don't fire under realistic inputs. The two `bash …/foo.sh "${args[@]}"` exec sites are the load-bearing ones.
+
+## Fix
+
+Standard idiom for bash 3.2-safe empty-array expansion:
+
+```bash
+"${args[@]+"${args[@]}"}"
+```
+
+— "expand `args[@]` only if it is set." Equivalent under bash 4+ and safe under bash 3.2 with `set -u`.
+
+Suggested patch (illustrative — review for repo style):
+
+```diff
+--- a/bin/touchstone
++++ b/bin/touchstone
+@@ -232,7 +232,7 @@ cmd_init() {
+       # … (preserved comment block)
+-      exec bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh" "${update_args[@]}"
++      exec bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh" ${update_args[@]+"${update_args[@]}"}
+       ;;
+   esac
+
+   # Fresh init: greet with the branded hero so setup feels like setup.
+   tk_hero "setting up this project"
+
+-  bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$project_dir" "${args[@]}"
++  bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$project_dir" ${args[@]+"${args[@]}"}
+```
+
+Three alternatives considered and rejected:
+
+1. **Bump shebang to `bash` ≥ 4 (e.g. `#!/usr/bin/env bash` requiring Homebrew bash).** Adds a hard dependency on `brew install bash` for every user, and the brew caveats already invoke `touchstone init` from the system bash environment. The whole point of `#!/usr/bin/env bash` is to let stock macOS work.
+2. **Drop `set -u`.** Loses real safety elsewhere in the script. The existing principle ("No silent failures") cuts the other way — keep `set -u`, fix the expansion.
+3. **Always seed `args` with a sentinel.** Possible (e.g. always pass `--ship` to `new-project.sh` if `ship_upgrade=true`), but couples the fix to a side effect and doesn't help line 235's case.
+
+The `${arr[@]+"${arr[@]}"}` idiom is the one-line, behavior-preserving fix.
+
+## Regression test
+
+Add to `tests/test-bootstrap.sh` — exercises the path no existing test covers:
+
+```bash
+# touchstone init with no flags must succeed (regression: bash 3.2 empty-array
+# expansion under `set -u` aborts at "${args[@]}" if not guarded).
+PROJECT_INIT_BARE="$TEST_DIR/init-bare"
+mkdir -p "$PROJECT_INIT_BARE"
+git -C "$PROJECT_INIT_BARE" init >/dev/null
+if (cd "$PROJECT_INIT_BARE" && \
+    TOUCHSTONE_NO_AUTO_UPDATE=1 \
+    "$TOUCHSTONE_ROOT/bin/touchstone" init --no-register --no-setup --no-ship \
+   ) >"$TEST_DIR/touchstone-init-bare.txt" 2>&1; then
+  assert_contains "$TEST_DIR/touchstone-init-bare.txt" 'touchstone bootstrapped'
+else
+  echo "FAIL: bare 'touchstone init' must succeed (bash 3.2 empty-args regression)" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+```
+
+(Note: even `--no-register --no-setup --no-ship` populates `args` indirectly — the *truly* bare invocation depends on `args` staying empty. The cleanest regression test is a wrapper that runs `cmd_init` after parsing zero flags. Acceptable shortcut: shell out to `bash -c 'set -u; source bin/touchstone; cmd_init'` in a temp repo. Pick whichever fits the test harness style.)
+
+Belt-and-braces: a `tests/test-shellcheck.sh` rule that flags any unguarded `"${arr[@]}"` expansion under `set -u` would catch the next instance proactively. ShellCheck SC2086/SC2068 don't quite cover this; a bespoke grep-based check inside `test-shellcheck.sh` is probably the right shape.
+
+## Workaround for users hitting this today
+
+Pass any flag that `cmd_init` recognizes — they all populate `args` and dodge the expansion. The most innocuous:
+
+```bash
+touchstone init --type swift     # or --type python / --type node / --type generic
+```
+
+This is what I used to get past it on the repo I was bootstrapping (a SwiftUI Xcode project at `~/repos/NavExplo`). The init then succeeded normally and scaffolded all 23 files, registered the project, etc.
+
+## Why this matters
+
+`touchstone init` is the **first command** every user runs in a brewed install — it's printed verbatim in the brew caveats. A first-run failure with a bash internals error message is exactly the kind of friction that makes someone give up on a tool before they've used it. The fix is a one-line idiom; the regression test is six lines. Worth shipping as a 2.3.2 patch.
+
+## Suggested release
+
+- `fix(init): guard empty-array expansion for bash 3.2 (`${args[@]+"${args[@]}"}` idiom)`
+- Add the no-flag init regression test
+- Bump `VERSION` to 2.3.2 and ship through the standard release flow (the homebrew-bump workflow auto-bumps the tap)
+
+Happy to follow up with a PR if useful.

--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -1045,7 +1045,7 @@ resolve_assist_reviewer() {
   ASSIST_REVIEWER=""
   ASSIST_REVIEWER_STATUS=""
 
-  for helper in "${ASSIST_HELPERS[@]}"; do
+  for helper in ${ASSIST_HELPERS[@]+"${ASSIST_HELPERS[@]}"}; do
     if [ "$helper" = "$ACTIVE_REVIEWER" ]; then
       ASSIST_REVIEWER_STATUS="${ASSIST_REVIEWER_STATUS}    ${helper}: skipped primary reviewer\n"
       continue

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -1045,7 +1045,7 @@ resolve_assist_reviewer() {
   ASSIST_REVIEWER=""
   ASSIST_REVIEWER_STATUS=""
 
-  for helper in "${ASSIST_HELPERS[@]}"; do
+  for helper in ${ASSIST_HELPERS[@]+"${ASSIST_HELPERS[@]}"}; do
     if [ "$helper" = "$ACTIVE_REVIEWER" ]; then
       ASSIST_REVIEWER_STATUS="${ASSIST_REVIEWER_STATUS}    ${helper}: skipped primary reviewer\n"
       continue

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -1440,6 +1440,34 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
+# ---------------------------------------------------------------------------
+# Regression: bash 3.2 empty-array expansion guard.
+# Under bash 3.2 (macOS /bin/bash), "${arr[@]}" aborts with "unbound variable"
+# when arr=() is empty and set -u is active. bin/touchstone declares args=()
+# and expands it (unguarded) when touchstone init is run with no flags that
+# populate args. This test must FAIL on the unpatched code and PASS on the fix.
+# See: fix/init-empty-args-bash3
+# ---------------------------------------------------------------------------
+PROJECT_INIT_ZERO_ARGS="$TEST_DIR/test-project-init-zero-args"
+mkdir -p "$PROJECT_INIT_ZERO_ARGS"
+git -C "$PROJECT_INIT_ZERO_ARGS" init >/dev/null
+# Redirect HOME so ~/.touchstone-projects is written to a temp location that
+# gets cleaned up with $TEST_DIR, not the user's actual home directory.
+ZERO_ARGS_FAKE_HOME="$TEST_DIR/zero-args-fake-home"
+mkdir -p "$ZERO_ARGS_FAKE_HOME"
+# --no-setup skips running setup.sh but does NOT populate args[] — exactly
+# the zero-args path that triggered the bug. HOOKS_FAKE_BIN stubs pre-commit.
+if (cd "$PROJECT_INIT_ZERO_ARGS" && HOME="$ZERO_ARGS_FAKE_HOME" PATH="$HOOKS_FAKE_BIN:$PATH" \
+    TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" init --no-setup \
+    </dev/null) >"$TEST_DIR/init-zero-args.txt" 2>&1; then
+  assert_contains "$TEST_DIR/init-zero-args.txt" 'setting up this project'
+else
+  echo "FAIL: touchstone init --no-setup (zero args[] to new-project.sh) exited nonzero" >&2
+  echo "      This detects the bash 3.2 empty-array expansion bug at bin/touchstone:242." >&2
+  echo "      Output: $(cat "$TEST_DIR/init-zero-args.txt")" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
 # Any non-5 pytest failure must still propagate — we haven't accidentally swallowed real errors.
 cat > "$PYTEST_FAKE_BIN/python3" <<'FAKEPY'
 #!/usr/bin/env bash

--- a/tests/test-empty-array-guard.sh
+++ b/tests/test-empty-array-guard.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# tests/test-empty-array-guard.sh — guard against the bash 3.2 empty-array bug.
+#
+# Under bash 3.2 (macOS /bin/bash), "${arr[@]}" aborts with "arr[@]: unbound
+# variable" when arr is empty and set -u is active. Bash 4.4+ treats it as an
+# empty expansion. The safe idiom for both versions is:
+#
+#   ${arr[@]+"${arr[@]}"}
+#
+# This test heuristically scans every shell script Touchstone ships for the
+# unsafe pattern: a name declared as =() somewhere in the same file and later
+# expanded as "${name[@]}" without the guard. False positives are possible
+# (e.g., array always populated before expansion); silence them with a
+# trailing inline comment:  # empty-array-guard: safe — <reason>
+#
+# The check is intentionally heuristic — not a full dataflow analysis — so it
+# may miss cross-file bugs. The goal is to catch the next "local foo=(); ...
+# ${foo[@]}" pattern before it ships.
+#
+set -euo pipefail
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+ERRORS=0
+FILES_CHECKED=0
+
+check_file() {
+  local file="$1"
+  local found_error=false
+
+  # Collect array names declared as =() in this file.
+  local declared_arrays=()
+  while IFS= read -r line; do
+    # Match: optional whitespace, optional "local ", name=()
+    name="$(printf '%s' "$line" | sed 's/^[[:space:]]*//' | sed 's/^local[[:space:]][[:space:]]*//' | sed 's/=().*//')"
+    # Ignore if name contains spaces or special chars (not a variable name).
+    case "$name" in
+      *[[:space:]]*|*[!a-zA-Z0-9_]*) continue ;;
+    esac
+    declared_arrays+=("$name")
+  done < <(grep -E '^\s*(local\s+)?[a-zA-Z_][a-zA-Z0-9_]*=\(\)' "$file" 2>/dev/null || true)
+
+  if [ "${#declared_arrays[@]}" -eq 0 ]; then
+    return 0
+  fi
+
+  # For each declared array, look for unguarded expansion in the same file.
+  local name
+  for name in ${declared_arrays[@]+"${declared_arrays[@]}"}; do
+    # Look for "${name[@]}" — unguarded expansion (fixed-string search avoids
+    # bracket-class ambiguity in ERE when name contains no special chars).
+    if grep -Fn '"${'"$name"'[@]}"' "$file" 2>/dev/null | \
+         grep -v 'empty-array-guard: safe' >/dev/null 2>&1; then
+      # Treat the expansion as guarded if the file uses any of:
+      #   ${name[@]+"${name[@]}"}  — the direct bash 3.2 idiom
+      #   ${#name[@]}              — a length check guards the expansion site
+      if ! grep -qF '${'"$name"'[@]+' "$file" 2>/dev/null && \
+         ! grep -qF '${#'"$name"'[@]}' "$file" 2>/dev/null; then
+        echo "  WARN: $file: '${name}' declared =() but expanded as \"\${${name}[@]}\" without guard" >&2
+        echo "        Use: \${${name}[@]+\"\${${name}[@]}\"}" >&2
+        grep -Fn '"${'"$name"'[@]}"' "$file" 2>/dev/null | head -5 >&2 || true
+        found_error=true
+      fi
+    fi
+  done
+
+  if [ "$found_error" = true ]; then
+    ERRORS=$((ERRORS + 1))
+  fi
+}
+
+# Scan all shell scripts Touchstone ships or uses.
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+  check_file "$file"
+  FILES_CHECKED=$((FILES_CHECKED + 1))
+done < <(
+  find \
+    "$TOUCHSTONE_ROOT/bin" \
+    "$TOUCHSTONE_ROOT/hooks" \
+    "$TOUCHSTONE_ROOT/scripts" \
+    "$TOUCHSTONE_ROOT/bootstrap" \
+    "$TOUCHSTONE_ROOT/lib" \
+    "$TOUCHSTONE_ROOT/tests" \
+    -maxdepth 1 -type f \( -name '*.sh' -o -name 'touchstone' \) -print 2>/dev/null | sort
+)
+
+echo "==> Test: empty-array guard check on $FILES_CHECKED shell scripts"
+
+if [ "$ERRORS" -gt 0 ]; then
+  echo "" >&2
+  echo "FAIL: $ERRORS file(s) have unguarded empty-array expansions." >&2
+  echo "      These abort under bash 3.2 + set -u (macOS /bin/bash)." >&2
+  echo "      Replace \"\${name[@]}\" with \${name[@]+\"\${name[@]}\"}" >&2
+  echo "      or add '# empty-array-guard: safe — <reason>' to suppress." >&2
+  exit 1
+fi
+
+echo "==> PASS: no unguarded empty-array expansions found"

--- a/tests/test-shellcheck.sh
+++ b/tests/test-shellcheck.sh
@@ -39,11 +39,12 @@ done < <(
     "$TOUCHSTONE_ROOT/bootstrap" \
     "$TOUCHSTONE_ROOT/lib" \
     "$TOUCHSTONE_ROOT/tests" \
-    -maxdepth 1 -type f -name '*.sh' -print 2>/dev/null | sort
+    -maxdepth 1 -type f -name '*.sh' -print 2>/dev/null | sort;
+  find "$TOUCHSTONE_ROOT/bin" -maxdepth 1 -type f -print 2>/dev/null | sort
 )
 
 if [ "${#SCRIPTS[@]}" -eq 0 ]; then
-  echo "FAIL: no shell scripts found under hooks/, scripts/, bootstrap/, lib/, tests/" >&2
+  echo "FAIL: no shell scripts found under bin/, hooks/, scripts/, bootstrap/, lib/, tests/" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

`touchstone init` (the documented brew first-run command) was broken on every fresh macOS install whose user passed no flags — aborting with `args[@]: unbound variable` on macOS system bash 3.2.57. CI ran on Linux bash 4+, where the idiom is safe, so the suite stayed green even though the documented first-run path was broken.

This PR replaces unguarded `"${arr[@]}"` expansions with the bash 3.2-safe idiom `${arr[@]+"${arr[@]}"}` at the load-bearing sites, audits the class across the codebase, and adds a guardrail to catch the next instance.

## Changes

**Production fixes (6 sites across 6 files):**
- `bin/touchstone:235` — `update_args` exec to `update-project.sh`
- `bin/touchstone:242` — `args` exec to `new-project.sh`
- `bootstrap/review.sh:280` — `args` exec to `conductor route`
- `bootstrap/update-project.sh:176` — `ADDED_PATHS` rollback loop
- `hooks/codex-review.sh:1048` + `scripts/codex-review.sh:1048` — `ASSIST_HELPERS` for-loop (was always empty in v2.0; would have aborted any time assist-mode was triggered)

**Audit:** 17 declaration sites scanned across `bin/`, `bootstrap/`, `hooks/`, `scripts/`, `lib/`, `tests/`. Six fixed, ten left alone (length-checked or unconditionally populated), one annotated with a suppression comment.

**Tests + guardrails:**
- New regression in `tests/test-bootstrap.sh` (`PROJECT_INIT_ZERO_ARGS`) — zero-args path through `cmd_init` with HOME redirect. Fails on unpatched code, passes after fix.
- New `tests/test-empty-array-guard.sh` — heuristic scanner that flags the unsafe pattern in any shipped shell script. Suppress false positives with a trailing `# empty-array-guard: safe — <reason>` comment.
- `tests/test-shellcheck.sh` now scans `bin/` (it didn't before, which is part of how this snuck through).

Per `principles/engineering-principles.md` "Audit weak-point classes": one structural bug → audit the class + add a guardrail.

## Test plan

- [x] `tests/test-bootstrap.sh` passes on macOS bash 3.2 (was failing pre-fix at the `init --no-setup --no-ship` outdated case)
- [x] New regression test fails on unpatched code, passes on patched code
- [x] `tests/test-empty-array-guard.sh` passes (no false positives in current codebase)
- [x] `tests/test-shellcheck.sh` passes with `bin/` included
- [x] Full test suite: 16/19 pass; the 3 flakes are LLM-judgment guidance/skill probes unrelated to this change

## Source

`feedback/2026-04-27-init-empty-args-bash3.md` — original bug report from a Claude Code session that hit this on a fresh macOS bootstrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)