### PR TITLE
fix(codex-review): tolerate footers after sentinel emission

### DIFF
--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -78,6 +78,43 @@
 #
 set -euo pipefail
 
+# extract_review_sentinel — find exactly one standalone CODEX_REVIEW_*
+# sentinel line in the reviewer's output. The wrapper used to inspect
+# only the final physical line via `tail -1 | tr -d '\r '` and case on
+# that exact value; any footer after the sentinel — a stray markdown
+# rule, a closing fence, an LLM's habitual "Hope this helps." — pushed
+# the real sentinel off the last position and the wrapper reported
+# malformed despite a clean review. Reading "the unique standalone
+# sentinel line, anywhere in the output" is robust to that footer
+# class while still rejecting ambiguous cases (zero or multiple
+# sentinels) where the contract was actually broken.
+extract_review_sentinel() {
+  awk '
+    /^[[:space:]]*CODEX_REVIEW_(CLEAN|FIXED|BLOCKED)[[:space:]]*$/ {
+      line = $0
+      gsub(/\r/, "", line)
+      sub(/^[[:space:]]+/, "", line)
+      sub(/[[:space:]]+$/, "", line)
+      sentinel = line
+      count++
+    }
+    END {
+      if (count == 1) {
+        print sentinel
+      }
+    }
+  '
+}
+
+# Test entry-point — when CODEX_REVIEW_TEST_SENTINEL=1, read stdin,
+# pipe it through the helper, and exit. Lets shell tests verify the
+# extraction logic in isolation without spinning up the full review
+# pipeline.
+if [ "${CODEX_REVIEW_TEST_SENTINEL:-0}" = "1" ]; then
+  extract_review_sentinel
+  exit 0
+fi
+
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 CONFIG_FILE="$REPO_ROOT/.codex-review.toml"
 cd "$REPO_ROOT"
@@ -2072,8 +2109,8 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
     fi
   fi
 
-  LAST_LINE="$(printf '%s\n' "$OUTPUT" | tail -1 | tr -d '\r ')"
-  case "$LAST_LINE" in
+  LAST_SENTINEL="$(printf '%s\n' "$OUTPUT" | extract_review_sentinel)"
+  case "$LAST_SENTINEL" in
     CODEX_REVIEW_CLEAN)
       phase "done — clean"
       clean_subtitle="${REVIEWER_LABEL} · ${DIFF_LINE_COUNT} lines · push approved"
@@ -2150,8 +2187,14 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
       ;;
 
     *)
+      LAST_LINE="$(printf '%s\n' "$OUTPUT" | awk 'NF { line = $0 } END { print line }' | tr -d '\r')"
       echo "==> $REVIEWER_LABEL output did not match the expected sentinel contract."
-      echo "    Last line was: '$LAST_LINE'"
+      if [ -n "$LAST_SENTINEL" ]; then
+        echo "    Last matching sentinel line was: '$LAST_SENTINEL'"
+      else
+        echo "    No unique standalone sentinel line was found."
+      fi
+      echo "    Last non-blank line was: '$LAST_LINE'"
       echo "    Raw output (first 20 lines):"
       printf '%s\n' "$OUTPUT" | head -20 | sed 's/^/    /'
       REVIEW_EXIT_REASON="malformed-sentinel"

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -78,6 +78,43 @@
 #
 set -euo pipefail
 
+# extract_review_sentinel — find exactly one standalone CODEX_REVIEW_*
+# sentinel line in the reviewer's output. The wrapper used to inspect
+# only the final physical line via `tail -1 | tr -d '\r '` and case on
+# that exact value; any footer after the sentinel — a stray markdown
+# rule, a closing fence, an LLM's habitual "Hope this helps." — pushed
+# the real sentinel off the last position and the wrapper reported
+# malformed despite a clean review. Reading "the unique standalone
+# sentinel line, anywhere in the output" is robust to that footer
+# class while still rejecting ambiguous cases (zero or multiple
+# sentinels) where the contract was actually broken.
+extract_review_sentinel() {
+  awk '
+    /^[[:space:]]*CODEX_REVIEW_(CLEAN|FIXED|BLOCKED)[[:space:]]*$/ {
+      line = $0
+      gsub(/\r/, "", line)
+      sub(/^[[:space:]]+/, "", line)
+      sub(/[[:space:]]+$/, "", line)
+      sentinel = line
+      count++
+    }
+    END {
+      if (count == 1) {
+        print sentinel
+      }
+    }
+  '
+}
+
+# Test entry-point — when CODEX_REVIEW_TEST_SENTINEL=1, read stdin,
+# pipe it through the helper, and exit. Lets shell tests verify the
+# extraction logic in isolation without spinning up the full review
+# pipeline.
+if [ "${CODEX_REVIEW_TEST_SENTINEL:-0}" = "1" ]; then
+  extract_review_sentinel
+  exit 0
+fi
+
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 CONFIG_FILE="$REPO_ROOT/.codex-review.toml"
 cd "$REPO_ROOT"
