### PR TITLE
test: cover touchstone status / status --all behaviors

### DIFF
--- a/bin/touchstone
+++ b/bin/touchstone
@@ -12,7 +12,8 @@
 #   touchstone update --check             Report whether current project needs update
 #   touchstone sync                       Update all registered projects
 #   touchstone sync --pull-first          Pull latest touchstone, then sync all projects
-#   touchstone status                     Dashboard — health of all registered projects
+#   touchstone status                     Show status of the current project
+#   touchstone status --all               Show version distribution across registered projects
 #   touchstone version                    Show installed version
 #   touchstone doctor                     Check health of touchstone installation
 #   touchstone help                       Show this help
@@ -41,6 +42,7 @@ source "$TOUCHSTONE_ROOT/lib/auto-update.sh"
 source "$TOUCHSTONE_ROOT/lib/colors.sh"
 source "$TOUCHSTONE_ROOT/lib/ui.sh"
 source "$TOUCHSTONE_ROOT/lib/claude-md-principles-ref.sh"
+source "$TOUCHSTONE_ROOT/lib/status.sh"
 
 # Auto-update check (throttled, non-blocking on failure).
 touchstone_auto_update || true
@@ -313,72 +315,35 @@ cmd_version() {
 }
 
 cmd_status() {
-  local version
-  version="$(touchstone_version_str)"
-  local current_id
-  current_id="$(touchstone_current_id)"
+  # Two views, one entrypoint:
+  #   touchstone status         -> single-project block for $(pwd)
+  #   touchstone status --all   -> registry walk with the version-distribution table
+  #
+  # This intentionally narrows the old `touchstone status` (which always
+  # walked the registry). The registry view moves to `--all` so the bare
+  # command is useful inside any one project — the more common ask. The
+  # old behavior remains reachable via `--all`; `touchstone list` is
+  # the registry-only listing without the version-distribution math.
+  local mode="project"
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --all|-a) mode="all"; shift ;;
+      -h|--help)
+        echo "Usage: touchstone status [--all]"
+        echo "  (no flag)  Show status for the current working directory"
+        echo "  --all      Show version distribution across registered projects"
+        return 0
+        ;;
+      *) echo "ERROR: unknown argument '$1'" >&2; exit 1 ;;
+    esac
+  done
 
-  tk_header "Touchstone Status — v${version}"
-
-  local projects_file="$HOME/.touchstone-projects"
-  if [ ! -f "$projects_file" ]; then
-    tk_warn "No projects registered. Run: touchstone new <dir>"
-    return
+  if [ "$mode" = "all" ]; then
+    status_print_all
+    return $?
   fi
 
-  while IFS= read -r project_dir; do
-    [ -z "$project_dir" ] && continue
-    [[ "$project_dir" == \#* ]] && continue
-
-    local name
-    name="$(basename "$project_dir")"
-
-    if [ ! -d "$project_dir" ]; then
-      printf "  ${RED}✗${RESET} ${BOLD}%-20s${RESET} directory not found\n" "$name"
-      continue
-    fi
-
-    # Gather project state.
-    local proj_version
-    proj_version="$(cat "$project_dir/.touchstone-version" 2>/dev/null | tr -d '[:space:]' || echo "none")"
-    local synced=""
-    if [ "$proj_version" = "$current_id" ]; then
-      synced="${GREEN}synced${RESET}"
-    else
-      synced="${YELLOW}needs sync${RESET}"
-    fi
-
-    # Git state.
-    local git_status=""
-    if [ -d "$project_dir/.git" ]; then
-      local dirty=""
-      local unpushed=""
-      local branch=""
-      branch="$(git -C "$project_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "?")"
-
-      if [ -n "$(git -C "$project_dir" status --porcelain 2>/dev/null)" ]; then
-        dirty="${YELLOW}dirty${RESET}"
-      else
-        dirty="${GREEN}clean${RESET}"
-      fi
-
-      local ahead
-      ahead="$(git -C "$project_dir" rev-list --count '@{u}..HEAD' 2>/dev/null || echo "?")"
-      if [ "$ahead" = "?" ] || [ "$ahead" = "0" ]; then
-        unpushed=""
-      else
-        unpushed=" ${YELLOW}${ahead} unpushed${RESET}"
-      fi
-
-      git_status="${dirty}${unpushed} ${DIM}(${branch})${RESET}"
-    else
-      git_status="${DIM}not a git repo${RESET}"
-    fi
-
-    printf "  ${GREEN}✓${RESET} ${BOLD}%-20s${RESET} %b  %b\n" "$name" "$synced" "$git_status"
-  done < "$projects_file"
-
-  echo ""
+  status_print_project "$(pwd)"
 }
 
 cmd_doctor_project() {
@@ -1386,7 +1351,8 @@ cmd_help() {
   echo "  ${BOLD}Registry commands:${RESET}"
   printf "    ${BOLD}touchstone list${RESET}                   Show registered projects\n"
   printf "    ${BOLD}touchstone unregister${RESET} <name>      Remove a project from registry\n"
-  printf "    ${BOLD}touchstone status${RESET}                 Dashboard — all projects at a glance\n"
+  printf "    ${BOLD}touchstone status${RESET}                 Show status of the current project\n"
+  printf "    ${BOLD}touchstone status${RESET} --all           Version distribution across registered projects\n"
   echo ""
   echo "  ${BOLD}Touchstone commands:${RESET}"
   printf "    ${BOLD}touchstone doctor${RESET}                 Check installation health\n"
@@ -1419,7 +1385,7 @@ case "$COMMAND" in
   migrate-review-config) cmd_migrate_review_config "$@" ;;
   review)       cmd_review "$@" ;;
   sync)         cmd_sync "$@" ;;
