### PR TITLE
feat(reviewer): inject sentinel cycle journal into reviewer context (closes #87)

### DIFF
--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -115,6 +115,100 @@ if [ "${CODEX_REVIEW_TEST_SENTINEL:-0}" = "1" ]; then
   exit 0
 fi
 
+# --------------------------------------------------------------------------
+# Sentinel-cycle journal detection helpers
+# --------------------------------------------------------------------------
+
+# Returns 0 (truthy) when .sentinel/runs/ contains at least one .md artifact.
+is_sentinel_authored_branch() {
+  [ -d .sentinel/runs ] && find .sentinel/runs -name '*.md' -type f -print -quit | grep -q .
+}
+
+# Prints the path of the most-recently-modified sentinel run artifact.
+find_latest_sentinel_run() {
+  # ls -t is the simplest portable mtime sort; filenames here are controlled.
+  # shellcheck disable=SC2012
+  ls -t .sentinel/runs/*.md 2>/dev/null | head -1
+}
+
+# Extracts the cycle-id frontmatter field from a sentinel run artifact.
+get_cycle_id_from_run() {
+  local run_file="$1"
+  awk '/^---$/{f=1-f; next} f && /^cycle-id:/{print $2; exit}' "$run_file"
+}
+
+# Returns the path of the journal entry whose filename contains cycle-id $1.
+find_journal_entry_by_cycle_id() {
+  local cycle_id="$1"
+  find .cortex/journal -maxdepth 1 -name "*sentinel-cycle-${cycle_id}.md" -type f 2>/dev/null \
+    | head -1
+}
+
+# Returns path to the most recent sentinel-cycle journal entry by mtime.
+find_latest_sentinel_journal_entry() {
+  # shellcheck disable=SC2012
+  ls -t .cortex/journal/*sentinel-cycle*.md 2>/dev/null | head -1
+}
+
+# Returns path to the best-matching sentinel cycle journal entry:
+#   1. If the latest run artifact has a cycle-id field, prefer the journal
+#      entry whose filename contains that id (per sentinel#97 convention).
+#   2. Fall back to the most recently modified sentinel-cycle journal entry.
+find_sentinel_journal_entry() {
+  local run_file cycle_id matched
+  run_file="$(find_latest_sentinel_run)"
+  if [ -n "$run_file" ]; then
+    cycle_id="$(get_cycle_id_from_run "$run_file")"
+    if [ -n "$cycle_id" ]; then
+      matched="$(find_journal_entry_by_cycle_id "$cycle_id")"
+      if [ -n "$matched" ]; then
+        echo "$matched"
+        return 0
+      fi
+    fi
+  fi
+  # Fallback: most recent journal entry by mtime.
+  find_latest_sentinel_journal_entry || true
+}
+
+# Prints the <sentinel-cycle-context> block to stdout when this branch is
+# sentinel-authored and a cycle journal entry can be resolved. Prints nothing
+# (and warns to stderr) when detection fails, the journal is missing, or the
+# journal cannot be read.
+build_sentinel_journal_context() {
+  if ! is_sentinel_authored_branch; then
+    return 0
+  fi
+  local journal_entry
+  journal_entry="$(find_sentinel_journal_entry)"
+  if [ -z "$journal_entry" ] || [ ! -f "$journal_entry" ]; then
+    echo "WARNING: sentinel branch detected but no cycle journal entry found in .cortex/journal/; reviewing without cycle context." >&2
+    return 0
+  fi
+  if [ ! -r "$journal_entry" ]; then
+    echo "WARNING: sentinel journal found at $journal_entry but could not be read; reviewing without cycle context." >&2
+    return 0
+  fi
+  local journal_content
+  if ! journal_content="$(cat "$journal_entry" 2>/dev/null)"; then
+    echo "WARNING: sentinel journal found at $journal_entry but could not be read; reviewing without cycle context." >&2
+    return 0
+  fi
+  printf '<sentinel-cycle-context>\n'
+  printf 'This diff was authored by an autonomous Sentinel cycle. The cycle'"'"'s journal entry follows; read it for the planner'"'"'s reasoning, the coder'"'"'s attempts, and any rejections handled mid-cycle. Review the diff against this context.\n\n'
+  printf '%s\n' "$journal_content"
+  printf '</sentinel-cycle-context>\n'
+}
+
+# Test entry-point for sentinel journal context helpers.
+# When CODEX_REVIEW_TEST_SENTINEL_CONTEXT=1, print the sentinel context block
+# to stdout (empty if detection fails) and exit without running the full
+# review pipeline.
+if [ "${CODEX_REVIEW_TEST_SENTINEL_CONTEXT:-0}" = "1" ]; then
+  build_sentinel_journal_context
+  exit 0
+fi
+
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 CONFIG_FILE="$REPO_ROOT/.codex-review.toml"
 cd "$REPO_ROOT"
@@ -1518,6 +1612,17 @@ If you emit CODEX_REVIEW_FIXED, briefly describe what you fixed (one line per fi
 
 Do not invent new sentinels. Do not output anything after the sentinel line.
 PROMPT_EOF
+
+# --------------------------------------------------------------------------
+# Inject sentinel-cycle journal context into the reviewer prompt (if any)
+# --------------------------------------------------------------------------
+SENTINEL_JOURNAL_CONTEXT="$(build_sentinel_journal_context)"
+if [ -n "$SENTINEL_JOURNAL_CONTEXT" ]; then
+  REVIEW_PROMPT="${SENTINEL_JOURNAL_CONTEXT}
+
+${REVIEW_PROMPT}"
+  echo "==> Sentinel cycle journal injected into reviewer context."
+fi
 
 # --------------------------------------------------------------------------
 # Clean-review cache

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -115,6 +115,100 @@ if [ "${CODEX_REVIEW_TEST_SENTINEL:-0}" = "1" ]; then
   exit 0
 fi
 
+# --------------------------------------------------------------------------
+# Sentinel-cycle journal detection helpers
+# --------------------------------------------------------------------------
+
+# Returns 0 (truthy) when .sentinel/runs/ contains at least one .md artifact.
+is_sentinel_authored_branch() {
+  [ -d .sentinel/runs ] && find .sentinel/runs -name '*.md' -type f -print -quit | grep -q .
+}
+
+# Prints the path of the most-recently-modified sentinel run artifact.
+find_latest_sentinel_run() {
+  # ls -t is the simplest portable mtime sort; filenames here are controlled.
+  # shellcheck disable=SC2012
+  ls -t .sentinel/runs/*.md 2>/dev/null | head -1
+}
+
+# Extracts the cycle-id frontmatter field from a sentinel run artifact.
+get_cycle_id_from_run() {
+  local run_file="$1"
+  awk '/^---$/{f=1-f; next} f && /^cycle-id:/{print $2; exit}' "$run_file"
+}
+
+# Returns the path of the journal entry whose filename contains cycle-id $1.
+find_journal_entry_by_cycle_id() {
+  local cycle_id="$1"
+  find .cortex/journal -maxdepth 1 -name "*sentinel-cycle-${cycle_id}.md" -type f 2>/dev/null \
+    | head -1
+}
+
+# Returns path to the most recent sentinel-cycle journal entry by mtime.
+find_latest_sentinel_journal_entry() {
+  # shellcheck disable=SC2012
+  ls -t .cortex/journal/*sentinel-cycle*.md 2>/dev/null | head -1
+}
+
+# Returns path to the best-matching sentinel cycle journal entry:
+#   1. If the latest run artifact has a cycle-id field, prefer the journal
+#      entry whose filename contains that id (per sentinel#97 convention).
+#   2. Fall back to the most recently modified sentinel-cycle journal entry.
+find_sentinel_journal_entry() {
+  local run_file cycle_id matched
+  run_file="$(find_latest_sentinel_run)"
+  if [ -n "$run_file" ]; then
+    cycle_id="$(get_cycle_id_from_run "$run_file")"
+    if [ -n "$cycle_id" ]; then
+      matched="$(find_journal_entry_by_cycle_id "$cycle_id")"
+      if [ -n "$matched" ]; then
+        echo "$matched"
+        return 0
+      fi
+    fi
+  fi
+  # Fallback: most recent journal entry by mtime.
+  find_latest_sentinel_journal_entry || true
+}
+
+# Prints the <sentinel-cycle-context> block to stdout when this branch is
+# sentinel-authored and a cycle journal entry can be resolved. Prints nothing
+# (and warns to stderr) when detection fails, the journal is missing, or the
+# journal cannot be read.
+build_sentinel_journal_context() {
+  if ! is_sentinel_authored_branch; then
+    return 0
+  fi
+  local journal_entry
+  journal_entry="$(find_sentinel_journal_entry)"
+  if [ -z "$journal_entry" ] || [ ! -f "$journal_entry" ]; then
+    echo "WARNING: sentinel branch detected but no cycle journal entry found in .cortex/journal/; reviewing without cycle context." >&2
+    return 0
+  fi
+  if [ ! -r "$journal_entry" ]; then
+    echo "WARNING: sentinel journal found at $journal_entry but could not be read; reviewing without cycle context." >&2
+    return 0
+  fi
+  local journal_content
+  if ! journal_content="$(cat "$journal_entry" 2>/dev/null)"; then
+    echo "WARNING: sentinel journal found at $journal_entry but could not be read; reviewing without cycle context." >&2
+    return 0
+  fi
+  printf '<sentinel-cycle-context>\n'
+  printf 'This diff was authored by an autonomous Sentinel cycle. The cycle'"'"'s journal entry follows; read it for the planner'"'"'s reasoning, the coder'"'"'s attempts, and any rejections handled mid-cycle. Review the diff against this context.\n\n'
+  printf '%s\n' "$journal_content"
+  printf '</sentinel-cycle-context>\n'
+}
+
+# Test entry-point for sentinel journal context helpers.
+# When CODEX_REVIEW_TEST_SENTINEL_CONTEXT=1, print the sentinel context block
+# to stdout (empty if detection fails) and exit without running the full
+# review pipeline.
+if [ "${CODEX_REVIEW_TEST_SENTINEL_CONTEXT:-0}" = "1" ]; then
+  build_sentinel_journal_context
+  exit 0
+fi
+
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 CONFIG_FILE="$REPO_ROOT/.codex-review.toml"
 cd "$REPO_ROOT"
@@ -1518,6 +1612,17 @@ If you emit CODEX_REVIEW_FIXED, briefly describe what you fixed (one line per fi
 
 Do not invent new sentinels. Do not output anything after the sentinel line.
 PROMPT_EOF
+
+# --------------------------------------------------------------------------
+# Inject sentinel-cycle journal context into the reviewer prompt (if any)
+# --------------------------------------------------------------------------
+SENTINEL_JOURNAL_CONTEXT="$(build_sentinel_journal_context)"
+if [ -n "$SENTINEL_JOURNAL_CONTEXT" ]; then
+  REVIEW_PROMPT="${SENTINEL_JOURNAL_CONTEXT}
+
+${REVIEW_PROMPT}"
+  echo "==> Sentinel cycle journal injected into reviewer context."
+fi
 
 # --------------------------------------------------------------------------
 # Clean-review cache

--- a/tests/test-reviewer-sentinel-context.sh
+++ b/tests/test-reviewer-sentinel-context.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+#
+# Unit and smoke tests for sentinel cycle journal injection in codex-review.sh.
+#
+set -euo pipefail
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$TOUCHSTONE_ROOT/hooks/codex-review.sh"
+
+if [ ! -x "$SCRIPT" ]; then
+  echo "FAIL: $SCRIPT not found or not executable" >&2
+  exit 1
+fi
+
+TEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/touchstone-test-reviewer-sentinel.XXXXXX")"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+ERRORS=0
+
+fail() {
+  echo "FAIL: $1" >&2
+  ERRORS=$((ERRORS + 1))
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local name="$3"
+  if ! printf '%s' "$haystack" | grep -Fq "$needle"; then
+    fail "$name: expected output to contain [$needle]"
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local name="$3"
+  if printf '%s' "$haystack" | grep -Fq "$needle"; then
+    fail "$name: expected output not to contain [$needle]"
+  fi
+}
+
+assert_empty() {
+  local value="$1"
+  local name="$2"
+  if [ -n "$value" ]; then
+    fail "$name: expected empty output, got [$value]"
+  fi
+}
+
+new_repo() {
+  local repo="$1"
+  mkdir -p "$repo"
+  git -C "$repo" init -q
+  git -C "$repo" config user.email t@t
+  git -C "$repo" config user.name t
+  printf 'init\n' > "$repo/README.md"
+  git -C "$repo" add README.md
+  git -C "$repo" commit -qm init
+}
+
+run_context_helper() {
+  local repo="$1"
+  local stdout_file="$TEST_DIR/stdout"
+  local stderr_file="$TEST_DIR/stderr"
+  (
+    cd "$repo"
+    CODEX_REVIEW_TEST_SENTINEL_CONTEXT=1 bash "$SCRIPT"
+  ) >"$stdout_file" 2>"$stderr_file"
+  CONTEXT_STDOUT="$(cat "$stdout_file")"
+  CONTEXT_STDERR="$(cat "$stderr_file")"
+}
+
+echo "==> reviewer sentinel context"
+
+echo "==> Test: detects_and_injects_journal"
+REPO_DETECT="$TEST_DIR/repo-detect"
+new_repo "$REPO_DETECT"
+mkdir -p "$REPO_DETECT/.sentinel/runs" "$REPO_DETECT/.cortex/journal"
+printf -- '---\ncycle-id: foo\n---\n' > "$REPO_DETECT/.sentinel/runs/run.md"
+cat > "$REPO_DETECT/.cortex/journal/20260428-sentinel-cycle-foo.md" <<'EOF'
+---
+title: Sentinel Cycle Foo
+---
+planner considered cached review behavior
+coder tried prompt injection
+rejected mid-cycle shortcut
+EOF
+run_context_helper "$REPO_DETECT"
+assert_contains "$CONTEXT_STDOUT" "<sentinel-cycle-context>" "detects_and_injects_journal"
+assert_contains "$CONTEXT_STDOUT" "planner considered cached review behavior" "detects_and_injects_journal"
+assert_contains "$CONTEXT_STDOUT" "</sentinel-cycle-context>" "detects_and_injects_journal"
+assert_empty "$CONTEXT_STDERR" "detects_and_injects_journal stderr"
+
+echo "==> Test: no_sentinel_no_injection"
+REPO_NONE="$TEST_DIR/repo-none"
+new_repo "$REPO_NONE"
+run_context_helper "$REPO_NONE"
+assert_empty "$CONTEXT_STDOUT" "no_sentinel_no_injection stdout"
+assert_empty "$CONTEXT_STDERR" "no_sentinel_no_injection stderr"
+
+echo "==> Test: sentinel_but_no_cortex"
+REPO_NO_CORTEX="$TEST_DIR/repo-no-cortex"
+new_repo "$REPO_NO_CORTEX"
+mkdir -p "$REPO_NO_CORTEX/.sentinel/runs"
+printf 'sentinel run\n' > "$REPO_NO_CORTEX/.sentinel/runs/run.md"
+run_context_helper "$REPO_NO_CORTEX"
+assert_empty "$CONTEXT_STDOUT" "sentinel_but_no_cortex stdout"
+assert_contains "$CONTEXT_STDERR" "no cycle journal entry found" "sentinel_but_no_cortex stderr"
+
+echo "==> Test: cycle_id_match_preferred_over_recency"
+REPO_CYCLE="$TEST_DIR/repo-cycle"
+new_repo "$REPO_CYCLE"
+mkdir -p "$REPO_CYCLE/.sentinel/runs" "$REPO_CYCLE/.cortex/journal"
+printf -- '---\ncycle-id: B\n---\n' > "$REPO_CYCLE/.sentinel/runs/run.md"
+printf 'journal A newer\n' > "$REPO_CYCLE/.cortex/journal/20260428-sentinel-cycle-A.md"
+printf 'journal B matched\n' > "$REPO_CYCLE/.cortex/journal/20260427-sentinel-cycle-B.md"
+touch -t 202604281200 "$REPO_CYCLE/.cortex/journal/20260428-sentinel-cycle-A.md"
+touch -t 202604271200 "$REPO_CYCLE/.cortex/journal/20260427-sentinel-cycle-B.md"
+run_context_helper "$REPO_CYCLE"
+assert_contains "$CONTEXT_STDOUT" "journal B matched" "cycle_id_match_preferred_over_recency"
+assert_not_contains "$CONTEXT_STDOUT" "journal A newer" "cycle_id_match_preferred_over_recency"
+
+echo "==> Test: malformed_journal_falls_back"
+REPO_MALFORMED="$TEST_DIR/repo-malformed"
+new_repo "$REPO_MALFORMED"
+mkdir -p "$REPO_MALFORMED/.sentinel/runs" "$REPO_MALFORMED/.cortex/journal"
+printf 'sentinel run\n' > "$REPO_MALFORMED/.sentinel/runs/run.md"
+printf 'unreadable journal\n' > "$REPO_MALFORMED/.cortex/journal/20260428-sentinel-cycle-bad.md"
+chmod 000 "$REPO_MALFORMED/.cortex/journal/20260428-sentinel-cycle-bad.md"
+run_context_helper "$REPO_MALFORMED"
+chmod 644 "$REPO_MALFORMED/.cortex/journal/20260428-sentinel-cycle-bad.md"
+assert_empty "$CONTEXT_STDOUT" "malformed_journal_falls_back stdout"
+assert_contains "$CONTEXT_STDERR" "could not be read" "malformed_journal_falls_back stderr"
+
+echo "==> Test: smoke prompt sent to conductor includes sentinel context"
+REPO_SMOKE="$TEST_DIR/repo-smoke"
+new_repo "$REPO_SMOKE"
+mkdir -p "$REPO_SMOKE/.sentinel/runs" "$REPO_SMOKE/.cortex/journal" "$TEST_DIR/bin"
+printf -- '---\ncycle-id: smoke\n---\n' > "$REPO_SMOKE/.sentinel/runs/run.md"
+printf 'smoke journal context\n' > "$REPO_SMOKE/.cortex/journal/20260428-sentinel-cycle-smoke.md"
+printf 'change\n' >> "$REPO_SMOKE/README.md"
+git -C "$REPO_SMOKE" add README.md
+git -C "$REPO_SMOKE" commit -qm change
+PROMPT_CAPTURE="$TEST_DIR/prompt.capture"
+cat > "$TEST_DIR/bin/conductor" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  doctor)
+    printf '{"providers":[{"configured":true}]}\n'
+    ;;
+  call|exec)
+    cat > "$PROMPT_CAPTURE"
+    printf 'LGTM\nCODEX_REVIEW_CLEAN\n'
+    ;;
+  *)
+    echo "unexpected conductor command: $1" >&2
+    exit 2
+    ;;
+esac
+EOF
+chmod +x "$TEST_DIR/bin/conductor"
+(
+  cd "$REPO_SMOKE"
+  PATH="$TEST_DIR/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+    PROMPT_CAPTURE="$PROMPT_CAPTURE" \
+    CODEX_REVIEW_FORCE=1 \
+    CODEX_REVIEW_BASE=HEAD~1 \
+    CODEX_REVIEW_MODE=diff-only \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    TOUCHSTONE_REVIEW_LOG=/dev/null \
+    bash "$SCRIPT" >/dev/null
+)
+SMOKE_PROMPT="$(cat "$PROMPT_CAPTURE")"
+assert_contains "$SMOKE_PROMPT" "<sentinel-cycle-context>" "smoke prompt"
+assert_contains "$SMOKE_PROMPT" "smoke journal context" "smoke prompt"
+assert_contains "$SMOKE_PROMPT" "You are reviewing AND optionally auto-fixing" "smoke prompt"
+
+if [ "$ERRORS" -ne 0 ]; then
+  echo "==> FAIL: $ERRORS reviewer sentinel context test(s) failed" >&2
+  exit 1
+fi
+
+echo "==> OK: reviewer sentinel context tests passed"


### PR DESCRIPTION
## Summary

When Touchstone's reviewer cascade reviews a sentinel-authored diff, prepend the cycle's journal entry from \`.cortex/journal/\` to the reviewer prompt under a \`<sentinel-cycle-context>\` fence. Reviewer sees the planner's reasoning, the coder's attempts, and mid-cycle rejections — not just the final diff and commit message.

Closes #87.

### What landed

- **\`hooks/codex-review.sh\` + \`scripts/codex-review.sh\` (synced)** — detection helpers (\`is_sentinel_authored_branch\`, \`find_latest_sentinel_journal_entry\`, \`get_cycle_id_from_run\`) + prompt-prepending logic.
- **\`tests/test-reviewer-sentinel-context.sh\`** — 5 cases including a fake-conductor prompt-capture smoke test:
  - detects + injects journal
  - no sentinel → no injection
  - sentinel but no cortex → no injection (warning logged)
  - cycle-id match preferred over recency
  - malformed journal falls back gracefully

### Detection convention

Same as #86 (PR #89): sentinel-authored branch identified by \`.sentinel/runs/*.md\`. Cycle-id matching preferred (using the \`cycle-id\` frontmatter field landing in autumngarage/sentinel#97); recency fallback for the transition window.

### Provenance

Implementation delegated via \`conductor exec --auto --tags strong-reasoning,tool-use --prefer best\` from autumn-garage. Routed to codex/gpt-5.4 (claude fallback). Session: ~6 min, ~2.2M input + 12k output tokens.

Helper duplication with #89 is intentional — copied locally to avoid a merge dependency. Cleanup PR after #89 merges will dedupe.

## Test plan

- [ ] CI green
- [ ] PR-body anchor consumer (#89) merged for the dedupe follow-up
- [ ] Cycle-id-preferred matching works against autumngarage/sentinel#97's schema once that lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)