### PR TITLE
fix(open-pr): never exit 0 unless PR is actually merged

### DIFF
--- a/scripts/open-pr.sh
+++ b/scripts/open-pr.sh
@@ -13,6 +13,19 @@
 #   bash scripts/open-pr.sh --base feat/X  # stacked PR: base this PR on feat/X, not main
 #   bash scripts/open-pr.sh "Custom title" # explicit title
 #
+# Exit contract (--auto-merge):
+#   exit 0 ⇔ `gh pr view <n> --json mergedAt --jq .mergedAt` is non-empty.
+#   Any other terminal state exits nonzero AND prints the PR URL with recovery
+#   commands as the last lines of output. This prevents the "swarm-agent orphan
+#   PR" failure mode where an agent's session ends mid-merge and leaves a
+#   reviewed-but-unmerged PR open indefinitely.
+#
+#   Why local polling instead of `gh pr merge --auto`: native auto-merge fires
+#   when GitHub's required-checks gate flips green. Touchstone's review gate is
+#   the local Conductor review (run from merge-pr.sh), not a GitHub Action, so
+#   a queued native auto-merge would never fire. Keeping the merge in-band lets
+#   us positively confirm merge before reporting success.
+#
 # ⚠ Stacked PRs — read this before using --base:
 #   Stacking a PR on another PR's branch is useful when work naturally
 #   splits into a chain (parent PR ships primitive, child PR ships the
@@ -25,6 +38,65 @@
 #   stacks when you can. See principles/git-workflow.md.
 #
 set -euo pipefail
+
+# orphan_warning is set to a PR URL once we know one — any nonzero exit after
+# that point prints recovery instructions as the script's last output, so the
+# user (or future agent) can see exactly which PR is stuck.
+ORPHAN_PR_URL=""
+ORPHAN_PR_NUMBER=""
+BODY_FILE=""
+
+on_exit() {
+  local rc="$?"
+  # Always clean up the temp body file, no matter how we exit.
+  if [ -n "$BODY_FILE" ] && [ -f "$BODY_FILE" ]; then
+    rm -f "$BODY_FILE"
+  fi
+  print_orphan_warning "$rc"
+  return "$rc"
+}
+
+print_orphan_warning() {
+  local rc="$1"
+  if [ "$rc" -eq 0 ]; then
+    return 0
+  fi
+  if [ -z "$ORPHAN_PR_URL" ]; then
+    return 0
+  fi
+  # Re-check merge state on exit — if the PR actually merged in flight (e.g.
+  # we ran past the merge step but tripped on a follow-up like the local pull)
+  # then this isn't an orphan. The exit code stays nonzero; we just suppress
+  # the misleading orphan banner.
+  if [ -n "$ORPHAN_PR_NUMBER" ] \
+    && command -v gh >/dev/null 2>&1 \
+    && [ -n "$(gh pr view "$ORPHAN_PR_NUMBER" --json mergedAt --jq '.mergedAt // empty' 2>/dev/null || true)" ]; then
+    return 0
+  fi
+  {
+    echo ""
+    echo "==> ORPHAN RISK: PR opened but not merged. Resolve manually:"
+    echo "==>   $ORPHAN_PR_URL"
+    if [ -n "$ORPHAN_PR_NUMBER" ]; then
+      echo "==>   gh pr merge $ORPHAN_PR_NUMBER --squash --delete-branch    (if review passed)"
+      echo "==>   gh pr close $ORPHAN_PR_NUMBER                              (if abandoning)"
+    fi
+  } >&2
+}
+
+# Verify the PR actually merged. Returns 0 if mergedAt is non-empty, 1 otherwise.
+# Used as the post-merge sanity check that turns the script's exit contract from
+# "merge-pr.sh exited 0" (proxy) into "GitHub says it's merged" (truth).
+verify_pr_merged() {
+  local pr_number="$1"
+  local merged_at
+  merged_at="$(gh pr view "$pr_number" --json mergedAt --jq '.mergedAt // empty' 2>/dev/null || echo "")"
+  if [ -n "$merged_at" ]; then
+    echo "==> Verified: PR #$pr_number merged at $merged_at"
+    return 0
+  fi
+  return 1
+}
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 TEMPLATE_PATH="$REPO_ROOT/.github/pull_request_template.md"
@@ -115,18 +187,36 @@ else
   git push -u origin "$CURRENT_BRANCH"
 fi
 