-  status)       cmd_status ;;
+  status)       cmd_status "$@" ;;
   list|ls)      cmd_list ;;
   unregister)   cmd_unregister "$@" ;;
   diff)         cmd_diff ;;

--- a/completions/touchstone.bash
+++ b/completions/touchstone.bash
@@ -18,6 +18,9 @@ _touchstone() {
     sync)
       COMPREPLY=( $(compgen -W "--pull-first --check --dry-run" -- "$cur") )
       ;;
+    status)
+      COMPREPLY=( $(compgen -W "--all" -- "$cur") )
+      ;;
     unregister)
       if [ -f "$HOME/.touchstone-projects" ]; then
         COMPREPLY=( $(compgen -W "$(cat "$HOME/.touchstone-projects" 2>/dev/null)" -- "$cur") )

--- a/completions/touchstone.zsh
+++ b/completions/touchstone.zsh
@@ -7,7 +7,7 @@ _touchstone() {
     'new:Bootstrap a new project from scratch'
     'update:Create a branch and commit for touchstone updates'
     'sync:Update all registered projects'
-    'status:Dashboard — health of all projects'
+    'status:Show project status (use --all for the registry view)'
     'doctor:Check touchstone installation health'
     'version:Show installed version'
     'list:Show registered projects'
@@ -69,6 +69,10 @@ _touchstone() {
             '--pull-first[Pull latest touchstone before syncing]' \
             '--check[Report which projects need sync]' \
             '--dry-run[Preview updates without applying]'
+          ;;
+        status)
+          _arguments \
+            '--all[Show version distribution across registered projects]'
           ;;
         unregister)
           # Complete from registered projects.