@@ -2072,8 +2109,8 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
     fi
   fi
 
-  LAST_LINE="$(printf '%s\n' "$OUTPUT" | tail -1 | tr -d '\r ')"
-  case "$LAST_LINE" in
+  LAST_SENTINEL="$(printf '%s\n' "$OUTPUT" | extract_review_sentinel)"
+  case "$LAST_SENTINEL" in
     CODEX_REVIEW_CLEAN)
       phase "done — clean"
       clean_subtitle="${REVIEWER_LABEL} · ${DIFF_LINE_COUNT} lines · push approved"
@@ -2150,8 +2187,14 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
       ;;
 
     *)
+      LAST_LINE="$(printf '%s\n' "$OUTPUT" | awk 'NF { line = $0 } END { print line }' | tr -d '\r')"
       echo "==> $REVIEWER_LABEL output did not match the expected sentinel contract."
-      echo "    Last line was: '$LAST_LINE'"
+      if [ -n "$LAST_SENTINEL" ]; then
+        echo "    Last matching sentinel line was: '$LAST_SENTINEL'"
+      else
+        echo "    No unique standalone sentinel line was found."
+      fi
+      echo "    Last non-blank line was: '$LAST_LINE'"
       echo "    Raw output (first 20 lines):"
       printf '%s\n' "$OUTPUT" | head -20 | sed 's/^/    /'
       REVIEW_EXIT_REASON="malformed-sentinel"

--- a/tests/test-codex-review-sentinel.sh
+++ b/tests/test-codex-review-sentinel.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# tests/test-codex-review-sentinel.sh — unit tests for the sentinel
+# extraction helper in hooks/codex-review.sh. The wrapper used to
+# inspect only the final physical line via `tail -1 | tr -d '\r '` and
+# case on that exact value, so any footer after the sentinel — a stray
+# markdown rule, a closing fence, an LLM's habitual closing remark —
+# pushed the real sentinel off the last position and the wrapper
+# reported "malformed sentinel" despite a clean review. The new
+# extract_review_sentinel reads "the unique standalone sentinel line,
+# anywhere in the output" — robust to that footer class while still
+# rejecting genuinely ambiguous outputs (zero or multiple sentinels).
+#
+# These tests exercise the helper via CODEX_REVIEW_TEST_SENTINEL=1,
+# which short-circuits the script after the helper definition and
+# pipes stdin through awk only.
+#
+set -euo pipefail
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$TOUCHSTONE_ROOT/hooks/codex-review.sh"
+
+if [ ! -x "$SCRIPT" ]; then
+  echo "FAIL: $SCRIPT not found or not executable" >&2
+  exit 1
+fi
+
+run_detector() {
+  local input="$1"
+  printf '%s' "$input" | CODEX_REVIEW_TEST_SENTINEL=1 bash "$SCRIPT"
+}
+
+assert_detector() {
+  local name="$1"
+  local input="$2"
+  local expected="$3"
+  local actual
+
+  actual="$(run_detector "$input")"
+  if [ "$actual" != "$expected" ]; then
+    printf 'FAIL: %s\nexpected: [%s]\nactual:   [%s]\n' "$name" "$expected" "$actual" >&2
+    exit 1
+  fi
+  printf '  OK: %s\n' "$name"
+}
+
+echo "==> codex-review sentinel extraction"
+
+assert_detector \
+  "exact sentinel" \
+  $'Summary\nCODEX_REVIEW_CLEAN\n' \
+  "CODEX_REVIEW_CLEAN"
+
+assert_detector \
+  "trailing whitespace" \
+  $'Summary\nCODEX_REVIEW_CLEAN   \n\n' \
+  "CODEX_REVIEW_CLEAN"
+
+# This is the regression case: footer after sentinel was reported as
+# malformed by the old `tail -1` parser. The helper now finds the
+# sentinel anywhere in the output as long as it's the only one.
+assert_detector \
+  "footer after sentinel — does not break extraction" \
+  $'LGTM\nCODEX_REVIEW_CLEAN\n---\nreview complete\n' \
+  "CODEX_REVIEW_CLEAN"
+
+assert_detector \
+  "indented sentinel" \
+  $'Summary\n  CODEX_REVIEW_FIXED\t\nextra note\n' \
+  "CODEX_REVIEW_FIXED"
+
+# Inline sentinels (text on the same line as other content) are NOT
+# accepted — the contract is "sentinel on its own line."
+assert_detector \
+  "inline sentinel rejected" \
+  $'Summary: CODEX_REVIEW_CLEAN\n' \
+  ""
+
+# Multiple sentinel lines are ambiguous — the reviewer either changed
+# its mind or got confused; reject and surface as malformed.
+assert_detector \
+  "multiple sentinel lines rejected" \
+  $'CODEX_REVIEW_CLEAN\nCODEX_REVIEW_BLOCKED\n' \
+  ""
+
+# Empty output → empty result. The wrapper's malformed-sentinel branch
+# then reports "no unique standalone sentinel" rather than echoing an
+# empty last line.
+assert_detector \
+  "no sentinel at all" \
+  $'just some prose\nno verdict\n' \
+  ""
+
+echo "==> OK: all sentinel tests passed"