+# Install the cleanup/orphan-warning trap now — every later exit path may
+# already have a PR URL we need to surface to the user, and the trap also
+# handles temp-file cleanup once BODY_FILE is set further down.
+trap on_exit EXIT
+
 # If a PR already exists for this branch, just print the URL (and auto-merge if requested).
 EXISTING_PR_URL="$(gh pr list --head "$CURRENT_BRANCH" --author "@me" --state open --json url --jq '.[0].url // empty' 2>/dev/null || echo "")"
 if [ -n "$EXISTING_PR_URL" ]; then
   echo "==> PR already open for $CURRENT_BRANCH: $EXISTING_PR_URL"
   if [ "$AUTO_MERGE" = true ]; then
     PR_NUMBER="$(basename "$EXISTING_PR_URL")"
+    ORPHAN_PR_URL="$EXISTING_PR_URL"
+    ORPHAN_PR_NUMBER="$PR_NUMBER"
     MERGE_SCRIPT="$(dirname "$0")/merge-pr.sh"
-    if [ -f "$MERGE_SCRIPT" ]; then
-      echo ""
-      echo "==> Auto-merging PR #$PR_NUMBER ..."
-      exec bash "$MERGE_SCRIPT" "$PR_NUMBER"
+    if [ ! -f "$MERGE_SCRIPT" ]; then
+      echo "ERROR: merge-pr.sh not found at $MERGE_SCRIPT — cannot auto-merge." >&2
+      exit 1
     fi
+    echo ""
+    echo "==> Auto-merging PR #$PR_NUMBER ..."
+    # Don't exec — we need to verify mergedAt after merge-pr.sh returns.
+    if ! bash "$MERGE_SCRIPT" "$PR_NUMBER"; then
+      echo "ERROR: merge-pr.sh failed for PR #$PR_NUMBER." >&2
+      exit 1
+    fi
+    if ! verify_pr_merged "$PR_NUMBER"; then
+      echo "ERROR: merge-pr.sh exited 0 but PR #$PR_NUMBER is not merged on GitHub." >&2
+      exit 1
+    fi
+    exit 0
   fi
   exit 0
 fi
@@ -139,9 +229,9 @@ fi
 
 COMMIT_BODY="$(git log -1 --format=%b)"
 
-# Build body from commit body + PR template (if present).
+# Build body from commit body + PR template (if present). The unified EXIT
+# trap installed above (`on_exit`) will rm the file regardless of how we exit.
 BODY_FILE="$(mktemp -t touchstone-pr-body.XXXXXX.md)"