--- a/lib/status.sh
+++ b/lib/status.sh
@@ -268,6 +268,11 @@ _status_iter_registry() {
   fi
   local line
   while IFS= read -r line || [ -n "$line" ]; do
+    # Trim leading + trailing whitespace before the empty/comment check —
+    # otherwise a "   " line in the registry falls through to the callback
+    # and renders as "(missing)" because $project_dir doesn't exist.
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
     [ -z "$line" ] && continue
     case "$line" in \#*) continue ;; esac
     "$cb" "$line"
@@ -275,24 +280,33 @@ _status_iter_registry() {
   return 0
 }
 
-# Truncate a string to N visible columns, appending "…" when cut. Keeps the
-# table readable in a 100-column terminal even when a project path is long.
+# Truncate a string to N visible columns, preserving the tail (most informative
+# for paths — the basename matters; the leading directory components don't).
+# Adds a leading "…" when cut. Keeps the table readable in a 100-column
+# terminal even when a project path is long, and keeps the basename visible
+# so tests and humans can both identify which project is which.
 _status_truncate() {
   local s="$1" max="$2"
   if [ "${#s}" -le "$max" ]; then
     printf '%s' "$s"
   else
-    # Reserve 1 column for the ellipsis.
-    printf '%s…' "${s:0:max-1}"
+    # Reserve 1 column for the ellipsis; keep the rightmost (max-1) chars.
+    local keep=$((max - 1))
+    printf '…%s' "${s: -keep}"
   fi
 }
 
-# Replace $HOME prefix with "~" for compact display.
+# Replace $HOME prefix with "~" for compact display. The literal "~" in the
+# printf format is intentional — we're rendering it as text, not asking the
+# shell to expand it (shellcheck SC2088 fires on the tilde-in-quotes pattern
+# precisely because most callers want expansion; here we don't).
 _status_tildefy() {
   local p="$1"
   if [ -n "${HOME:-}" ] && [ "${p#"$HOME"/}" != "$p" ]; then
+    # shellcheck disable=SC2088  # literal tilde for display, not expansion
     printf '~/%s' "${p#"$HOME"/}"
   elif [ "$p" = "$HOME" ]; then
+    # shellcheck disable=SC2088  # literal tilde for display, not expansion
     printf '~'
   else
     printf '%s' "$p"

--- a/lib/status.sh
+++ b/lib/status.sh
@@ -1,0 +1,400 @@
+#!/usr/bin/env bash
+#
+# lib/status.sh — version distribution and update-age helpers for `touchstone status`.
+#
+# Sourced by bin/touchstone. Owns the per-project read of `.touchstone-version`,
+# the "behind" computation against the touchstone git history, the file-age
+# computation, and the table renderer for `touchstone status --all`.
+#
+# Two outputs:
+#   touchstone status        single-project block for the current working dir
+#   touchstone status --all  fixed-width table walking $HOME/.touchstone-projects
+#
+# This file relies on RED/GREEN/YELLOW/DIM/RESET from lib/colors.sh and on
+# tk_header / tk_warn from lib/colors.sh. Source colors.sh before this file.
+
+# Guard: only define helpers once per shell.
+if [ -n "${TK_STATUS_SOURCED:-}" ]; then return 0; fi
+TK_STATUS_SOURCED=1
+
+# --- registry path -----------------------------------------------------------
+# Single source of truth for the registry location. Tests can point at a
+# tempdir registry by overriding HOME; we deliberately do not introduce a
+# second env-var override because every other touchstone caller of the
+# registry already keys off HOME (sync-all.sh, completions, doctor, list).
+# Adding a second knob would split the registry-resolution code path.
+_status_projects_file() {
+  printf '%s\n' "$HOME/.touchstone-projects"
+}
+
+# --- version / id helpers ----------------------------------------------------
+# Read .touchstone-version from a project directory, trimming whitespace.
+# Empty string when missing or unreadable.
+_status_read_project_version() {
+  local project_dir="$1"
+  [ -f "$project_dir/.touchstone-version" ] || return 0
+  tr -d '[:space:]' < "$project_dir/.touchstone-version" 2>/dev/null || true
+}
+
+# Render a recorded id for display. Long SHAs become short SHAs; semver-ish
+# strings ("2.3.4") pass through unchanged. The 12-char threshold matches the
+# rest of bin/touchstone's id-shortening (cmd_init's installed/current dim).
+_status_display_id() {
+  local id="$1"
+  if [ "${#id}" -ge 12 ] && printf '%s' "$id" | grep -Eq '^[0-9a-f]+$'; then
+    printf '%s' "${id:0:12}"
+  else
+    printf '%s' "$id"
+  fi
+}
+
+# --- "behind" computation ----------------------------------------------------
+# Count touchstone commits between the project's recorded version and the
+# current touchstone HEAD. Mirrors the OLD_SHA/CURRENT_SHA logic in
+# bootstrap/update-project.sh:
+#   - same id            -> "current"
+#   - reachable history  -> integer count of commits ahead
+#   - non-SHA / GC'd     -> "?"
+#   - non-git touchstone -> "?" (brew install: no history to walk)
+#
+# Echoes the display string. Never errors.
+_status_behind_count() {
+  local recorded="$1" current="$2"
+  if [ -z "$recorded" ]; then
+    printf '?'
+    return 0
+  fi
+  if [ "$recorded" = "$current" ]; then
+    printf 'current'
+    return 0
+  fi
+  if [ ! -d "${TOUCHSTONE_ROOT:-/nonexistent}/.git" ]; then
+    printf '?'
+    return 0
+  fi
+  # Both ids must resolve in touchstone's git history. If the recorded id is a
+  # version string (no SHA) or has been garbage-collected, rev-list will fail
+  # — print "?" so the caller can paint it red without inventing a count.
+  if ! git -C "$TOUCHSTONE_ROOT" rev-parse --verify "$recorded^{commit}" >/dev/null 2>&1; then
+    printf '?'
+    return 0
+  fi
+  local count
+  count="$(git -C "$TOUCHSTONE_ROOT" rev-list --count "$recorded..$current" 2>/dev/null || echo "?")"
+  if [ -z "$count" ]; then
+    printf '?'
+  else
+    printf '%s' "$count"
+  fi
+}
+
+# --- file-age helpers --------------------------------------------------------
+# Portable mtime in epoch seconds. macOS/BSD use `stat -f %m`; GNU/Linux uses
+# `stat -c %Y`. Returns empty string when the file is missing or stat fails.
+_status_file_mtime() {
+  local file="$1"
+  [ -e "$file" ] || return 0
+  local mtime
+  mtime="$(stat -f %m "$file" 2>/dev/null || stat -c %Y "$file" 2>/dev/null || true)"
+  printf '%s' "$mtime"
+}
+
+# Convert an mtime epoch into a "Nd" / "Nh" / "Nm" age string, relative to now.
+# Empty input -> "?".
+_status_age_short() {
+  local mtime="$1"
+  if [ -z "$mtime" ]; then
+    printf '?'
+    return 0
+  fi
+  local now elapsed days hours minutes
+  now="$(date +%s)"
+  elapsed=$((now - mtime))
+  if [ "$elapsed" -lt 0 ]; then
+    elapsed=0
+  fi
+  days=$((elapsed / 86400))
+  if [ "$days" -ge 1 ]; then
+    printf '%dd' "$days"
+    return 0
+  fi
+  hours=$((elapsed / 3600))
+  if [ "$hours" -ge 1 ]; then
+    printf '%dh' "$hours"
+    return 0
+  fi
+  minutes=$((elapsed / 60))
+  if [ "$minutes" -ge 1 ]; then
+    printf '%dm' "$minutes"
+    return 0
+  fi
+  printf '<1m'
+}
+
+# Long-form age "N days ago (YYYY-MM-DD HH:MM)" for the single-project block.
+_status_age_long() {
+  local mtime="$1"
+  if [ -z "$mtime" ]; then
+    printf 'unknown'
+    return 0
+  fi
+  local now elapsed days human stamp
+  now="$(date +%s)"
+  elapsed=$((now - mtime))
+  if [ "$elapsed" -lt 0 ]; then
+    elapsed=0
+  fi
+  days=$((elapsed / 86400))
+  if [ "$days" -le 0 ]; then
+    if [ "$elapsed" -lt 60 ]; then
+      human="just now"
+    elif [ "$elapsed" -lt 3600 ]; then
+      human="$((elapsed / 60)) minutes ago"
+    else
+      human="$((elapsed / 3600)) hours ago"
+    fi
+  elif [ "$days" -eq 1 ]; then
+    human="1 day ago"
+  else
+    human="$days days ago"
+  fi
+  # `date -r` (BSD/macOS) takes an epoch; `date -d @epoch` is GNU. Try both.
+  stamp="$(date -r "$mtime" '+%Y-%m-%d %H:%M' 2>/dev/null \
+        || date -d "@$mtime" '+%Y-%m-%d %H:%M' 2>/dev/null \
+        || echo '')"
+  if [ -n "$stamp" ]; then
+    printf '%s (%s)' "$human" "$stamp"
+  else
+    printf '%s' "$human"
+  fi
+}
+
+# --- color picking -----------------------------------------------------------
+# Map a behind-count to a color from lib/colors.sh. Inputs:
+#   "current"  -> GREEN
+#   1..3       -> YELLOW
+#   4..        -> RED
+#   "?"        -> RED (unknown is treated as a problem, not a neutral)
+# RED/GREEN/YELLOW/RESET are empty strings when stdout isn't a tty
+# (lib/colors.sh handles that), so this function works in pipes too.
+_status_behind_color() {
+  local behind="$1"
+  case "$behind" in
+    current) printf '%s' "$GREEN" ;;
+    \?)      printf '%s' "$RED" ;;
+    *)
+      # Numeric: 1..3 yellow, 4+ red.
+      if [ "$behind" -ge 4 ] 2>/dev/null; then
+        printf '%s' "$RED"
+      else
+        printf '%s' "$YELLOW"
+      fi
+      ;;
+  esac
+}
+
+# Stale-age coloring for the AGE column in --all. Threshold is 30 days, named
+# here so future tweaks don't have to chase a magic number around the file.
+STATUS_STALE_AGE_DAYS=30
+_status_age_color() {
+  local mtime="$1"
+  if [ -z "$mtime" ]; then
+    printf '%s' "$RED"
+    return 0
+  fi
+  local now elapsed days
+  now="$(date +%s)"
+  elapsed=$((now - mtime))
+  days=$((elapsed / 86400))
+  if [ "$days" -ge "$STATUS_STALE_AGE_DAYS" ]; then
+    printf '%s' "$RED"
+  else
+    printf '%s' ""
+  fi
+}
+
+# --- single-project block ----------------------------------------------------
+# Print the block for `touchstone status` (no flags). Caller passes the project
+# directory (typically $(pwd)). Returns 1 when the directory has no manifest,
+# so the CLI can exit nonzero per spec.
+status_print_project() {
+  local project_dir="$1"
+  if [ ! -f "$project_dir/.touchstone-version" ]; then
+    printf 'not a touchstone project\n'
+    return 1
+  fi
+
+  local recorded current_id current_version behind mtime age_long display_recorded display_current
+  recorded="$(_status_read_project_version "$project_dir")"
+  current_id="$(touchstone_current_id)"
+  current_version="$(touchstone_version_str)"
+  behind="$(_status_behind_count "$recorded" "$current_id")"
+  mtime="$(_status_file_mtime "$project_dir/.touchstone-version")"
+  age_long="$(_status_age_long "$mtime")"
+  display_recorded="$(_status_display_id "$recorded")"
+  display_current="$(_status_display_id "$current_id")"
+
+  # "latest" line: if the project's recorded id matches the touchstone HEAD,
+  # tag it "(current)"; otherwise show how far behind it is.
+  local latest_suffix
+  case "$behind" in
+    current) latest_suffix='(current)' ;;
+    \?)      latest_suffix='(unknown — recorded id not in touchstone history)' ;;
+    *)       latest_suffix="(${behind} commits behind)" ;;
+  esac
+
+  # Prefer the human-readable VERSION ("2.3.4") for the "latest" label when
+  # available; the CURRENT_SHA the project records is opaque to humans.
+  local latest_label="$current_version"
+  [ -z "$latest_label" ] && latest_label="$display_current"
+
+  printf 'project:        %s\n' "$project_dir"
+  printf 'touchstone:     %s\n' "$display_recorded"
+  printf 'latest:         %s %s\n' "$latest_label" "$latest_suffix"
+  printf 'last update:    %s\n' "$age_long"
+}
+
+# --- registry walker ---------------------------------------------------------
+# Iterate the registry and invoke a callback for each project line. The
+# callback gets ($project_dir) and is responsible for output + tallying.
+# Skips empty lines and "#"-prefixed comments to match every other registry
+# reader in the codebase.
+_status_iter_registry() {
+  local cb="$1"
+  local projects_file
+  projects_file="$(_status_projects_file)"
+  if [ ! -f "$projects_file" ] || [ ! -s "$projects_file" ]; then
+    return 1
+  fi
+  local line
+  while IFS= read -r line || [ -n "$line" ]; do
+    [ -z "$line" ] && continue
+    case "$line" in \#*) continue ;; esac
+    "$cb" "$line"
+  done < "$projects_file"
+  return 0
+}
+
+# Truncate a string to N visible columns, appending "…" when cut. Keeps the
+# table readable in a 100-column terminal even when a project path is long.
+_status_truncate() {
+  local s="$1" max="$2"
+  if [ "${#s}" -le "$max" ]; then
+    printf '%s' "$s"
+  else
+    # Reserve 1 column for the ellipsis.
+    printf '%s…' "${s:0:max-1}"
+  fi
+}
+
+# Replace $HOME prefix with "~" for compact display.
+_status_tildefy() {
+  local p="$1"
+  if [ -n "${HOME:-}" ] && [ "${p#"$HOME"/}" != "$p" ]; then
+    printf '~/%s' "${p#"$HOME"/}"
+  elif [ "$p" = "$HOME" ]; then
+    printf '~'
+  else
+    printf '%s' "$p"
+  fi
+}
+
+# Column widths for the --all table. Tuned so a typical entry fits in ~80
+# columns; the project column expands to 30 visible chars with truncation.
+STATUS_COL_PROJECT=30
+STATUS_COL_VERSION=12
+STATUS_COL_BEHIND=8
+STATUS_COL_AGE=6
+
+# Row renderer. Stateful — bumps the four counters defined by status_print_all
+# via dynamic-scope inheritance (matching how cmd_doctor_project handles
+# `issues` in bin/touchstone). Every code path here updates exactly one
+# tally, so the totals always sum to the total row count.
+_status_render_row() {
+  local project_dir="$1"
+  local display_path
+  display_path="$(_status_tildefy "$project_dir")"
+  local proj_col
+  proj_col="$(_status_truncate "$display_path" "$STATUS_COL_PROJECT")"
+
+  local version_col behind_col age_col behind_color age_color row_color reset_inline
+  reset_inline="$RESET"
+
+  if [ ! -d "$project_dir" ]; then
+    version_col='(missing)'
+    behind_col='?'
+    age_col='?'
+    row_color="$RED"
+    total_missing=$((total_missing + 1))
+  elif [ ! -f "$project_dir/.touchstone-version" ]; then
+    version_col='(no manifest)'
+    behind_col='?'
+    age_col='?'
+    row_color="$RED"
+    total_missing=$((total_missing + 1))
+  else
+    local recorded behind mtime
+    recorded="$(_status_read_project_version "$project_dir")"
+    if [ -z "$recorded" ]; then
+      recorded='(empty)'
+      behind='?'
+    else
+      behind="$(_status_behind_count "$recorded" "$status_current_id")"
+    fi
+    version_col="$(_status_display_id "$recorded")"
+    behind_col="$behind"
+    mtime="$(_status_file_mtime "$project_dir/.touchstone-version")"
+    age_col="$(_status_age_short "$mtime")"
+    behind_color="$(_status_behind_color "$behind")"
+    age_color="$(_status_age_color "$mtime")"
+    if [ "$behind" = "current" ]; then
+      total_current=$((total_current + 1))
+    else
+      total_behind=$((total_behind + 1))
+    fi
+    # Row color is the more concerning of behind/age. RED beats YELLOW beats
+    # green/none. We compose by checking from most-severe down.
+    if [ "$behind_color" = "$RED" ] || [ "$age_color" = "$RED" ]; then
+      row_color="$RED"
+    elif [ "$behind_color" = "$YELLOW" ]; then
+      row_color="$YELLOW"
+    else
+      row_color="$GREEN"
+    fi
+  fi
+
+  total_rows=$((total_rows + 1))
+
+  # printf %-Ns pads to N visible chars; ANSI escapes don't count toward
+  # printf's width, which is why we wrap the whole row in one color pair
+  # instead of coloring each cell. Width math stays right.
+  printf "${row_color}%-${STATUS_COL_PROJECT}s  %-${STATUS_COL_VERSION}s  %-${STATUS_COL_BEHIND}s  %-${STATUS_COL_AGE}s${reset_inline}\n" \
+    "$proj_col" "$version_col" "$behind_col" "$age_col"
+}
+
+# Render the --all view. Returns 0 on success (including the empty-registry
+# case, per spec).
+status_print_all() {
+  local projects_file
+  projects_file="$(_status_projects_file)"
+  if [ ! -f "$projects_file" ] || [ ! -s "$projects_file" ]; then
+    printf 'no registered projects\n'
+    return 0
+  fi
+
+  # Cache touchstone HEAD once for the whole walk — every row reuses it.
+  local status_current_id
+  status_current_id="$(touchstone_current_id)"
+
+  # Tallies for the footer. Updated by _status_render_row through dynamic scope.
+  local total_rows=0 total_current=0 total_behind=0 total_missing=0
+
+  # Header row (uncolored, plain).
+  printf "${BOLD}%-${STATUS_COL_PROJECT}s  %-${STATUS_COL_VERSION}s  %-${STATUS_COL_BEHIND}s  %-${STATUS_COL_AGE}s${RESET}\n" \
+    "PROJECT" "VERSION" "BEHIND" "AGE"
+
+  _status_iter_registry _status_render_row || true
+
+  printf '\n%d projects total, %d current, %d behind, %d missing\n' \
+    "$total_rows" "$total_current" "$total_behind" "$total_missing"
+}