### PR DESCRIPTION
## Summary

The merge-review wrapper reads `tail -1` of the reviewer's output and cases on that exact value. Any footer after the sentinel — a stray markdown rule, a closing fence, an LLM's habitual closing line — pushes the real sentinel off the last position and the wrapper reports "malformed sentinel" despite a clean review. Replace the tail-based check with a helper that finds exactly one standalone sentinel line anywhere in the output.

## Why

Hit this 4+ times in `autumngarage/conductor` (PRs #61, #64, #68, #70) where reviewer findings were 0 but the wrapper aborted with "malformed sentinel". The reviewer was emitting `CODEX_REVIEW_CLEAN` correctly; the wrapper was just looking in the wrong place. Local fix landed as conductor PR #79 on 2026-04-27. Upstreaming so the next `touchstone update` doesn't regress projects that have absorbed it locally.

The new helper is robust to footer text but still strict about ambiguity: zero or multiple standalone sentinels return empty, and the wrapper's malformed branch surfaces "no unique standalone sentinel" — so future regressions report the actual shape problem rather than a misleading "last line was: '---'".

## Changes

- `hooks/codex-review.sh`:
  - New `extract_review_sentinel()` awk helper near the top that returns the unique standalone `CODEX_REVIEW_(CLEAN|FIXED|BLOCKED)` line, with surrounding whitespace tolerated.
  - `CODEX_REVIEW_TEST_SENTINEL=1` short-circuit so shell tests can exercise the helper without the full review pipeline.
  - Replace `LAST_LINE="$(... | tail -1 | tr -d '\r ')"` with `LAST_SENTINEL="$(... | extract_review_sentinel)"` and case on that.
  - Malformed-sentinel branch reports both the extracted sentinel (if any) and the last non-blank line, so the failure mode is unambiguous in logs.

- `scripts/codex-review.sh`: synced (verified by existing `test-codex-review-sync.sh`).

- `tests/test-codex-review-sentinel.sh` (new): seven assertions covering exact / trailing-whitespace / footer-after / indented / inline-rejected / multiple-rejected / empty cases.

## Testing

```sh
$ bash tests/test-codex-review-sentinel.sh
==> codex-review sentinel extraction
  OK: exact sentinel
  OK: trailing whitespace
  OK: footer after sentinel — does not break extraction
  OK: indented sentinel
  OK: inline sentinel rejected
  OK: multiple sentinel lines rejected
  OK: no sentinel at all
==> OK: all sentinel tests passed

$ bash tests/test-codex-review-sync.sh
==> PASS: hooks/codex-review.sh and scripts/codex-review.sh are in sync

$ bash tests/test-shellcheck.sh
==> PASS: shellcheck clean at --severity=warning
```

## Risk

Low. The new helper is additive (a self-contained awk pass guarded by a test-mode env var). The case-statement change reads from a more reliable source but the contract for the three sentinels (`CLEAN`, `FIXED`, `BLOCKED`) is unchanged. The malformed-sentinel branch is strictly more informative; it doesn't change behavior in any other path.

## Rollback

Clean revert — three files in one commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)