### PR TITLE
fix(review): harden Conductor sentinel handshake

### DIFF
--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -98,13 +98,18 @@ extract_review_sentinel() {
       sentinel = line
       count++
     }
-    /^[[:space:]]*"response"[[:space:]]*:[[:space:]]*"CODEX_REVIEW_(CLEAN|FIXED|BLOCKED)(\\n)?"[[:space:]]*,?[[:space:]]*$/ {
+    /^[[:space:]]*"response"[[:space:]]*:/ {
       line = $0
       gsub(/\r/, "", line)
       sub(/^[[:space:]]*"response"[[:space:]]*:[[:space:]]*"/, "", line)
-      sub(/(\\n)?"[[:space:]]*,?[[:space:]]*$/, "", line)
-      sentinel = line
-      count++
+      while (match(line, /(^|\\n)CODEX_REVIEW_(CLEAN|FIXED|BLOCKED)(\\n|")/)) {
+        candidate = substr(line, RSTART, RLENGTH)
+        sub(/^\\n/, "", candidate)
+        sub(/(\\n|")$/, "", candidate)
+        sentinel = candidate
+        count++
+        line = substr(line, RSTART + RLENGTH)
+      }
     }
     END {
       if (count == 1) {
@@ -1184,10 +1189,10 @@ reviewer_conductor_exec() {
   # REVIEW_MODE → subcommand + tools + sandbox. Conductor translates these
   # portable names into each provider's native flag dialect.
   local tools sandbox
+  subcommand="$(conductor_subcommand_for_mode)"
   case "$REVIEW_MODE" in
     diff-only)
       # Single-turn call — the diff is already embedded in the prompt.
-      subcommand="call"
       ;;
     review-only)
       subcommand="exec"
@@ -1222,6 +1227,13 @@ reviewer_conductor_exec() {
   CODEX_REVIEW_IN_PROGRESS=1 \
     printf '%s' "$prompt" \
     | conductor "$subcommand" "${args[@]}"
+}
+
+conductor_subcommand_for_mode() {
+  case "$REVIEW_MODE" in
+    diff-only) printf 'call' ;;
+    *)         printf 'exec' ;;
+  esac
 }
 
 # --------------------------------------------------------------------------
@@ -1460,6 +1472,9 @@ handle_error() {
     log_skip_event conductor-error "fail-closed:${reason}"
     exit 1
   else
+    if [ "$reason" = "malformed sentinel" ]; then
+      echo "[review:fail-open] missing sentinel — policy permits merge but the review verdict is untrustworthy" >&2
+    fi
     echo "==> ERROR ($reason) — not blocking push (on_error=fail-open)."
     echo "    Set on_error = \"fail-closed\" in .codex-review.toml to block on errors."
     log_skip_event conductor-error "fail-open:${reason}"
@@ -1619,6 +1634,7 @@ If you emit CODEX_REVIEW_BLOCKED, list each blocking issue on its own line in th
 If you emit CODEX_REVIEW_FIXED, briefly describe what you fixed (one line per fix).
 
 Do not invent new sentinels. Do not output anything after the sentinel line.
+This is a strict gate contract: the very last physical line of the entire response must be exactly one sentinel token and nothing else.
 PROMPT_EOF
 
 # --------------------------------------------------------------------------
@@ -1991,6 +2007,29 @@ parse_primary_provider() {
   #   [conductor] auto (...) -> claude (tier: ...)
   # `sed -nE` treats `(a|b)` as ERE alternation.
   printf '%s' "$line" | sed -nE 's/.*(→|-> ?)([a-zA-Z0-9_.-]+).*/\2/p' | head -1
+}
+
+conductor_invocation_label() {
+  local conductor_path subcommand
+  conductor_path="$(command -v conductor 2>/dev/null || printf 'conductor')"
+  subcommand="$(conductor_subcommand_for_mode)"
+  printf '%s %s' "$conductor_path" "$subcommand"
+}
+
+print_malformed_sentinel_diagnostics() {
+  if [ "$ACTIVE_REVIEWER" != "conductor" ]; then
+    return 0
+  fi
+
+  local selected_provider
+  selected_provider="$(parse_primary_provider)"
+  if [ -z "$selected_provider" ] && [ -n "${CONDUCTOR_WITH:-}" ]; then
+    selected_provider="$CONDUCTOR_WITH"
+  fi
+  [ -n "$selected_provider" ] || selected_provider="unknown"
+
+  echo "    Conductor selected provider: $selected_provider"
+  echo "    Conductor command invoked: $(conductor_invocation_label)"
 }
 
 # Run a peer review via Conductor, excluding the primary's provider.
@@ -2436,6 +2475,7 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
       else
         echo "    No unique standalone sentinel line was found."
       fi
+      print_malformed_sentinel_diagnostics
       echo "    Last non-blank line was: '$LAST_LINE'"
       echo "    Raw output (first 20 lines):"
       printf '%s\n' "$OUTPUT" | head -20 | sed 's/^/    /'

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -98,13 +98,18 @@ extract_review_sentinel() {
       sentinel = line
       count++
     }
-    /^[[:space:]]*"response"[[:space:]]*:[[:space:]]*"CODEX_REVIEW_(CLEAN|FIXED|BLOCKED)(\\n)?"[[:space:]]*,?[[:space:]]*$/ {
+    /^[[:space:]]*"response"[[:space:]]*:/ {
       line = $0
       gsub(/\r/, "", line)
       sub(/^[[:space:]]*"response"[[:space:]]*:[[:space:]]*"/, "", line)
-      sub(/(\\n)?"[[:space:]]*,?[[:space:]]*$/, "", line)
-      sentinel = line
-      count++
+      while (match(line, /(^|\\n)CODEX_REVIEW_(CLEAN|FIXED|BLOCKED)(\\n|")/)) {
+        candidate = substr(line, RSTART, RLENGTH)
+        sub(/^\\n/, "", candidate)
+        sub(/(\\n|")$/, "", candidate)
+        sentinel = candidate
+        count++
+        line = substr(line, RSTART + RLENGTH)
+      }
     }
     END {
       if (count == 1) {
@@ -1184,10 +1189,10 @@ reviewer_conductor_exec() {
   # REVIEW_MODE → subcommand + tools + sandbox. Conductor translates these
   # portable names into each provider's native flag dialect.
   local tools sandbox
+  subcommand="$(conductor_subcommand_for_mode)"
   case "$REVIEW_MODE" in
     diff-only)
       # Single-turn call — the diff is already embedded in the prompt.
-      subcommand="call"
       ;;
     review-only)
       subcommand="exec"
@@ -1222,6 +1227,13 @@ reviewer_conductor_exec() {
   CODEX_REVIEW_IN_PROGRESS=1 \
     printf '%s' "$prompt" \
     | conductor "$subcommand" "${args[@]}"
+}
+
+conductor_subcommand_for_mode() {
+  case "$REVIEW_MODE" in
+    diff-only) printf 'call' ;;
+    *)         printf 'exec' ;;
+  esac
 }
 
 # --------------------------------------------------------------------------
@@ -1460,6 +1472,9 @@ handle_error() {
     log_skip_event conductor-error "fail-closed:${reason}"
     exit 1
   else
+    if [ "$reason" = "malformed sentinel" ]; then
+      echo "[review:fail-open] missing sentinel — policy permits merge but the review verdict is untrustworthy" >&2
+    fi
     echo "==> ERROR ($reason) — not blocking push (on_error=fail-open)."
     echo "    Set on_error = \"fail-closed\" in .codex-review.toml to block on errors."
     log_skip_event conductor-error "fail-open:${reason}"
@@ -1619,6 +1634,7 @@ If you emit CODEX_REVIEW_BLOCKED, list each blocking issue on its own line in th
 If you emit CODEX_REVIEW_FIXED, briefly describe what you fixed (one line per fix).
 
 Do not invent new sentinels. Do not output anything after the sentinel line.
+This is a strict gate contract: the very last physical line of the entire response must be exactly one sentinel token and nothing else.
 PROMPT_EOF
 
 # --------------------------------------------------------------------------
@@ -1991,6 +2007,29 @@ parse_primary_provider() {
   #   [conductor] auto (...) -> claude (tier: ...)
   # `sed -nE` treats `(a|b)` as ERE alternation.
   printf '%s' "$line" | sed -nE 's/.*(→|-> ?)([a-zA-Z0-9_.-]+).*/\2/p' | head -1
+}
+
+conductor_invocation_label() {
+  local conductor_path subcommand
+  conductor_path="$(command -v conductor 2>/dev/null || printf 'conductor')"
+  subcommand="$(conductor_subcommand_for_mode)"
+  printf '%s %s' "$conductor_path" "$subcommand"
+}
+
+print_malformed_sentinel_diagnostics() {
+  if [ "$ACTIVE_REVIEWER" != "conductor" ]; then
+    return 0
+  fi
+
+  local selected_provider
+  selected_provider="$(parse_primary_provider)"
+  if [ -z "$selected_provider" ] && [ -n "${CONDUCTOR_WITH:-}" ]; then
+    selected_provider="$CONDUCTOR_WITH"
+  fi
+  [ -n "$selected_provider" ] || selected_provider="unknown"
+
+  echo "    Conductor selected provider: $selected_provider"
+  echo "    Conductor command invoked: $(conductor_invocation_label)"
 }
 
 # Run a peer review via Conductor, excluding the primary's provider.
@@ -2436,6 +2475,7 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
       else
         echo "    No unique standalone sentinel line was found."
       fi
+      print_malformed_sentinel_diagnostics
       echo "    Last non-blank line was: '$LAST_LINE'"
       echo "    Raw output (first 20 lines):"
       printf '%s\n' "$OUTPUT" | head -20 | sed 's/^/    /'

--- a/tests/test-codex-review-sentinel.sh
+++ b/tests/test-codex-review-sentinel.sh
@@ -19,6 +19,8 @@ set -euo pipefail
 
 TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SCRIPT="$TOUCHSTONE_ROOT/hooks/codex-review.sh"
+TEST_DIR="$(mktemp -d -t touchstone-test-codex-review-sentinel.XXXXXX)"
+trap 'rm -rf "$TEST_DIR"' EXIT
 
 if [ ! -x "$SCRIPT" ]; then
   echo "FAIL: $SCRIPT not found or not executable" >&2
@@ -90,8 +92,13 @@ assert_detector \
   ""
 
 assert_detector \
-  "JSON response wrapper with prose rejected" \
+  "JSON response wrapper with escaped-line sentinel" \
   $'{\n  "response": "Summary\\nCODEX_REVIEW_CLEAN\\n"\n}\n' \
+  "CODEX_REVIEW_CLEAN"
+
+assert_detector \
+  "JSON response wrapper with inline sentinel rejected" \
+  $'{\n  "response": "Summary CODEX_REVIEW_CLEAN"\n}\n' \
   ""
 
 # Multiple sentinel lines are ambiguous — the reviewer either changed
@@ -110,3 +117,103 @@ assert_detector \
   ""
 
 echo "==> OK: all sentinel tests passed"
+
+echo "==> codex-review malformed-sentinel gate behavior"
+
+REPO_DIR="$TEST_DIR/repo"
+FAKE_BIN="$TEST_DIR/bin"
+PROMPT_FILE="$TEST_DIR/review-prompt.txt"
+CLOSED_OUTPUT="$TEST_DIR/fail-closed-output.txt"
+OPEN_OUTPUT="$TEST_DIR/fail-open-output.txt"
+
+mkdir -p "$REPO_DIR" "$FAKE_BIN"
+git -C "$REPO_DIR" init >/dev/null 2>&1
+git -C "$REPO_DIR" config user.name "Touchstone Test"
+git -C "$REPO_DIR" config user.email "touchstone@example.com"
+printf 'base\n' > "$REPO_DIR/example.txt"
+git -C "$REPO_DIR" add example.txt
+git -C "$REPO_DIR" commit -m "base" >/dev/null 2>&1
+printf 'changed\n' >> "$REPO_DIR/example.txt"
+git -C "$REPO_DIR" add example.txt
+git -C "$REPO_DIR" commit -m "change" >/dev/null 2>&1
+
+cat > "$FAKE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "main"
+EOF
+
+cat > "$FAKE_BIN/conductor" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "doctor" ]; then
+  printf '{"providers":[{"configured":true}]}\n'
+  exit 0
+fi
+cat > "$PROMPT_FILE"
+printf '[conductor] auto (prefer=best, effort=max) -> codex (tier: frontier)\n' >&2
+printf 'No blocking issues were found in the diff.\n'
+printf 'The changes look safe to merge.\n'
+EOF
+chmod +x "$FAKE_BIN/gh" "$FAKE_BIN/conductor"
+
+set +e
+(
+  cd "$REPO_DIR"
+  PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    PROMPT_FILE="$PROMPT_FILE" \
+    TOUCHSTONE_REVIEW_LOG=/dev/null \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    CODEX_REVIEW_ON_ERROR=fail-closed \
+    bash "$SCRIPT" > "$CLOSED_OUTPUT" 2>&1
+)
+CLOSED_EXIT=$?
+set -e
+
+if [ "$CLOSED_EXIT" -eq 1 ] \
+  && grep -q 'No unique standalone sentinel line was found.' "$CLOSED_OUTPUT" \
+  && grep -q 'Conductor selected provider: codex' "$CLOSED_OUTPUT" \
+  && grep -q "Conductor command invoked: $FAKE_BIN/conductor exec" "$CLOSED_OUTPUT"; then
+  printf '  OK: missing sentinel blocks under fail-closed policy with provider diagnostics\n'
+else
+  printf 'FAIL: missing sentinel should block with provider and command diagnostics\n' >&2
+  printf 'exit code: %s\n' "$CLOSED_EXIT" >&2
+  cat "$CLOSED_OUTPUT" >&2
+  exit 1
+fi
+
+set +e
+(
+  cd "$REPO_DIR"
+  PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    PROMPT_FILE="$PROMPT_FILE" \
+    TOUCHSTONE_REVIEW_LOG=/dev/null \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    CODEX_REVIEW_ON_ERROR=fail-open \
+    bash "$SCRIPT" > "$OPEN_OUTPUT" 2>&1
+)
+OPEN_EXIT=$?
+set -e
+
+if [ "$OPEN_EXIT" -eq 0 ] \
+  && grep -q 'No unique standalone sentinel line was found.' "$OPEN_OUTPUT" \
+  && grep -q '\[review:fail-open\] missing sentinel — policy permits merge but the review verdict is untrustworthy' "$OPEN_OUTPUT"; then
+  printf '  OK: missing sentinel fail-opens only with visible warning under fail-open policy\n'
+else
+  printf 'FAIL: missing sentinel should visibly warn under fail-open policy\n' >&2
+  printf 'exit code: %s\n' "$OPEN_EXIT" >&2
+  cat "$OPEN_OUTPUT" >&2
+  exit 1
+fi
+
+if grep -q 'very last physical line of the entire response must be exactly one sentinel token' "$PROMPT_FILE"; then
+  printf '  OK: reviewer prompt states the strict final-line sentinel contract\n'
+else
+  printf 'FAIL: prompt did not include strict final-line sentinel contract\n' >&2
+  sed -n '1,220p' "$PROMPT_FILE" >&2
+  exit 1
+fi
+
+echo "==> OK: malformed-sentinel gate behavior passed"


### PR DESCRIPTION
Closes #97.

When Conductor delegates merge review to a provider that returns clean
prose with no sentinel, the gate previously had two failure modes:
fail-closed blocked merges with thin diagnostics, and fail-open let the
merge through silently with no record that the review verdict was
untrustworthy. Both are bad — the first frustrates legitimate clean
merges, the second loses the safety boundary without making the loss
visible.

Changes:

- Tighten the reviewer prompt to declare a strict gate contract: the
  very last physical line of the response must be exactly one sentinel
  token. This narrows the contract Conductor is asked to honor.
- Loosen JSON-wrapper sentinel parsing so escaped-line sentinels inside
  a `response` value are extracted (the inline-prose case is still
  rejected as ambiguous).
- On malformed sentinel, print the selected Conductor provider and the
  exact `conductor <subcommand>` command path, so operators can tell
  Conductor wrapper issues from provider-native review behavior.
- Under fail-open policy, emit a visible
  `[review:fail-open] missing sentinel — policy permits merge but the
  review verdict is untrustworthy` warn line so the loss of safety is
  never silent.
- Regression tests for: fail-closed block + diagnostics, fail-open
  visible warning, and prompt strict-contract content.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
