### PR TITLE
chore: refresh touchstone + conductor 0.8.1 wiring

### DIFF
--- a/.cursor/rules/conductor-delegation.mdc
+++ b/.cursor/rules/conductor-delegation.mdc
@@ -1,0 +1,50 @@
+---
+description: Use when delegating or routing tasks to a different LLM via the conductor CLI — e.g., cheap second opinions, long-context reads, web search, or offline runs.
+globs: 
+alwaysApply: false
+managed-by: conductor v0.8.1
+---
+
+# Conductor delegation
+
+This project has [conductor](https://github.com/autumngarage/conductor)
+available — a CLI that dispatches work to other LLMs (Kimi, Gemini,
+Claude, Codex, Ollama) under a uniform interface.
+
+Use it when:
+- Quick factual/background ask:
+  `conductor ask --kind research --effort minimal --brief-file /tmp/brief.md`.
+- Deeper synthesis/research:
+  `conductor ask --kind research --effort medium --brief-file /tmp/brief.md`.
+- Code explanation or small coding judgment:
+  `conductor ask --kind code --effort low --brief-file /tmp/brief.md`.
+- Repo-changing implementation/debugging:
+  `conductor ask --kind code --effort high --brief-file /tmp/brief.md`.
+- Merge/PR/diff review:
+  `conductor ask --kind review --base <ref> --brief-file /tmp/review.md`.
+- You want multiple model perspectives:
+  `conductor ask --kind council --effort medium --brief-file /tmp/brief.md`.
+- You want a cheap second opinion (`conductor call --with kimi --brief "..."`).
+- You need fresh web information (`conductor call --with gemini --brief "..."`).
+- You want to stay local / offline (`conductor call --with ollama --brief "..."`).
+- You want a true read-only code review:
+  `conductor review --auto --base origin/main --brief-file /tmp/review.md`.
+- You're not sure which provider fits — let the router pick:
+  `conductor call --auto --tags <tag1>,<tag2> --brief "..."`.
+
+Conductor does not inherit your conversation context. Write a complete
+brief before delegating; for `exec`, prefer `--brief-file` with goal,
+context, scope, constraints, expected output, and validation.
+Default to `conductor ask`; use provider-specific `call` / `exec` only
+when the user explicitly asks for a provider or the semantic API does not
+fit.
+
+For longer running tool-using sessions:
+
+    conductor exec --with <provider> --tools Read,Edit,Bash \
+        --sandbox workspace-write --brief-file /tmp/conductor-brief.md
+
+Discover configured providers: `conductor list`.
+
+Full delegation guidance (when to delegate, when not to, error handling):
+`~/.conductor/delegation-guidance.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,3 +160,46 @@ Flag any of the following:
 4. **Tests** — do the self-tests pass?
 
 If there are zero blocking issues: "LGTM."
+
+<!-- conductor:begin v0.8.1 -->
+## Conductor delegation
+
+This project has [conductor](https://github.com/autumngarage/conductor)
+available for delegating tasks to other LLMs from inside an agent loop.
+You can shell out to it instead of trying to do everything yourself.
+
+Quick reference:
+
+- Quick factual/background ask:
+  `conductor ask --kind research --effort minimal --brief-file /tmp/brief.md`.
+- Deeper synthesis/research:
+  `conductor ask --kind research --effort medium --brief-file /tmp/brief.md`.
+- Code explanation or small coding judgment:
+  `conductor ask --kind code --effort low --brief-file /tmp/brief.md`.
+- Repo-changing implementation/debugging:
+  `conductor ask --kind code --effort high --brief-file /tmp/brief.md`.
+- Merge/PR/diff review:
+  `conductor ask --kind review --base <ref> --brief-file /tmp/review.md`.
+- Architecture/product judgment needing multiple views:
+  `conductor ask --kind council --effort medium --brief-file /tmp/brief.md`.
+- `conductor list` — show configured providers and their tags.
+
+Conductor does not inherit your conversation context. For delegation,
+write a complete brief with goal, context, scope, constraints, expected
+output, and validation; use `--brief-file` for nontrivial `exec` tasks.
+Default to `conductor ask`; use provider-specific `call` / `exec` only
+when the user explicitly asks for a provider or the semantic API does not
+fit.
+
+Providers commonly worth delegating to:
+
+- `kimi` — long-context summarization, cheap second opinions.
+- `gemini` — web search, multimodal.
+- `claude` / `codex` — strongest reasoning / coding agent loops.
+- `ollama` — local, offline, privacy-sensitive.
+- `council` kind — OpenRouter-only multi-model deliberation and synthesis.
+
+Full delegation guidance (when to delegate, when not to, error handling):
+
+    ~/.conductor/delegation-guidance.md
+<!-- conductor:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,3 +131,46 @@ Release flow:
 Required repo secret: `HOMEBREW_TAP_PAT` (classic PAT with `repo` scope on the tap, or fine-grained with `contents:write` on `autumngarage/homebrew-touchstone`).
 
 Do not call a Touchstone release complete until GitHub Releases, the Homebrew formula, `origin/main`, and the local brew install all agree on the same version.
+
+<!-- conductor:begin v0.8.1 -->
+## Conductor delegation
+
+This project has [conductor](https://github.com/autumngarage/conductor)
+available for delegating tasks to other LLMs from inside an agent loop.
+You can shell out to it instead of trying to do everything yourself.
+
+Quick reference:
+
+- Quick factual/background ask:
+  `conductor ask --kind research --effort minimal --brief-file /tmp/brief.md`.
+- Deeper synthesis/research:
+  `conductor ask --kind research --effort medium --brief-file /tmp/brief.md`.
+- Code explanation or small coding judgment:
+  `conductor ask --kind code --effort low --brief-file /tmp/brief.md`.
+- Repo-changing implementation/debugging:
+  `conductor ask --kind code --effort high --brief-file /tmp/brief.md`.
+- Merge/PR/diff review:
+  `conductor ask --kind review --base <ref> --brief-file /tmp/review.md`.
+- Architecture/product judgment needing multiple views:
+  `conductor ask --kind council --effort medium --brief-file /tmp/brief.md`.
+- `conductor list` — show configured providers and their tags.
+
+Conductor does not inherit your conversation context. For delegation,
+write a complete brief with goal, context, scope, constraints, expected
+output, and validation; use `--brief-file` for nontrivial `exec` tasks.
+Default to `conductor ask`; use provider-specific `call` / `exec` only
+when the user explicitly asks for a provider or the semantic API does not
+fit.
+
+Providers commonly worth delegating to:
+
+- `kimi` — long-context summarization, cheap second opinions.
+- `gemini` — web search, multimodal.
+- `claude` / `codex` — strongest reasoning / coding agent loops.
+- `ollama` — local, offline, privacy-sensitive.
+- `council` kind — OpenRouter-only multi-model deliberation and synthesis.
+
+Full delegation guidance (when to delegate, when not to, error handling):
+
+    ~/.conductor/delegation-guidance.md
+<!-- conductor:end -->

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -21,3 +21,46 @@ Drive this automatically unless the user asks for a different flow:
 5. If Conductor creates fix commits, let the loop finish. If it blocks, address findings, commit, and rerun until clean.
 6. Ship with `bash scripts/open-pr.sh --auto-merge`; this creates the PR, runs the final read-only Conductor merge review, squash-merges, and syncs the default branch.
 7. Clean up the feature branch if it still exists locally.
+
+<!-- conductor:begin v0.8.1 -->
+## Conductor delegation
+
+This project has [conductor](https://github.com/autumngarage/conductor)
+available for delegating tasks to other LLMs from inside an agent loop.
+You can shell out to it instead of trying to do everything yourself.
+
+Quick reference:
+
+- Quick factual/background ask:
+  `conductor ask --kind research --effort minimal --brief-file /tmp/brief.md`.
+- Deeper synthesis/research:
+  `conductor ask --kind research --effort medium --brief-file /tmp/brief.md`.
+- Code explanation or small coding judgment:
+  `conductor ask --kind code --effort low --brief-file /tmp/brief.md`.
+- Repo-changing implementation/debugging:
+  `conductor ask --kind code --effort high --brief-file /tmp/brief.md`.
+- Merge/PR/diff review:
+  `conductor ask --kind review --base <ref> --brief-file /tmp/review.md`.
+- Architecture/product judgment needing multiple views:
+  `conductor ask --kind council --effort medium --brief-file /tmp/brief.md`.
+- `conductor list` — show configured providers and their tags.
+
+Conductor does not inherit your conversation context. For delegation,
+write a complete brief with goal, context, scope, constraints, expected
+output, and validation; use `--brief-file` for nontrivial `exec` tasks.
+Default to `conductor ask`; use provider-specific `call` / `exec` only
+when the user explicitly asks for a provider or the semantic API does not
+fit.
+
+Providers commonly worth delegating to:
+
+- `kimi` — long-context summarization, cheap second opinions.
+- `gemini` — web search, multimodal.
+- `claude` / `codex` — strongest reasoning / coding agent loops.
+- `ollama` — local, offline, privacy-sensitive.
+- `council` kind — OpenRouter-only multi-model deliberation and synthesis.
+
+Full delegation guidance (when to delegate, when not to, error handling):
+
+    ~/.conductor/delegation-guidance.md
+<!-- conductor:end -->


### PR DESCRIPTION
Coordinated sweep across all autumn-garage tool repos and customer projects: refresh per-repo conductor wiring to v0.8.1 (sentinel-bounded delegation block in AGENTS.md / CLAUDE.md / GEMINI.md, managed Cursor rule), bump touchstone hooks/templates to 2.3.5.

Fully removable via `conductor init --unwire`.