-trap 'rm -f "$BODY_FILE"' EXIT
 
 {
   if [ -n "$COMMIT_BODY" ]; then
@@ -161,19 +251,51 @@ fi
 
 echo "$PR_URL"
 
+# Capture the PR for the orphan-warning trap — anything that exits nonzero
+# from here on is a stuck-PR risk.
+ORPHAN_PR_URL="$PR_URL"
+ORPHAN_PR_NUMBER="$(basename "$PR_URL")"
+
 if [ -n "$DRAFT_FLAG" ]; then
   echo "    Opened as draft. Mark ready on github.com when ready to merge."
+  if [ "$AUTO_MERGE" = true ]; then
+    # --auto-merge + --draft is a contradiction (drafts can't merge). Don't
+    # claim success silently — the user explicitly asked for a merge.
+    echo "WARNING: --auto-merge ignored because --draft was passed; PR opened as draft only." >&2
+  fi
+  # Draft path: PR is intentionally open and not merged. That's not an orphan.
+  ORPHAN_PR_URL=""
+  ORPHAN_PR_NUMBER=""
+  exit 0
 fi
 
-# Auto-merge: extract PR number and run merge-pr.sh.
-if [ "$AUTO_MERGE" = true ] && [ -z "$DRAFT_FLAG" ]; then
+# Auto-merge: extract PR number and run merge-pr.sh, then positively verify
+# the PR actually reached MERGED state on GitHub before claiming success.
+if [ "$AUTO_MERGE" = true ]; then
   PR_NUMBER="$(basename "$PR_URL")"
   MERGE_SCRIPT="$(dirname "$0")/merge-pr.sh"
-  if [ -f "$MERGE_SCRIPT" ]; then
-    echo ""
-    echo "==> Auto-merging PR #$PR_NUMBER ..."
-    exec bash "$MERGE_SCRIPT" "$PR_NUMBER"
-  else
-    echo "WARNING: merge-pr.sh not found at $MERGE_SCRIPT — skipping auto-merge." >&2
+  if [ ! -f "$MERGE_SCRIPT" ]; then
+    echo "ERROR: merge-pr.sh not found at $MERGE_SCRIPT — cannot auto-merge." >&2
+    exit 1
+  fi
+  echo ""
+  echo "==> Auto-merging PR #$PR_NUMBER ..."
+  # Don't exec — we need to verify mergedAt after merge-pr.sh returns. The
+  # earlier `exec bash "$MERGE_SCRIPT"` form propagated merge-pr.sh's exit
+  # code but never positively confirmed merge happened, so any silent failure
+  # post-review (network blip on `gh pr merge`, etc.) could end with exit 0
+  # and a still-open PR. The new flow always asks GitHub.
+  if ! bash "$MERGE_SCRIPT" "$PR_NUMBER"; then
+    echo "ERROR: merge-pr.sh failed for PR #$PR_NUMBER." >&2
+    exit 1
+  fi
+  if ! verify_pr_merged "$PR_NUMBER"; then
+    echo "ERROR: merge-pr.sh exited 0 but PR #$PR_NUMBER is not merged on GitHub." >&2
+    exit 1
   fi
 fi
+
+# Reached the natural end with no failures — clear the orphan markers so the
+# EXIT trap stays quiet on a clean exit 0.
+ORPHAN_PR_URL=""
+ORPHAN_PR_NUMBER=""

--- a/tests/test-open-pr-exit-contract.sh
+++ b/tests/test-open-pr-exit-contract.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+#
+# tests/test-open-pr-exit-contract.sh — guard the open-pr.sh exit contract.
+#
+# Failure mode being prevented (flagged by the user 2026-04-28 with concrete
+# example outriderintel #90-94): a swarm agent runs `open-pr.sh --auto-merge`,
+# the PR opens, review passes, but the agent's session ends before merge
+# completes. The script must NEVER exit 0 unless the PR is actually merged on
+# GitHub, and any non-success terminal state must print the PR URL so a human
+# (or the next agent) can see what's stuck.
+#
+# Cases covered:
+#   1. Happy path — PR opens, merge-pr.sh succeeds, mergedAt non-null → exit 0.
+#   2. merge-pr.sh fails (review blocks, conflict, etc.) → nonzero + URL printed.
+#   3. merge-pr.sh exits 0 but PR is NOT actually merged (the silent-orphan
+#      class — gh API hiccup post-review) → nonzero + URL printed.
+#   4. merge-pr.sh missing on disk → nonzero + URL printed (no silent skip).
+#
+# Design: the script under test is copied into a temp dir, real `git` is used
+# (the repo is local), and `gh` plus `merge-pr.sh` are stubbed out. Stub
+# behaviour is keyed by env vars so each test scenario reuses the same mocks
+# with different toggles.
+#
+set -euo pipefail
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_DIR="$(mktemp -d -t touchstone-test-open-pr.XXXXXX)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+ERRORS=0
+
+REPO_DIR="$TEST_DIR/repo"
+SCRIPT_DIR="$TEST_DIR/scripts"
+FAKE_BIN="$TEST_DIR/bin"
+mkdir -p "$REPO_DIR" "$SCRIPT_DIR" "$FAKE_BIN"
+
+cp "$TOUCHSTONE_ROOT/scripts/open-pr.sh" "$SCRIPT_DIR/open-pr.sh"
+chmod +x "$SCRIPT_DIR/open-pr.sh"
+
+# Real git inside a fresh repo with a feature branch checked out, so the
+# branch-name and uncommitted-tree checks all use real behaviour.
+git -C "$REPO_DIR" init -b main >/dev/null 2>&1
+git -C "$REPO_DIR" config user.name "Touchstone Test"
+git -C "$REPO_DIR" config user.email "touchstone@example.com"
+printf 'base\n' > "$REPO_DIR/file.txt"
+git -C "$REPO_DIR" add file.txt
+git -C "$REPO_DIR" commit -m "base commit" >/dev/null 2>&1
+git -C "$REPO_DIR" checkout -b feat/test >/dev/null 2>&1
+printf 'change\n' >> "$REPO_DIR/file.txt"
+git -C "$REPO_DIR" add file.txt
+git -C "$REPO_DIR" commit -m "test change" >/dev/null 2>&1
+
+# Mock gh — behaviour controlled by env vars so each scenario reuses one mock.
+# GH_MERGED_AT  — value returned for `gh pr view --json mergedAt --jq …`
+# GH_HAS_EXISTING_PR — if "1", `gh pr list` returns an existing PR URL
+cat > "$FAKE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$1 $2" in
+  "repo view")
+    echo "main"
+    ;;
+  "pr list")
+    if [ "${GH_HAS_EXISTING_PR:-0}" = "1" ]; then
+      echo "https://example.test/touchstone/pull/777"
+    else
+      echo ""
+    fi
+    ;;
+  "pr create")
+    # Last positional is the body file flag pair; we only need to emit a URL.
+    echo "https://example.test/touchstone/pull/123"
+    ;;
+  "pr view")
+    # Calls of interest:
+    #   gh pr view <n> --json mergedAt --jq '.mergedAt // empty'
+    # Return GH_MERGED_AT (may be empty string).
+    echo "${GH_MERGED_AT:-}"
+    ;;
+  *)
+    echo "unexpected gh args: $*" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "$FAKE_BIN/gh"
+
+# Stub git push so the script doesn't try to talk to a real remote.
+# We wrap real git via $REAL_GIT for everything else.
+REAL_GIT="$(command -v git)"
+cat > "$FAKE_BIN/git" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "push" ]; then
+  echo "[mock] git push \$*"
+  exit 0
+fi
+exec "$REAL_GIT" "\$@"
+EOF
+chmod +x "$FAKE_BIN/git"
+
+# Stub merge-pr.sh — behaviour controlled by MERGE_PR_EXIT (default 0).
+# When nonzero, simulates "Conductor blocked" or similar review-failure.
+cat > "$SCRIPT_DIR/merge-pr.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "[mock merge-pr.sh] called for PR $1"
+exit "${MERGE_PR_EXIT:-0}"
+EOF
+chmod +x "$SCRIPT_DIR/merge-pr.sh"
+
+# Helper: run open-pr.sh in the test repo with a given mock environment.
+# Sets a clean PATH so only the fake gh+git are visible (plus system bins).
+run_open_pr() {
+  (
+    cd "$REPO_DIR"
+    PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+      GH_MERGED_AT="${GH_MERGED_AT:-}" \
+      GH_HAS_EXISTING_PR="${GH_HAS_EXISTING_PR:-0}" \
+      MERGE_PR_EXIT="${MERGE_PR_EXIT:-0}" \
+      bash "$SCRIPT_DIR/open-pr.sh" --auto-merge
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: happy path — exit 0, no orphan banner, mergedAt confirmed.
+# ---------------------------------------------------------------------------
+echo "==> Case 1: happy path"
+OUT="$TEST_DIR/case1.out"
+RC=0
+GH_MERGED_AT="2026-04-28T12:00:00Z" GH_HAS_EXISTING_PR=0 MERGE_PR_EXIT=0 \
+  run_open_pr > "$OUT" 2>&1 || RC=$?
+
+if [ "$RC" = "0" ] \
+  && grep -q '==> Verified: PR #123 merged at 2026-04-28T12:00:00Z' "$OUT" \
+  && ! grep -q 'ORPHAN RISK' "$OUT"; then
+  echo "    PASS"
+else
+  echo "    FAIL: expected exit 0 + verified-merge line + no orphan banner" >&2
+  echo "    rc=$RC" >&2
+  cat "$OUT" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# Case 2: merge-pr.sh blocks (review failure / conductor blocked).
+# Expect: nonzero exit + ORPHAN RISK banner with PR URL.
+# ---------------------------------------------------------------------------
+echo "==> Case 2: merge-pr.sh blocks (Conductor blocks review)"
+OUT="$TEST_DIR/case2.out"
+RC=0
+GH_MERGED_AT="" GH_HAS_EXISTING_PR=0 MERGE_PR_EXIT=1 \
+  run_open_pr > "$OUT" 2>&1 || RC=$?
+
+if [ "$RC" != "0" ] \
+  && grep -q 'ORPHAN RISK: PR opened but not merged' "$OUT" \
+  && grep -q 'https://example.test/touchstone/pull/123' "$OUT" \
+  && grep -q 'gh pr merge 123 --squash --delete-branch' "$OUT" \
+  && grep -q 'gh pr close 123' "$OUT"; then
+  echo "    PASS"
+else
+  echo "    FAIL: expected nonzero exit + orphan banner + PR URL + recovery hints" >&2
+  echo "    rc=$RC" >&2
+  cat "$OUT" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# Case 3: silent orphan — merge-pr.sh exits 0 but mergedAt is empty.
+# This is the dangerous case the new exit contract specifically catches:
+# without verify_pr_merged the script would have exited 0 with an open PR.
+# ---------------------------------------------------------------------------
+echo "==> Case 3: silent orphan — merge-pr.sh exits 0 but PR not actually merged"
+OUT="$TEST_DIR/case3.out"
+RC=0
+GH_MERGED_AT="" GH_HAS_EXISTING_PR=0 MERGE_PR_EXIT=0 \
+  run_open_pr > "$OUT" 2>&1 || RC=$?
+
+if [ "$RC" != "0" ] \
+  && grep -q 'merge-pr.sh exited 0 but PR #123 is not merged on GitHub' "$OUT" \
+  && grep -q 'ORPHAN RISK: PR opened but not merged' "$OUT" \
+  && grep -q 'https://example.test/touchstone/pull/123' "$OUT"; then
+  echo "    PASS"
+else
+  echo "    FAIL: expected nonzero exit + post-merge verification failure + orphan banner" >&2
+  echo "    rc=$RC" >&2
+  cat "$OUT" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# Case 4: merge-pr.sh missing on disk — script must NOT silently exit 0.
+# Earlier behaviour: WARNING + fall through to exit 0 (the orphan trap).
+# New behaviour: ERROR + nonzero exit + orphan banner.
+# ---------------------------------------------------------------------------
+echo "==> Case 4: merge-pr.sh missing on disk"
+OUT="$TEST_DIR/case4.out"
+RC=0
+mv "$SCRIPT_DIR/merge-pr.sh" "$SCRIPT_DIR/merge-pr.sh.hidden"
+GH_MERGED_AT="" GH_HAS_EXISTING_PR=0 \
+  run_open_pr > "$OUT" 2>&1 || RC=$?
+mv "$SCRIPT_DIR/merge-pr.sh.hidden" "$SCRIPT_DIR/merge-pr.sh"
+
+if [ "$RC" != "0" ] \
+  && grep -q 'merge-pr.sh not found' "$OUT" \
+  && grep -q 'ORPHAN RISK: PR opened but not merged' "$OUT" \
+  && grep -q 'https://example.test/touchstone/pull/123' "$OUT"; then
+  echo "    PASS"
+else
+  echo "    FAIL: expected nonzero exit + missing-script error + orphan banner" >&2
+  echo "    rc=$RC" >&2
+  cat "$OUT" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# Case 5: idempotency — invoked when a PR already exists, the script delegates
+# to merge-pr.sh and verifies merge state. With merge-pr.sh succeeding and
+# mergedAt populated, exit 0. (The earlier `exec` form also reached merge-pr;
+# the new form additionally verifies — make sure the existing-PR path didn't
+# regress on the happy path.)
+# ---------------------------------------------------------------------------
+echo "==> Case 5: existing-PR path with --auto-merge succeeds and verifies"
+OUT="$TEST_DIR/case5.out"
+RC=0
+GH_MERGED_AT="2026-04-28T13:00:00Z" GH_HAS_EXISTING_PR=1 MERGE_PR_EXIT=0 \
+  run_open_pr > "$OUT" 2>&1 || RC=$?
+
+if [ "$RC" = "0" ] \
+  && grep -q 'PR already open' "$OUT" \
+  && grep -q '==> Verified: PR #777 merged at 2026-04-28T13:00:00Z' "$OUT" \
+  && ! grep -q 'ORPHAN RISK' "$OUT"; then
+  echo "    PASS"
+else
+  echo "    FAIL: expected exit 0 + verified-merge for existing-PR path" >&2
+  echo "    rc=$RC" >&2
+  cat "$OUT" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+if [ "$ERRORS" = "0" ]; then
+  echo "==> PASS: open-pr.sh exit contract holds across orphan-risk paths"
+  exit 0
+fi
+echo "==> FAIL: $ERRORS case(s) regressed" >&2
+exit 1


### PR DESCRIPTION
A swarm agent running `open-pr.sh --auto-merge` could exit 0 with the PR
still open if `merge-pr.sh` returned 0 but `gh pr merge` silently failed
post-review (network blip, etc.), or if `merge-pr.sh` was missing on
disk (the previous WARNING-then-fall-through path). The agent's session
ends, the PR sits open indefinitely, and the next agent has no signal
that anything is stuck.

Changes:
- Replace `exec bash merge-pr.sh` with a call-and-verify flow: run
  merge-pr.sh, then positively confirm `gh pr view --json mergedAt` is
  non-empty before exiting 0.
- Install an EXIT trap that prints the PR URL plus recovery commands
  (`gh pr merge` / `gh pr close`) on any nonzero exit after the PR has
  been opened, so a stuck PR is never silently abandoned.
- Treat missing merge-pr.sh as ERROR + nonzero exit (was: WARNING +
  exit 0). Treat --auto-merge + --draft as a contradiction with a
  visible warning.
- Cover all four orphan-risk paths plus happy path with
  tests/test-open-pr-exit-contract.sh — fails on the prior code at
  cases 3 (silent orphan) and 4 (missing script).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
