### PR TITLE
fix(branch-guard): worktree-aware via `git -C <path>` parsing

### DIFF
--- a/hooks/branch-guard.sh
+++ b/hooks/branch-guard.sh
@@ -28,9 +28,9 @@ set -euo pipefail
 input="$(cat)"
 
 # Fast path — bail on non-git-commit calls without the jq/git overhead.
-# Matches "git commit" with optional whitespace; explicitly NOT matching
-# "git commit-tree" or other unrelated subcommands.
-if ! printf '%s' "$input" | grep -qE '"command"[[:space:]]*:[[:space:]]*"[^"]*\bgit[[:space:]]+commit\b'; then
+# Matches `git commit` with optional `-c key=value` / `-C <path>` flags
+# ahead of the subcommand; explicitly NOT matching `commit-tree`.
+if ! printf '%s' "$input" | grep -qE '"command"[[:space:]]*:[[:space:]]*"[^"]*\bgit([[:space:]]+-c[[:space:]]+[^[:space:]]+|[[:space:]]+-C[[:space:]]+[^[:space:]]+)*[[:space:]]+commit([[:space:]]|$)'; then
   exit 0
 fi
 
@@ -49,8 +49,23 @@ cwd="$(printf '%s' "$input" | jq -r '.cwd // ""')"
 # class is explicit — `\b` would match `commit-tree` because `-` is a
 # non-word char; we want `commit` followed by whitespace or end-of-string
 # only, so plumbing subcommands like `git commit-tree` pass through.
-if ! printf '%s' "$command" | grep -qE '\bgit[[:space:]]+commit([[:space:]]|$)'; then
+if ! printf '%s' "$command" | grep -qE '\bgit([[:space:]]+-c[[:space:]]+[^[:space:]]+|[[:space:]]+-C[[:space:]]+[^[:space:]]+)*[[:space:]]+commit([[:space:]]|$)'; then
   exit 0
+fi
+
+# Worktree-aware: when commit targets a different repo via `-C <path>`,
+# check that branch instead. The previous version saw `main` as the
+# current branch even when the commit was being directed at a feature
+# worktree via `git -C <worktree> commit`, blocking legitimate work.
+# Lowercase `-c` (the config-override flag) does not change directory
+# and so does NOT trigger this override.
+target_cwd="$(printf '%s' "$command" | grep -oE '\-C[[:space:]]+[^[:space:]]+' | sed -E 's/^-C[[:space:]]+//' | tail -1 || true)"
+if [ -n "$target_cwd" ]; then
+  if [ -n "$cwd" ] && [ -d "$cwd/$target_cwd" ]; then
+    cwd="$cwd/$target_cwd"
+  elif [ -d "$target_cwd" ]; then
+    cwd="$target_cwd"
+  fi
 fi
 
 # Determine current branch in the project Claude is operating in.

--- a/tests/test-guidance-hooks.sh
+++ b/tests/test-guidance-hooks.sh
@@ -122,6 +122,34 @@ assert "TOUCHSTONE_EMERGENCY=1 allows commit on main" "0" "$EXIT_OVERRIDE"
 assert "does not match 'git commit-tree' (plumbing)" "0" \
   "$(run_hook "$BRANCH_GUARD" "$(mkjson "git commit-tree -p HEAD")")"
 