--- a/tests/test-status.sh
+++ b/tests/test-status.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+#
+# tests/test-status.sh — regression test for `touchstone status` and
+# `touchstone status --all`.
+#
+# Covers:
+#   - status --all walks ~/.touchstone-projects and renders a row per project
+#   - "current" / behind / "(missing)" / "(no manifest)" branches all render
+#   - bare `status` from inside a project prints the per-project block
+#   - bare `status` from a tempdir without .touchstone-version exits nonzero
+#   - empty/missing registry prints "no registered projects" and exits 0
+#
+set -euo pipefail
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TOUCHSTONE_BIN="$TOUCHSTONE_ROOT/bin/touchstone"
+TEST_DIR="$(mktemp -d -t touchstone-test-status.XXXXXX)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+ERRORS=0
+
+assert_contains() {
+  local file="$1" needle="$2"
+  if ! grep -q -- "$needle" "$file" 2>/dev/null; then
+    echo "FAIL: expected '$file' to contain '$needle'" >&2
+    echo "  ---- file content ----" >&2
+    sed 's/^/    /' "$file" >&2 || true
+    echo "  ----------------------" >&2
+    ERRORS=$((ERRORS + 1))
+  fi
+}
+
+assert_not_contains() {
+  local file="$1" needle="$2"
+  if grep -q -- "$needle" "$file" 2>/dev/null; then
+    echo "FAIL: expected '$file' to NOT contain '$needle'" >&2
+    ERRORS=$((ERRORS + 1))
+  fi
+}
+
+# Run touchstone with HOME pointed at a tempdir registry. NO_COLOR keeps the
+# output ANSI-free so grep assertions don't trip over escapes.
+run_touchstone() {
+  local fake_home="$1"; shift
+  HOME="$fake_home" \
+    NO_COLOR=1 \
+    TOUCHSTONE_NO_AUTO_UPDATE=1 \
+    bash "$TOUCHSTONE_BIN" "$@"
+}
+
+CURRENT_VERSION="$(tr -d '[:space:]' < "$TOUCHSTONE_ROOT/VERSION")"
+
+echo "==> Test: touchstone status / status --all"
+echo "    Test dir: $TEST_DIR"
+
+# --------------------------------------------------------------------------
+# Setup: build a synthetic HOME with a registry pointing at three fake
+# projects and one nonexistent path.
+# --------------------------------------------------------------------------
+FAKE_HOME="$TEST_DIR/home"
+mkdir -p "$FAKE_HOME"
+
+CURRENT_PROJECT="$TEST_DIR/proj-current"
+BEHIND_PROJECT="$TEST_DIR/proj-behind"
+NO_MANIFEST_PROJECT="$TEST_DIR/proj-no-manifest"
+MISSING_PROJECT="$TEST_DIR/proj-missing"  # never created
+
+mkdir -p "$CURRENT_PROJECT" "$BEHIND_PROJECT" "$NO_MANIFEST_PROJECT"
+
+# proj-current: version matches the touchstone HEAD (VERSION string, since
+# the brew-install path uses that as the id when there's no .git directory —
+# which is also the worktree path we're running from).
+printf '%s\n' "$CURRENT_VERSION" > "$CURRENT_PROJECT/.touchstone-version"
+
+# proj-behind: arbitrary GC'd-style id that isn't reachable in touchstone's
+# git history. The behind computation must report "?" rather than crash.
+printf '%s\n' "0000000000000000000000000000000000000abc" > "$BEHIND_PROJECT/.touchstone-version"
+
+# proj-no-manifest: directory exists but has no .touchstone-version. The
+# table must render "(no manifest)" without aborting the walk.
+# (no file written intentionally)
+
+# Registry includes all four — current, behind, no-manifest, missing path.
+{
+  printf '%s\n' "$CURRENT_PROJECT"
+  printf '%s\n' "$BEHIND_PROJECT"
+  printf '%s\n' "$NO_MANIFEST_PROJECT"
+  printf '%s\n' "$MISSING_PROJECT"
+} > "$FAKE_HOME/.touchstone-projects"
+
+# --------------------------------------------------------------------------
+# Test 1: `touchstone status --all` renders a row per registry entry
+# --------------------------------------------------------------------------
+echo ""
+echo "--- Test 1: status --all ---"
+
+ALL_OUT="$TEST_DIR/all.out"
+run_touchstone "$FAKE_HOME" status --all >"$ALL_OUT" 2>&1
+
+assert_contains "$ALL_OUT" "PROJECT"
+assert_contains "$ALL_OUT" "VERSION"
+assert_contains "$ALL_OUT" "BEHIND"
+assert_contains "$ALL_OUT" "AGE"
+
+# All three real projects show up by their basename (path may be tildefied
+# or absolute depending on whether HOME prefix matched).
+assert_contains "$ALL_OUT" "proj-current"
+assert_contains "$ALL_OUT" "proj-behind"
+assert_contains "$ALL_OUT" "proj-no-manifest"
+assert_contains "$ALL_OUT" "proj-missing"
+
+# proj-current: version column shows the touchstone version, behind=current.
+assert_contains "$ALL_OUT" "current"
+
+# proj-behind: behind=? because the recorded id isn't in touchstone history.
+# (The literal "?" appears in the AGE/BEHIND cells for unresolvable rows.)
+assert_contains "$ALL_OUT" "proj-behind.* ?"
+
+# proj-no-manifest: literal "(no manifest)" appears for the missing-file row.
+assert_contains "$ALL_OUT" "(no manifest)"
+
+# proj-missing: literal "(missing)" appears for the nonexistent path row.
+assert_contains "$ALL_OUT" "(missing)"
+
+# Footer tally — counts the four registered rows.
+assert_contains "$ALL_OUT" "4 projects total"
+
+# --------------------------------------------------------------------------
+# Test 2: bare `touchstone status` from inside a project prints the block
+# --------------------------------------------------------------------------
+echo ""
+echo "--- Test 2: status from inside a project ---"
+
+PROJECT_OUT="$TEST_DIR/project.out"
+( cd "$CURRENT_PROJECT" && run_touchstone "$FAKE_HOME" status ) >"$PROJECT_OUT" 2>&1
+
+assert_contains "$PROJECT_OUT" "^project: *${CURRENT_PROJECT}"
+assert_contains "$PROJECT_OUT" "^touchstone: *${CURRENT_VERSION}"
+assert_contains "$PROJECT_OUT" "^latest: *${CURRENT_VERSION} (current)"
+assert_contains "$PROJECT_OUT" "^last update: *"
+
+# --------------------------------------------------------------------------
+# Test 3: bare `touchstone status` in a non-touchstone dir exits nonzero
+# --------------------------------------------------------------------------
+echo ""
+echo "--- Test 3: status in non-touchstone dir exits nonzero ---"
+
+NON_PROJECT="$TEST_DIR/not-a-project"
+mkdir -p "$NON_PROJECT"
+NOT_OUT="$TEST_DIR/not.out"
+
+set +e
+( cd "$NON_PROJECT" && run_touchstone "$FAKE_HOME" status ) >"$NOT_OUT" 2>&1
+NOT_EXIT=$?
+set -e
+
+if [ "$NOT_EXIT" -eq 0 ]; then
+  echo "FAIL: status in a non-touchstone dir should exit nonzero (got 0)" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+assert_contains "$NOT_OUT" "not a touchstone project"
+
+# --------------------------------------------------------------------------
+# Test 4: empty / missing registry prints "no registered projects" and exit 0
+# --------------------------------------------------------------------------
+echo ""
+echo "--- Test 4: status --all with empty registry ---"
+
+EMPTY_HOME="$TEST_DIR/empty-home"
+mkdir -p "$EMPTY_HOME"
+# No .touchstone-projects file at all.
+
+EMPTY_OUT="$TEST_DIR/empty.out"
+set +e
+run_touchstone "$EMPTY_HOME" status --all >"$EMPTY_OUT" 2>&1
+EMPTY_EXIT=$?
+set -e
+
+if [ "$EMPTY_EXIT" -ne 0 ]; then
+  echo "FAIL: status --all with empty registry should exit 0 (got $EMPTY_EXIT)" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+assert_contains "$EMPTY_OUT" "no registered projects"
+
+# --------------------------------------------------------------------------
+# Test 5: registry exists but is empty — same "no registered projects" path
+# --------------------------------------------------------------------------
+echo ""
+echo "--- Test 5: status --all with zero-byte registry ---"
+
+EMPTY_FILE_HOME="$TEST_DIR/empty-file-home"
+mkdir -p "$EMPTY_FILE_HOME"
+: > "$EMPTY_FILE_HOME/.touchstone-projects"
+
+EMPTY_FILE_OUT="$TEST_DIR/empty-file.out"
+set +e
+run_touchstone "$EMPTY_FILE_HOME" status --all >"$EMPTY_FILE_OUT" 2>&1
+EMPTY_FILE_EXIT=$?
+set -e
+
+if [ "$EMPTY_FILE_EXIT" -ne 0 ]; then
+  echo "FAIL: status --all with zero-byte registry should exit 0 (got $EMPTY_FILE_EXIT)" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+assert_contains "$EMPTY_FILE_OUT" "no registered projects"
+
+# --------------------------------------------------------------------------
+# Test 6: registry with comments and blank lines is tolerated
+# --------------------------------------------------------------------------
+echo ""
+echo "--- Test 6: registry with comments and blank lines ---"
+
+COMMENT_HOME="$TEST_DIR/comment-home"
+mkdir -p "$COMMENT_HOME"
+{
+  printf '# leading comment\n'
+  printf '\n'
+  printf '%s\n' "$CURRENT_PROJECT"
+  printf '   \n'
+  printf '# trailing comment\n'
+} > "$COMMENT_HOME/.touchstone-projects"
+
+COMMENT_OUT="$TEST_DIR/comment.out"
+run_touchstone "$COMMENT_HOME" status --all >"$COMMENT_OUT" 2>&1
+
+assert_contains "$COMMENT_OUT" "proj-current"
+assert_contains "$COMMENT_OUT" "1 projects total"
+assert_not_contains "$COMMENT_OUT" "leading comment"
+
+# --------------------------------------------------------------------------
+# Results
+# --------------------------------------------------------------------------
+echo ""
+if [ "$ERRORS" -eq 0 ]; then
+  echo "==> PASS: all assertions passed"
+  exit 0
+else
+  echo "==> FAIL: $ERRORS assertion(s) failed"
+  exit 1
+fi


### PR DESCRIPTION
Verifies the new status surface end-to-end against a synthetic
~/.touchstone-projects in a tempdir (HOME-override, the same pattern
test-bootstrap.sh uses for registry isolation):

- status --all walks the registry, renders one row per project
  (current / behind-with-GC'd-id / no-manifest / missing-on-disk),
  and emits the footer tally
- bare status from inside a project prints the per-project block
  (project / touchstone / latest / last update)
- bare status from a non-touchstone tempdir exits nonzero with
  "not a touchstone project"
- empty registry (file missing) prints "no registered projects"
  and exits 0
- zero-byte registry takes the same empty-registry path
- registry tolerates "#" comments and whitespace-only lines

Also tightens lib/status.sh to make those last two cases work:
truncate the PROJECT column from the front (preserving the basename)
so test paths under /var/folders/... still expose the project name,
and trim whitespace before the empty/comment check in the registry
walker so blank-with-spaces lines don't render as "(missing)".

The shellcheck SC2088 warnings in _status_tildefy are intentional —
we're printing literal "~" for display, not asking the shell to
expand it — and have an inline disable + rationale.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
