### PR TITLE
[codex] steer codex with agents guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,11 @@
-# AGENTS.md — AI Reviewer Guide for Touchstone
+# Touchstone — AI Agent Instructions
+
+This file steers Codex and other AGENTS.md-native coding agents. Claude Code also reads `CLAUDE.md`; keep the two files aligned when project-level workflow changes. When you are coding, follow the authoring guidance first. When you are explicitly reviewing a PR or running the AI review hook, use the review guide below.
 
 <!-- touchstone:shared-principles:start -->
 ## Shared Engineering Principles (apply these first)
 
-These principles are touchstone-owned and shared across every project. Apply them as the **primary review criteria** before any project-specific rule below — a reviewer that lets a band-aid or a silent failure through has missed the point of this gate.
+These principles are touchstone-owned and shared across every project. Apply them as the **primary coding and review criteria** before any project-specific rule below — an agent that lets a band-aid or a silent failure through has missed the point of this gate.
 
 - **No band-aids** — fix the root cause; if patching a symptom, say so explicitly and name the root cause.
 - **Keep interfaces narrow** — expose the smallest stable contract; don't leak storage shape, vendor SDKs, or workflow sequencing.
@@ -26,9 +28,37 @@ Full rationale, worked examples, and the *why* behind each rule:
 - `principles/documentation-ownership.md`
 - `principles/git-workflow.md`
 
-This block is managed by `touchstone` and refreshes on `touchstone update` / `touchstone init`. Edit content **outside** the markers to add project-specific reviewer guidance — touchstone will not touch it.
+This block is managed by `touchstone` and refreshes on `touchstone update` / `touchstone init`. Edit content **outside** the markers to add project-specific agent guidance — touchstone will not touch it.
 <!-- touchstone:shared-principles:end -->
 
+## Authoring Guide
+
+You are maintaining a shared engineering platform that provides universal principles, reusable scripts, and a Conductor-backed AI merge/default-branch review hook for Henry's projects. Changes here propagate to downstream projects via `sync-all.sh`, so treat fixes here as platform changes, not isolated repo edits.
+
+### Git Workflow
+
+- Start each code change from a feature branch. Before editing tracked files, run `git branch --show-current`; if it reports `main` or `master`, branch with `git checkout -b <type>/<short-description>`.
+- Keep changes logically grouped. Stage explicit file paths, commit with a concise message, and avoid unrelated refactors.
+- To ship a completed branch, use `bash scripts/open-pr.sh --auto-merge`; it pushes, creates the PR, runs AI review, squash-merges, and syncs the default branch.
+
+### Touchstone-Specific Rules
+
+- Files in `principles/`, `hooks/`, and `scripts/` are touchstone-owned and copied into downstream projects by `update-project.sh`.
+- Files in `templates/` are copied once at bootstrap time and then project-owned; template changes affect new projects only.
+- `bootstrap/new-project.sh`, `bootstrap/update-project.sh`, and `hooks/codex-review.sh` are high-risk. Preserve backup, clean-worktree, branch/commit, skip, and fail-open behavior.
+- All shell must stay portable to macOS with standard tools: `bash`, `git`, `gh`, `sed`, and `awk`.
+
+### Testing
+
+Before pushing, run:
+
+```bash
+for test in tests/test-*.sh; do bash "$test"; done
+```
+
+For focused bootstrap/update changes, at minimum run `bash tests/test-bootstrap.sh` and `bash tests/test-update.sh`, then run the broader suite before shipping.
+
+## Review Guide
 
 You are reviewing pull requests for the **touchstone** repo — a shared engineering platform whose files propagate to all downstream projects. A bug here becomes a bug everywhere.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@
 
 You are maintaining a shared engineering platform that provides universal principles, reusable scripts, and a Codex merge/default-branch review hook for all of Henry's projects. Changes here propagate to every downstream project via `sync-all.sh`. Quality matters doubly: a bug in Touchstone is a bug in every project that uses it.
 