+# 7. worktree-aware: `git -C <worktree> commit` while the parent agent's
+#    cwd is on main but the worktree is on a feature branch — should be
+#    allowed. The previous version checked the parent cwd's branch and
+#    blocked, forcing operators to use `git -C <path>` as an exploit (the
+#    earlier regex didn't match `-C path` between `git` and `commit`,
+#    silently bypassing the guard). This test verifies the legitimate
+#    parse: the hook follows `-C <path>` to the right repo.
+WORKTREE="$(mktemp -d -t touchstone-hook-test-wt.XXXXXX)"
+trap 'rm -rf "$TMPDIR" "$WORKTREE"' EXIT
+git -C "$TMPDIR" branch --quiet feat/wt-test 2>/dev/null || true
+git -C "$TMPDIR" worktree add --quiet "$WORKTREE" feat/wt-test
+# Parent cwd is on main; commit targets the feat/wt-test worktree.
+git -C "$TMPDIR" checkout --quiet main
+WT_JSON="$(jq -nc \
+  --arg cmd "git -C $WORKTREE commit -m 'wip'" \
+  --arg cwd "$TMPDIR" \
+  '{tool_name: "Bash", tool_input: {command: $cmd}, cwd: $cwd}')"
+assert "allows 'git -C <worktree>' commit when worktree is on a feature branch" "0" \
+  "$(run_hook "$BRANCH_GUARD" "$WT_JSON")"
+
+# 8. lowercase -c (config override, not change-directory) must NOT bypass
+#    the guard. Regression-guard for case-sensitivity of the -C parsing —
+#    if someone writes the regex with [Cc] it will treat
+#    `git -c core.editor=foo commit` as "directed at a different repo"
+#    and silently allow on main.
+assert "lowercase -c (config flag) does not bypass the guard on main" "2" \
+  "$(run_hook "$BRANCH_GUARD" "$(mkjson "git -c core.editor=foo commit -m 'wip'")")"
+
 # ----------------------------------------------------------------------
 # emergency-disclosure
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The PreToolUse `branch-guard.sh` hook silently let `git -C <worktree> commit` slip past the guard while incorrectly blocking the legitimate version of the same call from a main-parent. Both failure modes are fixed here, with regression tests.

## Why

The hook checks `git -C "$cwd" branch --show-current` against the JSON tool-call's `cwd`. Two structural problems:

1. **Silent bypass.** The fast-path regex `'git[[:space:]]+commit'` does NOT match `git -C <path> commit` — any operator who learned to use `-C` could commit on main without triggering the guard. That's a silent failure: the guard appeared to be enforcing the rule, but wasn't.
2. **False blocks on legitimate work.** When a parent agent is on `main` but the commit targets a feature-branch worktree (`git -C <worktree> commit`), the hook reads the parent's branch, sees `main`, and blocks — even though the actual commit is fine.

Hit this 8+ times in a parallel-worktree session in `autumngarage/conductor`. The local fix landed as conductor PR #78 on 2026-04-27. Upstreaming so the next `touchstone update` doesn't regress projects that have absorbed the fix locally.

## Changes

- `hooks/branch-guard.sh`:
  - Fast-path and parsed-command regex now match `git [-c key=value | -C path]+ commit\b` so the guard fires on those forms instead of being bypassed.
  - When `-C <path>` is present, follow it and check the target repo's branch instead of the parent cwd's branch.
  - Case-sensitive on `-C` only — lowercase `-c` (config override) does not change directory and doesn't trigger the cwd-override path.

- `tests/test-guidance-hooks.sh`: extended with two new assertions:
  - `git -C <worktree> commit` from a main-parent → allowed (the bug fix).
  - `git -c core.editor=foo commit` on main → still blocked (case-sensitivity regression guard).

## Testing

```sh
$ bash tests/test-guidance-hooks.sh
==> branch-guard
  OK: blocks 'git commit' on main
  OK: allows 'git commit' on feature branch
  OK: fast-passes non-git-commit ('ls -la')
  OK: blocks 'git commit' on master
  OK: TOUCHSTONE_EMERGENCY=1 allows commit on main
  OK: does not match 'git commit-tree' (plumbing)
  OK: allows 'git -C <worktree>' commit when worktree is on a feature branch
  OK: lowercase -c (config flag) does not bypass the guard on main
==> emergency-disclosure
  ...
==> OK: all 15 checks passed
```

## Risk

Low. The change tightens a hook regex and adds a single conditional cwd-override; no public surface, no schema, no config compat concerns. Tests cover both new cases plus the existing six branch-guard assertions.

## Rollback

Clean revert — single commit touching only `hooks/branch-guard.sh` and the test script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)