+Codex and other AGENTS.md-native tools read `AGENTS.md`. Keep `CLAUDE.md` and `AGENTS.md` aligned when Touchstone workflow, architecture, or hard-won lessons change.
+
 ## Engineering Principles (HARD REQUIREMENTS)
 
 Non-negotiable. Every code change is reviewed against them. Full rationale, worked examples, and the *why* behind each rule live in `principles/engineering-principles.md` — read it once; this list is the daily reminder.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ cd ~/Repos/my-new-project
 bash setup.sh
 ```
 
-Then open `CLAUDE.md` and `AGENTS.md` in your editor and fill in the placeholders. These files tell AI coding tools what your project is, what matters, and what to be careful with.
+Then open `CLAUDE.md` and `AGENTS.md` in your editor and fill in the placeholders. `CLAUDE.md` steers Claude Code. `AGENTS.md` steers Codex and other AGENTS.md-native tools, and also contains the AI review rubric.
 
 ### Add touchstone to an existing project
 
@@ -165,8 +165,8 @@ bash setup.sh --deps-only
 When you run `touchstone new`, these files get created in your project:
 
 **Project-owned** (yours to customize, never auto-updated):
-- `CLAUDE.md` — AI coding instructions with `{{PLACEHOLDERS}}` to fill in
-- `AGENTS.md` — AI reviewer rubric with project-specific priorities
+- `CLAUDE.md` — Claude Code instructions with `{{PLACEHOLDERS}}` to fill in
+- `AGENTS.md` — Codex/agent instructions plus the AI review rubric with project-specific priorities
 - `.codex-review.toml` — AI review hook config (reviewers, modes, safe/unsafe paths)
 - `.touchstone-config` — Project profile, workflow choices, and optional lint/test/build command overrides
 - `.pre-commit-config.yaml` — Pre-commit hooks including the default-branch AI review gate
@@ -235,7 +235,7 @@ Automatically reviews code before it reaches the default branch. In Touchstone 2
 - Runs from `scripts/merge-pr.sh`, and from the pre-push hook only when pushing directly to the default branch
 - Loops up to N times, gracefully skips when Conductor is not installed
 
-Configure per-project behavior in `.codex-review.toml`. Write your review rubric in `AGENTS.md`. See [hooks/README.md](hooks/README.md) for reviewer modes, caching, and fail-open behavior. Peer review returns in 2.1 via `conductor call --exclude <primary>`.
+Configure per-project behavior in `.codex-review.toml`. Write your coding-agent guidance and review rubric in `AGENTS.md`. See [hooks/README.md](hooks/README.md) for reviewer modes, caching, and fail-open behavior. Peer review returns in 2.1 via `conductor call --exclude <primary>`.
 
 ### Claude Code Skills
 

--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -20,6 +20,7 @@
 #   6. Prints next steps
 #
 # After running, fill in the {{PLACEHOLDERS}} in CLAUDE.md and AGENTS.md.
+# CLAUDE.md steers Claude Code; AGENTS.md steers Codex and other agents.
 #
 set -euo pipefail
 
@@ -1886,6 +1887,7 @@ if [ "$HOOK_INSTALL_STATUS" -eq 2 ]; then
 fi
 if [ "$RE_INIT" = false ]; then
   printf '  %d. Fill in CLAUDE.md and AGENTS.md (architecture, key files, hard-won lessons)\n' "$STEP_NUM"
+  printf '     CLAUDE.md steers Claude Code; AGENTS.md steers Codex and the review rubric.\n'
   STEP_NUM=$((STEP_NUM + 1))
 fi
 printf '  %d. Install dev tools and project deps: cd %s && bash setup.sh\n' "$STEP_NUM" "$PROJECT_DIR"

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -49,7 +49,7 @@ tags   = "code-review"
 
 ### 5. Write your review rubric
 
-Fill in `AGENTS.md` at the repo root with your project-specific review priorities. The hook tells the reviewer to read this file as the rubric. See `templates/AGENTS.md` for the skeleton.
+Fill in `AGENTS.md` at the repo root with your project-specific coding-agent guidance and review priorities. The hook tells the reviewer to use the Review Guide section as the rubric. See `templates/AGENTS.md` for the skeleton.
 
 ## How it works
 
@@ -57,7 +57,7 @@ When the review runs, the hook:
 
 1. Computes the diff between your branch and the default branch
 2. Skips review if the exact same diff and review inputs already passed cleanly (cache key includes the Conductor knobs, so changing `prefer`/`effort`/`with` invalidates)
-3. Invokes Conductor with the review prompt + AGENTS.md rubric, the requested tool set, and the requested sandbox
+3. Invokes Conductor with the review prompt + AGENTS.md review guide, the requested tool set, and the requested sandbox
 4. Reads one of three sentinels from the reviewer's output:
    - `CODEX_REVIEW_CLEAN` — no issues, push proceeds
    - `CODEX_REVIEW_FIXED` — the reviewer applied auto-fixes; the hook commits them and re-reviews

--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -1316,8 +1316,9 @@ AUTOFIX_POLICY="$(build_autofix_policy)"
 read -r -d '' REVIEW_PROMPT <<PROMPT_EOF || true
 You are reviewing AND optionally auto-fixing a pull request before it reaches the default branch.
 
-Read AGENTS.md at the repo root for the full review rubric (if it exists).
-Read CLAUDE.md at the repo root for project context (if it exists).
+Read AGENTS.md at the repo root for project context and the review rubric (if it exists).
+If AGENTS.md has both authoring guidance and a review guide, use the review guide for findings.
+Read CLAUDE.md at the repo root for additional Claude-specific project context (if it exists).
 
 Do NOT flag: formatting, style, naming, missing docstrings, speculative refactors, "you could consider" observations without a concrete bug.
 
@@ -1555,8 +1556,9 @@ You are a peer reviewer giving a focused second opinion before a push.
 Do not edit files. Do not stage, commit, or modify anything. You are advisory only.
 Answer the primary reviewer concisely and directly. Do not emit CODEX_REVIEW_CLEAN, CODEX_REVIEW_FIXED, or CODEX_REVIEW_BLOCKED.
 
-Read AGENTS.md at the repo root for the review rubric if it exists.
-Read CLAUDE.md at the repo root for project context if it exists.
+Read AGENTS.md at the repo root for project context and the review rubric if it exists.
+If AGENTS.md has both authoring guidance and a review guide, use the review guide for findings.
+Read CLAUDE.md at the repo root for additional Claude-specific project context if it exists.
 
 ## Primary reviewer
 

--- a/lib/agents-principles-block.sh
+++ b/lib/agents-principles-block.sh
@@ -5,15 +5,12 @@
 #
 # Why this exists:
 #   AGENTS.md is project-owned: copied once at bootstrap and then maintained by
-#   the project's authors. CLAUDE.md imports the principles via @principles/...
-#   so every Claude Code session loads them. AGENTS.md historically did not —
-#   so a Codex / Gemini / non-Claude reviewer running on a touchstone repo had
-#   no exposure to the engineering principles. That's a silent failure of the
-#   merge gate itself: the reviewer can't flag a band-aid if nobody told it
-#   band-aids are flag-worthy.
+#   the project's authors. Claude Code gets these principles through
+#   CLAUDE.md's @principles/... imports; Codex and other AGENTS.md-native tools
+#   need them directly in AGENTS.md. Reviewers need the same principles too.
 #
 #   This helper inserts (and refreshes) a sentinel-delimited block at the top
-#   of AGENTS.md that lists the principles in a format any reviewer can read.
+#   of AGENTS.md that lists the principles in a format any agent can read.
 #   The block is touchstone-owned; everything outside the markers is project-
 #   owned and never touched.
 #
@@ -34,7 +31,7 @@ agents_principles_block_render() {
 <!-- touchstone:shared-principles:start -->
 ## Shared Engineering Principles (apply these first)
 
-These principles are touchstone-owned and shared across every project. Apply them as the **primary review criteria** before any project-specific rule below — a reviewer that lets a band-aid or a silent failure through has missed the point of this gate.
+These principles are touchstone-owned and shared across every project. Apply them as the **primary coding and review criteria** before any project-specific rule below — an agent that lets a band-aid or a silent failure through has missed the point of this gate.
 
 - **No band-aids** — fix the root cause; if patching a symptom, say so explicitly and name the root cause.
 - **Keep interfaces narrow** — expose the smallest stable contract; don't leak storage shape, vendor SDKs, or workflow sequencing.
@@ -57,7 +54,7 @@ Full rationale, worked examples, and the *why* behind each rule:
 - `principles/documentation-ownership.md`
 - `principles/git-workflow.md`
 
-This block is managed by `touchstone` and refreshes on `touchstone update` / `touchstone init`. Edit content **outside** the markers to add project-specific reviewer guidance — touchstone will not touch it.
+This block is managed by `touchstone` and refreshes on `touchstone update` / `touchstone init`. Edit content **outside** the markers to add project-specific agent guidance — touchstone will not touch it.
 <!-- touchstone:shared-principles:end -->
 BLOCK
 }

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -1316,8 +1316,9 @@ AUTOFIX_POLICY="$(build_autofix_policy)"
 read -r -d '' REVIEW_PROMPT <<PROMPT_EOF || true
 You are reviewing AND optionally auto-fixing a pull request before it reaches the default branch.
 
-Read AGENTS.md at the repo root for the full review rubric (if it exists).
-Read CLAUDE.md at the repo root for project context (if it exists).
+Read AGENTS.md at the repo root for project context and the review rubric (if it exists).
+If AGENTS.md has both authoring guidance and a review guide, use the review guide for findings.
+Read CLAUDE.md at the repo root for additional Claude-specific project context (if it exists).
 
 Do NOT flag: formatting, style, naming, missing docstrings, speculative refactors, "you could consider" observations without a concrete bug.
 
@@ -1555,8 +1556,9 @@ You are a peer reviewer giving a focused second opinion before a push.
 Do not edit files. Do not stage, commit, or modify anything. You are advisory only.
 Answer the primary reviewer concisely and directly. Do not emit CODEX_REVIEW_CLEAN, CODEX_REVIEW_FIXED, or CODEX_REVIEW_BLOCKED.
 
-Read AGENTS.md at the repo root for the review rubric if it exists.
-Read CLAUDE.md at the repo root for project context if it exists.
+Read AGENTS.md at the repo root for project context and the review rubric if it exists.
+If AGENTS.md has both authoring guidance and a review guide, use the review guide for findings.
+Read CLAUDE.md at the repo root for additional Claude-specific project context if it exists.
 
 ## Primary reviewer
 

--- a/setup.sh
+++ b/setup.sh
@@ -99,6 +99,7 @@ info "Checking AI reviewer"
 AI_REVIEW_ENABLED=true
 AI_REVIEWERS=()
 AI_LOCAL_REVIEW_COMMAND=""
+AI_CONDUCTOR_WITH=""
 
 trim_review_value() {
   local value="$1"
@@ -127,7 +128,7 @@ load_ai_review_config() {
   local section="" line key value
 
   [ -f ".codex-review.toml" ] || {
-    AI_REVIEWERS=("codex")
+    AI_REVIEWERS=("conductor")
     return 0
   }
 
@@ -151,7 +152,12 @@ load_ai_review_config() {
     if [ "$section" = "review" ]; then
       case "$key" in
         enabled) AI_REVIEW_ENABLED="$value" ;;
+        reviewer) [ -n "$value" ] && AI_REVIEWERS+=("$value") ;;
         reviewers) add_reviewers_from_csv "${line#*=}" ;;
+      esac
+    elif [ "$section" = "review.conductor" ]; then
+      case "$key" in
+        with) AI_CONDUCTOR_WITH="$value" ;;
       esac
     elif [ "$section" = "review.local" ]; then
       case "$key" in
@@ -161,7 +167,7 @@ load_ai_review_config() {
   done < ".codex-review.toml"
 
   if [ "${#AI_REVIEWERS[@]}" -eq 0 ] && [ "$AI_REVIEW_ENABLED" != "false" ]; then
-    AI_REVIEWERS=("codex")
+    AI_REVIEWERS=("conductor")
   fi
 }
 
@@ -169,6 +175,21 @@ check_ai_reviewer() {
   local reviewer="$1"
 
   case "$reviewer" in
+    conductor)
+      if command -v conductor >/dev/null 2>&1; then
+        if conductor doctor --json 2>/dev/null | grep -q '"configured"[[:space:]]*:[[:space:]]*true'; then
+          if [ -n "$AI_CONDUCTOR_WITH" ]; then
+            ok "conductor installed and configured (pinned provider: $AI_CONDUCTOR_WITH)"
+          else
+            ok "conductor installed and configured"
+          fi
+        else
+          warn "conductor installed but no provider is configured. Run: conductor init"
+        fi
+      else
+        warn "conductor reviewer selected, but Conductor CLI is not installed. Run: brew install autumngarage/conductor/conductor && conductor init"
+      fi
+      ;;
     codex)
       if command -v codex >/dev/null 2>&1; then
         if codex login status >/dev/null 2>&1; then

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -1,13 +1,19 @@
-# AGENTS.md — AI Reviewer Guide for {{PROJECT_NAME}}
+# AGENTS.md — AI Agent Instructions for {{PROJECT_NAME}}
 
-You are reviewing pull requests for **{{PROJECT_NAME}}**. Optimize your review for catching the things that bite this repo, not generic style polish.
+This file steers Codex and other AGENTS.md-native coding agents. Claude Code also reads `CLAUDE.md`; keep the two files aligned when project-level workflow changes.
 
-This file is the source of truth for how AI reviewers (Codex, Claude, etc.) should think about a PR. The companion file `CLAUDE.md` is for the *author* writing the code; this file is for the *reviewer*.
+When coding, follow the authoring guide. When explicitly reviewing a PR or running the AI review hook, use the review guide.
+
+## Authoring Guide
+
+### Who You Are on This Project
+
+{{PROJECT_DESCRIPTION — describe the project's purpose, your role, and what "good" looks like for this codebase. Be specific about the domain.}}
 
 <!-- touchstone:shared-principles:start -->
 ## Shared Engineering Principles (apply these first)
 
-These principles are touchstone-owned and shared across every project. Apply them as the **primary review criteria** before any project-specific rule below — a reviewer that lets a band-aid or a silent failure through has missed the point of this gate.
+These principles are touchstone-owned and shared across every project. Apply them as the **primary coding and review criteria** before any project-specific rule below — an agent that lets a band-aid or a silent failure through has missed the point of this gate.
 
 - **No band-aids** — fix the root cause; if patching a symptom, say so explicitly and name the root cause.
 - **Keep interfaces narrow** — expose the smallest stable contract; don't leak storage shape, vendor SDKs, or workflow sequencing.
@@ -30,12 +36,64 @@ Full rationale, worked examples, and the *why* behind each rule:
 - `principles/documentation-ownership.md`
 - `principles/git-workflow.md`
 
-This block is managed by `touchstone` and refreshes on `touchstone update` / `touchstone init`. Edit content **outside** the markers to add project-specific reviewer guidance — touchstone will not touch it.
+This block is managed by `touchstone` and refreshes on `touchstone update` / `touchstone init`. Edit content **outside** the markers to add project-specific agent guidance — touchstone will not touch it.
 <!-- touchstone:shared-principles:end -->
+
+### Git Workflow
+
+Every change starts on a feature branch. Before editing tracked files, run `git branch --show-current`; if it reports the default branch (`main` or `master`), branch first with `git checkout -b <type>/<short-description>`.
+
+Use the normal lifecycle unless the user asks for a different flow:
+
+1. Pull/rebase the default branch.
+2. Branch before editing.
+3. Make the change, stage explicit file paths, and commit with a concise message.
+4. Ship with `bash scripts/open-pr.sh --auto-merge`.
+5. Clean up the feature branch if it still exists locally.
+
+### Testing
+
+```bash
+# Reinstall dependencies without rerunning the full machine setup
+bash setup.sh --deps-only
+
+# Before any push — uses .touchstone-config profile defaults and command overrides
+bash scripts/touchstone-run.sh validate
+```
+
+Fix failing tests before pushing.
+
+### Release & Distribution
+
+{{RELEASE_AND_DISTRIBUTION — how is this project shipped? Include the release command, package registry or deployment target, required version bump, post-release verification, and rollback path. Examples: Homebrew tap, npm package, Docker image, Vercel/Railway deploy, app store build.}}
+
+After merging release-affecting changes, verify the shipped artifact or deployed environment matches the pushed code.
+
+### Architecture
+
+{{ARCHITECTURE — describe key packages, their responsibilities, and how data flows between them. Keep it high-level.}}
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| {{key files and their purposes}} | |
+
+### State & Config
+
+{{STATE_AND_CONFIG — where does mutable state live? What's gitignored? Where's the config template?}}
+
+### Hard-Won Lessons
+
+{{HARD_WON_LESSONS — bugs that cost real time or money. Each should teach a generalizable lesson. Format: what happened, what was the root cause, what's the fix/guard now in place.}}
 
 ---
 
-## What to prioritize (in order)
+## Review Guide
+
+You are reviewing pull requests for **{{PROJECT_NAME}}**. Optimize your review for catching the things that bite this repo, not generic style polish.
+
+### What to prioritize (in order)
 
 {{PRIORITIES — list your project's review priorities in order of importance. Examples:
 
@@ -50,9 +108,9 @@ Style nits, formatting, and theoretical refactors are **out of scope** unless th
 
 ---
 
-## Specific review rules
+### Specific review rules
 
-### High-scrutiny paths
+#### High-scrutiny paths
 
 {{HIGH_SCRUTINY_PATHS — list the files/directories where mistakes are most expensive. Examples:
 
@@ -63,7 +121,7 @@ Flag any of the following:
 - (things that have gone wrong before)
 - (invariants that must hold)}}
 
-### Silent failures
+#### Silent failures
 
 Flag any of the following:
 
@@ -74,7 +132,7 @@ Flag any of the following:
 
 The rule: every exception is either re-raised or logged with enough context to debug from production logs alone.
 
-### Tests
+#### Tests
 
 - Bug fixes must include a test that reproduces the original failure mode.
 - Tests should use relative values (percentages, ratios) not absolute values where applicable.
@@ -82,7 +140,7 @@ The rule: every exception is either re-raised or logged with enough context to d
 
 ---
 
-## What NOT to flag
+### What NOT to flag
 
 - Formatting, whitespace, import order — pre-commit hooks handle these.
 - Type annotations on existing untyped code.
@@ -95,7 +153,7 @@ If you find yourself writing "consider" or "you might want to" without a concret
 
 ---
 
-## Output format
+### Output format
 
 1. **Summary** — one paragraph: what this PR does and your overall verdict (approve / request changes / comment).
 2. **Blocking issues** — bugs or risks that must be fixed before merge. Each item: file:line, what's wrong, why it matters, suggested fix.

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -4,6 +4,8 @@
 
 {{PROJECT_DESCRIPTION — describe the project's purpose, your role, and what "good" looks like for this codebase. Be specific about the domain.}}
 
+Codex and other AGENTS.md-native tools read `AGENTS.md`. Keep `CLAUDE.md` and `AGENTS.md` aligned when project workflow, architecture, or hard-won lessons change.
+
 ## Engineering Principles (HARD REQUIREMENTS)
 
 Non-negotiable. Every code change is reviewed against them. Full rationale, worked examples, and the *why* behind each rule live in `principles/engineering-principles.md` — read it once; this list is the daily reminder.

--- a/templates/setup.sh
+++ b/templates/setup.sh
@@ -173,6 +173,7 @@ AI_REVIEW_ENABLED=true
 AI_REVIEWERS=()
 AI_REVIEWERS_CHECKED=""
 AI_LOCAL_REVIEW_COMMAND=""
+AI_CONDUCTOR_WITH=""
 AI_REVIEW_ROUTING_ENABLED=false
 AI_REVIEW_ROUTING_SMALL_MAX=400
 
@@ -203,7 +204,7 @@ load_ai_review_config() {
   local section="" line key value
 
   [ -f ".codex-review.toml" ] || {
-    AI_REVIEWERS=("codex")
+    AI_REVIEWERS=("conductor")
     return 0
   }
 
@@ -227,7 +228,12 @@ load_ai_review_config() {
     if [ "$section" = "review" ]; then
       case "$key" in
         enabled) AI_REVIEW_ENABLED="$value" ;;
+        reviewer) [ -n "$value" ] && AI_REVIEWERS+=("$value") ;;
         reviewers) add_reviewers_from_csv "${line#*=}" ;;
+      esac
+    elif [ "$section" = "review.conductor" ]; then
+      case "$key" in
+        with) AI_CONDUCTOR_WITH="$value" ;;
       esac
     elif [ "$section" = "review.routing" ]; then
       case "$key" in
@@ -243,7 +249,7 @@ load_ai_review_config() {
   done < ".codex-review.toml"
 
   if [ "${#AI_REVIEWERS[@]}" -eq 0 ] && [ "$AI_REVIEW_ENABLED" != "false" ]; then
-    AI_REVIEWERS=("codex")
+    AI_REVIEWERS=("conductor")
   fi
 }
 
@@ -256,6 +262,21 @@ check_ai_reviewer() {
   AI_REVIEWERS_CHECKED="$AI_REVIEWERS_CHECKED $reviewer"
 
   case "$reviewer" in
+    conductor)
+      if command -v conductor >/dev/null 2>&1; then
+        if conductor doctor --json 2>/dev/null | grep -q '"configured"[[:space:]]*:[[:space:]]*true'; then
+          if [ -n "$AI_CONDUCTOR_WITH" ]; then
+            ok "conductor installed and configured (pinned provider: $AI_CONDUCTOR_WITH)"
+          else
+            ok "conductor installed and configured"
+          fi
+        else
+          warn "conductor installed but no provider is configured. Run: conductor init"
+        fi
+      else
+        warn "conductor reviewer selected, but Conductor CLI is not installed. Run: brew install autumngarage/conductor/conductor && conductor init"
+      fi
+      ;;
     codex)
       if command -v codex >/dev/null 2>&1; then
         if codex login status >/dev/null 2>&1; then

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -181,6 +181,9 @@ assert_contains "$PROJECT/AGENTS.md" "test-project"
 assert_contains "$PROJECT/AGENTS.md" "touchstone:shared-principles:start"
 assert_contains "$PROJECT/AGENTS.md" "touchstone:shared-principles:end"
 assert_contains "$PROJECT/AGENTS.md" "No band-aids"
+assert_contains "$PROJECT/AGENTS.md" "Authoring Guide"
+assert_contains "$PROJECT/AGENTS.md" "Codex and other AGENTS.md-native coding agents"
+assert_contains "$PROJECT/AGENTS.md" "Review Guide"
 
 # Help flags should print usage instead of bootstrapping a project named --help.
 if (cd "$TEST_DIR" && bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" --help) >"$TEST_DIR/new-project-help.txt" 2>&1; then
@@ -750,6 +753,16 @@ cat > "$SETUP_VERSION_FAKE_BIN/codex" <<'FAKECODEX'
 #!/usr/bin/env bash
 exit 0
 FAKECODEX
+cat > "$SETUP_VERSION_FAKE_BIN/conductor" <<'FAKECONDUCTOR'
+#!/usr/bin/env bash
+case "$1" in
+  doctor)
+    printf '{"configured": true}\n'
+    exit 0
+    ;;
+esac
+exit 0
+FAKECONDUCTOR
 cat > "$SETUP_VERSION_FAKE_BIN/but" <<'FAKEBUT'
 #!/usr/bin/env bash
 exit 0
@@ -762,6 +775,13 @@ assert_contains "$TEST_DIR/setup-version-output.txt" 'local reviewer configured:
 assert_contains "$TEST_DIR/setup-version-output.txt" 'GitButler selected'
 assert_contains "$TEST_DIR/setup-version-output.txt" 'but installed'
 assert_not_contains "$TEST_DIR/setup-version-output.txt" "unknown AI reviewer"
+
+SETUP_CONDUCTOR_PROJECT="$TEST_DIR/setup-conductor-project"
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$SETUP_CONDUCTOR_PROJECT" --no-register --reviewer codex >/dev/null
+(cd "$SETUP_CONDUCTOR_PROJECT" && PATH="$SETUP_VERSION_FAKE_BIN:$PATH" bash setup.sh) >"$TEST_DIR/setup-conductor-output.txt"
+assert_contains "$TEST_DIR/setup-conductor-output.txt" 'conductor installed and configured (pinned provider: codex)'
+assert_not_contains "$TEST_DIR/setup-conductor-output.txt" 'codex installed'
+assert_not_contains "$TEST_DIR/setup-conductor-output.txt" 'Installing Codex CLI'
 
 # touchstone-run.sh should provide ecosystem-neutral task dispatch.
 RUNNER_FAKE_BIN="$TEST_DIR/runner-fake-bin"


### PR DESCRIPTION
## Summary

- Make `AGENTS.md` and the project template dual-purpose: Codex/AGENTS.md-native authoring guidance first, review rubric second.
- Clarify that `CLAUDE.md` steers Claude Code and should stay aligned with `AGENTS.md`.
- Update the AI review prompt to use the `Review Guide` section when `AGENTS.md` also contains authoring guidance.
- Teach setup scripts to validate Touchstone 2.0 Conductor config instead of defaulting to direct `codex` CLI checks.

## Why

Touchstone already supported multiple review providers through Conductor, but Codex project-driving guidance was incomplete because `AGENTS.md` was only a reviewer rubric. This makes Codex understand the same project workflow Claude gets from `CLAUDE.md` without forcing a larger context-file migration.

## Validation

- `bash tests/test-agents-principles-block.sh`
- `bash tests/test-codex-review-sync.sh`
- `bash tests/test-bootstrap.sh`
- `bash tests/test-update.sh`
- `bash tests/test-shellcheck.sh`
- `bash tests/test-review-hook.sh`
- `bash tests/test-review-dry-run.sh`
- `git diff --check`

## Notes

Conductor checks confirmed Codex and Gemini can read the updated guidance. Claude direct CLI now resolves through a local shim, but the account is currently blocked by the org monthly usage limit, so the Claude prompt test could not complete.
