### PR TITLE
feat: agent-swarm worktree defaults + spawn/cleanup helpers

### DIFF
--- a/.touchstone-manifest
+++ b/.touchstone-manifest
@@ -5,6 +5,7 @@
 .claude/skills/touchstone-agent-swarms/SKILL.md
 .claude/skills/touchstone-audit-weak-points/SKILL.md
 .claude/skills/touchstone-audit/SKILL.md
+principles/agent-swarms.md
 principles/audit-weak-points.md
 principles/documentation-ownership.md
 principles/engineering-principles.md
@@ -13,9 +14,11 @@ principles/pre-implementation-checklist.md
 principles/README.md
 scripts/branch-guard.sh
 scripts/cleanup-branches.sh
+scripts/cleanup-worktrees.sh
 scripts/codex-review.sh
 scripts/emergency-disclosure.sh
 scripts/merge-pr.sh
 scripts/open-pr.sh
 scripts/run-pytest-in-venv.sh
+scripts/spawn-worktree.sh
 scripts/touchstone-run.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ Full rationale, worked examples, and the *why* behind each rule:
 - `principles/pre-implementation-checklist.md`
 - `principles/documentation-ownership.md`
 - `principles/git-workflow.md`
+- `principles/agent-swarms.md`
 
 ## Required Delivery Workflow
 
@@ -62,6 +63,7 @@ You are maintaining a shared engineering platform that provides universal princi
 - Keep changes logically grouped. Stage explicit file paths, commit with a concise message, and avoid unrelated refactors.
 - Before shipping, run `CODEX_REVIEW_FORCE=1 bash scripts/codex-review.sh` from a clean worktree to ask Conductor for review and safe auto-fixes. If Conductor commits fixes, let the loop finish; if it blocks, address the findings, commit, and rerun until clean.
 - To ship a completed branch, use `bash scripts/open-pr.sh --auto-merge`; it pushes, creates the PR, runs the final read-only Conductor merge review, squash-merges, and syncs the default branch.
+- File-writing subagents use isolated worktrees by default. Follow `principles/agent-swarms.md` for slice manifests, file ownership, concurrency caps, and cleanup; use `scripts/spawn-worktree.sh` and `scripts/cleanup-worktrees.sh` for local setup and teardown.
 
 ### Touchstone-Specific Rules
 
@@ -100,6 +102,13 @@ touchstone/
 ├── prototypes/     # Throwaway design experiments (e.g. UI banners) — not shipped to projects
 └── tests/          # Self-tests for bootstrap and update flows
 ```
+
+### Key Helper Scripts
+
+| File | Purpose |
+|------|---------|
+| `scripts/spawn-worktree.sh` | Create an isolated branch/worktree for parallel file-writing agent slices |
+| `scripts/cleanup-worktrees.sh` | Dry-run-first cleanup for clean merged-or-equivalent worktrees |
 
 ## Review Guide
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,10 +29,12 @@ Non-negotiable. Every code change is reviewed against them. Full rationale, work
 - **Make irreversible actions recoverable** — destructive operations need dry-run, backup, idempotency, rollback, or forward-fix plan before they run.
 - **Preserve compatibility at boundaries** — public API/config/schema/CLI/hook/template changes need a compatibility or migration plan.
 - **Audit weak-point classes** — find a structural bug → audit the class + add a guardrail. Use the `touchstone-audit-weak-points` skill.
+- **Isolate file-writing subagents** — parallel workers use dedicated worktrees, slice manifests, and disjoint file ownership by default.
 
 @principles/engineering-principles.md
 @principles/pre-implementation-checklist.md
 @principles/documentation-ownership.md
+@principles/agent-swarms.md
 
 ## Git Workflow
 
@@ -54,6 +56,7 @@ Every change — including one-liners, doc tweaks, and version bumps — starts 
 ### Housekeeping
 
 - Concise commit messages. Logically grouped changes.
+- File-writing subagents use isolated worktrees by default. Follow `principles/agent-swarms.md`; use `scripts/spawn-worktree.sh` and `scripts/cleanup-worktrees.sh` for local setup and teardown.
 - Run `/compact` at ~50% context. Start fresh sessions for unrelated work.
 
 ### Memory Hygiene
@@ -68,6 +71,7 @@ Every change — including one-liners, doc tweaks, and version bumps — starts 
 - **Changes propagate.** Every file in `principles/`, `hooks/`, and `scripts/` gets copied into downstream projects by `update-project.sh`. Updates must happen on a clean git worktree and land as a `chore/touchstone-*` branch commit, not as orphaned dirty files. Test changes here before syncing.
 - **Templates are starting points.** Files in `templates/` are copied once at bootstrap time and then owned by the project. Changes to templates only affect *new* projects.
 - **Self-tests are mandatory.** Run every `tests/test-*.sh` script before pushing. These validate the bootstrap, update, hook, merge, and helper flows end-to-end.
+- **Parallel agent work is isolated.** Use `principles/agent-swarms.md` for slice manifests and parent orchestration. Use `scripts/spawn-worktree.sh` to create branch/worktree slices and `scripts/cleanup-worktrees.sh` for dry-run-first teardown.
 - **Release completeness.** A touchstone release is not done until GitHub Releases, the Homebrew tap, `origin/main`, and the locally installed brew package all agree on the same version.
 
 ## Testing
@@ -108,6 +112,8 @@ touchstone/
 | `bootstrap/update-project.sh` | Pull latest touchstone files into an existing project |
 | `bootstrap/sync-all.sh` | Update all registered projects at once |
 | `hooks/codex-review.sh` | Conductor-backed AI merge/default-branch review + auto-fix hook |
+| `scripts/spawn-worktree.sh` | Create an isolated branch/worktree for parallel file-writing agent slices |
+| `scripts/cleanup-worktrees.sh` | Dry-run-first cleanup for clean merged-or-equivalent worktrees |
 | `lib/release.sh` | Release automation for GitHub Releases and the Homebrew tap |
 | `VERSION` | Current semver version |
 | `~/.touchstone-projects` | Registry of all bootstrapped projects |

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -22,6 +22,10 @@ Drive this automatically unless the user asks for a different flow:
 6. Ship with `bash scripts/open-pr.sh --auto-merge`; this creates the PR, runs the final read-only Conductor merge review, squash-merges, and syncs the default branch.
 7. Clean up the feature branch if it still exists locally.
 
+## Parallel Agent Work
+
+File-writing subagents use isolated worktrees by default. Follow `principles/agent-swarms.md` for slice manifests, file ownership, concurrency caps, and parent orchestration. Use `scripts/spawn-worktree.sh` to create local branch/worktree slices and `scripts/cleanup-worktrees.sh` for dry-run-first teardown.
+
 <!-- conductor:begin v0.8.2 -->
 ## Conductor delegation
 

--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -987,6 +987,8 @@ write_touchstone_manifest() {
     printf 'scripts/open-pr.sh\n'
     printf 'scripts/merge-pr.sh\n'
     printf 'scripts/cleanup-branches.sh\n'
+    printf 'scripts/spawn-worktree.sh\n'
+    printf 'scripts/cleanup-worktrees.sh\n'
     if [ "$INPUT_TYPE" = "python" ]; then
       printf 'scripts/run-pytest-in-venv.sh\n'
     fi
@@ -1233,6 +1235,8 @@ copy_file_force "$TOUCHSTONE_ROOT/scripts/touchstone-run.sh" "$PROJECT_DIR/scrip
 copy_file_force "$TOUCHSTONE_ROOT/scripts/open-pr.sh" "$PROJECT_DIR/scripts/open-pr.sh"
 copy_file_force "$TOUCHSTONE_ROOT/scripts/merge-pr.sh" "$PROJECT_DIR/scripts/merge-pr.sh"
 copy_file_force "$TOUCHSTONE_ROOT/scripts/cleanup-branches.sh" "$PROJECT_DIR/scripts/cleanup-branches.sh"
+copy_file_force "$TOUCHSTONE_ROOT/scripts/spawn-worktree.sh" "$PROJECT_DIR/scripts/spawn-worktree.sh"
+copy_file_force "$TOUCHSTONE_ROOT/scripts/cleanup-worktrees.sh" "$PROJECT_DIR/scripts/cleanup-worktrees.sh"
 chmod +x "$PROJECT_DIR/scripts/"*.sh
 
 # Claude Code settings — wires the branch-guard and emergency-disclosure

--- a/bootstrap/update-project.sh
+++ b/bootstrap/update-project.sh
@@ -346,6 +346,8 @@ update_file "$TOUCHSTONE_ROOT/scripts/touchstone-run.sh" "$PROJECT_DIR/scripts/t
 update_file "$TOUCHSTONE_ROOT/scripts/open-pr.sh" "$PROJECT_DIR/scripts/open-pr.sh"
 update_file "$TOUCHSTONE_ROOT/scripts/merge-pr.sh" "$PROJECT_DIR/scripts/merge-pr.sh"
 update_file "$TOUCHSTONE_ROOT/scripts/cleanup-branches.sh" "$PROJECT_DIR/scripts/cleanup-branches.sh"
+update_file "$TOUCHSTONE_ROOT/scripts/spawn-worktree.sh" "$PROJECT_DIR/scripts/spawn-worktree.sh"
+update_file "$TOUCHSTONE_ROOT/scripts/cleanup-worktrees.sh" "$PROJECT_DIR/scripts/cleanup-worktrees.sh"
 
 if [ "$PROJECT_TYPE" = "python" ] || [ -f "$PROJECT_DIR/scripts/run-pytest-in-venv.sh" ]; then
   update_file "$TOUCHSTONE_ROOT/scripts/run-pytest-in-venv.sh" "$PROJECT_DIR/scripts/run-pytest-in-venv.sh"
@@ -490,6 +492,8 @@ write_touchstone_manifest() {
     printf 'scripts/open-pr.sh\n'
     printf 'scripts/merge-pr.sh\n'
     printf 'scripts/cleanup-branches.sh\n'
+    printf 'scripts/spawn-worktree.sh\n'
+    printf 'scripts/cleanup-worktrees.sh\n'
     if [ "$PROJECT_TYPE" = "python" ] || [ -f "$PROJECT_DIR/scripts/run-pytest-in-venv.sh" ]; then
       printf 'scripts/run-pytest-in-venv.sh\n'
     fi

--- a/lib/agents-principles-block.sh
+++ b/lib/agents-principles-block.sh
@@ -62,6 +62,7 @@ Full rationale, worked examples, and the *why* behind each rule:
 - `principles/pre-implementation-checklist.md`
 - `principles/documentation-ownership.md`
 - `principles/git-workflow.md`
+- `principles/agent-swarms.md`
 
 ## Required Delivery Workflow
 

--- a/principles/README.md
+++ b/principles/README.md
@@ -9,3 +9,4 @@ Universal engineering standards that apply to all projects. These are imported b
 | [audit-weak-points.md](audit-weak-points.md) | Methodology for auditing structural bug patterns |
 | [documentation-ownership.md](documentation-ownership.md) | Single canonical owner per volatile fact |
 | [git-workflow.md](git-workflow.md) | Feature branch lifecycle with merge/default-branch review |
+| [agent-swarms.md](agent-swarms.md) | Worktree-isolated parallel agent workflow, slice manifests, and cleanup rules |

--- a/principles/agent-swarms.md
+++ b/principles/agent-swarms.md
@@ -1,0 +1,223 @@
+# Agent Swarms And Worktrees
+
+Agent swarms are useful only when the work is truly separable. The default
+coordination primitive is an isolated git worktree per file-writing worker:
+one checkout, one branch, one bounded file surface, one report back to the
+parent. A flat shared checkout is the exception and should be explicitly
+waived.
+
+## When To Spawn Worktrees
+
+Use one branch in the main checkout when the change is small or conceptually
+tight:
+
+- 1-3 files
+- one concept or one bug
+- one test surface
+- edits that need continuous judgment across the same files
+
+Use 2-4 worktrees when the work spans separable modules:
+
+- 4-12 files split across clear ownership boundaries
+- independent implementation slices with disjoint file sets
+- each slice can run focused tests without waiting on the others
+- the parent can integrate the final state without redesigning the work
+
+Use many worktrees only for broad repeated migrations:
+
+- the pattern is mechanical and already understood
+- slices are listed in a manifest before launch
+- each worker owns a narrow directory or file set
+- shared files are held back for the parent
+- automated PR fan-out or review routing exists
+
+Disjoint file sets are the prerequisite. If two workers need the same file,
+schema, generated index, lockfile, changelog, version file, or release note,
+they are not parallel for that part of the work. Sequence the overlapping edit
+or assign it to the parent.
+
+## The Slice Manifest
+
+Write the manifest before fan-out. It is the parent-owned contract that keeps
+parallel work from becoming unreviewable shared state.
+
+Each worker gets:
+
+- **Name**: stable label used in prompts, branches, and status updates.
+- **Branch**: unique `<type>/<slug>` branch. Never share a branch across
+  worktrees.
+- **Worktree path**: explicit directory, usually `../<repo>-<slug>`.
+- **Files allowed**: files or directories the worker may edit.
+- **Files forbidden**: shared files the worker must not touch.
+- **Tests/validation**: exact commands or manual checks for the slice.
+- **Expected output**: changed paths, commit SHA, tests run, and blockers.
+
+Example:
+
+| Worker | Branch | Worktree | Files allowed | Files forbidden | Validation | Output |
+|--------|--------|----------|---------------|-----------------|------------|--------|
+| auth-api | `feat/auth-api-slice` | `../app-auth-api` | `src/auth/**`, `tests/auth/**` | `package-lock.json`, `schema.sql`, `CHANGELOG.md` | `npm test -- auth` | changed paths, commit SHA, test result |
+| billing-ui | `feat/billing-ui-slice` | `../app-billing-ui` | `src/billing/**`, `tests/billing/**` | `package-lock.json`, `routes.generated.ts`, `CHANGELOG.md` | `npm test -- billing` | changed paths, commit SHA, test result |
+| docs-pass | `docs/swarm-docs-slice` | `../app-swarm-docs` | `docs/billing.md`, `docs/auth.md` | `CHANGELOG.md`, version files | `npm run docs:check` | changed paths, commit SHA, test result |
+
+YAML form is fine when the manifest needs comments:
+
+```yaml
+slices:
+  - name: auth-api
+    branch: feat/auth-api-slice
+    worktree: ../app-auth-api
+    files_allowed:
+      - src/auth/**
+      - tests/auth/**
+    files_forbidden:
+      - package-lock.json
+      - schema.sql
+      - CHANGELOG.md
+    validation:
+      - npm test -- auth
+    expected_output:
+      - changed paths
+      - commit SHA
+      - test results
+      - blockers
+```
+
+The manifest is not a suggestion. If a worker discovers it needs a forbidden
+file, it reports the need and stops that part of the work. The parent decides
+whether to edit the shared file centrally, revise the manifest, or sequence a
+follow-up slice.
+
+## Parent Orchestration Rules
+
+The parent session owns the coordination boundary:
+
+- creates or approves the slice manifest
+- spawns worktrees with `scripts/spawn-worktree.sh`
+- owns shared files: lockfiles, schemas, generated indexes, changelogs,
+  version files, route manifests, API indexes, and release notes
+- integrates worker outputs
+- runs final deterministic tests
+- invokes the final review path
+- opens or routes PRs
+- cleans up worktrees with `scripts/cleanup-worktrees.sh`
+
+Workers own only their slice:
+
+- edit allowed files only
+- never edit forbidden files
+- commit only their slice
+- run the slice validation
+- report changed paths, commit SHA, tests run, and blockers
+- leave integration and shared-file changes to the parent
+
+Default to one PR per worker when slices are independently shippable. Use an
+aggregate PR when the feature only makes sense as a unit, when shared files
+must be updated centrally, or when reviewers need one coherent story.
+
+## Concurrency Cap
+
+Parallel work has real coordination cost.
+
+- **Solo human supervising**: 3-5 concurrent worktrees.
+- **Parent-agent supervised**: 4-6 concurrent worktrees.
+- **10+ workers**: only with a manifest, automated PR fan-out, and automated
+  status collection.
+
+Higher numbers do not come for free. Every extra worker adds review load,
+branch state, test output, and cleanup responsibility. If the parent cannot
+name the current state of every slice, the swarm is too large.
+
+## Anti-Coordination Rules
+
+These rules prevent hidden shared state:
+
+- No `git stash` as a coordination mechanism.
+- No worker edits another worker's files.
+- No worker waits on another worker's in-flight result.
+- No shared branch across worktrees.
+- No worker-owned edits to shared files.
+- No checkpoint commits in review artifacts.
+
+Local recovery commits are allowed while a worker is exploring. Pushed `WIP:`,
+`checkpoint`, or deliberately broken commits do not belong on review branches.
+Squash or fix them before opening or marking a PR ready.
+
+## Worktree Hygiene
+
+Use the helper scripts when they are available:
+
+```bash
+bash scripts/spawn-worktree.sh feat/my-slice
+bash scripts/cleanup-worktrees.sh
+bash scripts/cleanup-worktrees.sh --execute
+```
+
+`scripts/spawn-worktree.sh` creates a new branch in an isolated worktree and
+copies explicitly allowlisted ignored local files from `.worktreeinclude`.
+
+`scripts/cleanup-worktrees.sh` is dry-run by default. It lists worktrees,
+checks dirty status, verifies merged-or-equivalent branches, previews
+`git worktree prune`, and removes only clean candidates when asked to execute.
+
+Rules:
+
+- never `git worktree remove --force` another agent's tree
+- never `git gc --prune=now` while sibling worktrees are active
+- never share one branch across multiple worktrees
+- never delete the main worktree from a cleanup script
+- never remove a dirty worktree unless the owner explicitly abandons it
+
+## The Untracked-File Problem
+
+Git worktrees contain tracked files. They do not bring along `.env`, local
+config, generated certificates, dependency directories, editor state, or other
+ignored local files.
+
+Use `.worktreeinclude` to allowlist ignored files that should be copied into
+new worktrees. The file uses gitignore-style patterns. Blank lines and `#`
+comments are ignored. Only ignored files should be copied; tracked files are
+already present in the worktree.
+
+Example:
+
+```gitignore
+# Local non-secret config needed for tests
+.env.test
+config/local.dev.json
+certs/dev/*.pem
+```
+
+Do not auto-copy secrets without explicit opt-in. If a secret is needed, the
+person or agent launching the worker must name it in `.worktreeinclude` and
+understand that it will be duplicated into another directory.
+
+Never symlink dependency or build artifact directories across worktrees:
+
+- `node_modules`
+- `.venv`
+- `target`
+- `.next`
+- `dist`
+- `build`
+
+Those directories carry platform artifacts, absolute shebangs, interpreter
+paths, lock state, and installer side effects. Sharing them across concurrent
+worktrees can corrupt installs or make tests pass for the wrong checkout.
+Recreate dependencies per worktree or use the project's normal setup command.
+
+If `scripts/setup-worktree-local.sh` exists, `scripts/spawn-worktree.sh` runs
+it from inside the new worktree. That hook is project-owned. Touchstone does
+not ship a default one because local setup varies by stack.
+
+## Cloud And Vendor Parallel
+
+Cloud agents use the same primitive under different names: isolated checkout,
+branch, validation, and PR. Claude Code supports agent isolation with
+worktrees, Codex cloud tasks run in isolated sandboxes, and Cursor background
+agents use separate branches and review artifacts. Local git worktrees are the
+cross-stack version of that model.
+
+The invariant is the same everywhere: file-writing workers do not share a
+mutable checkout. They return a branch, a diff, tests, and any blockers to the
+parent.

--- a/principles/git-workflow.md
+++ b/principles/git-workflow.md
@@ -26,9 +26,10 @@ The three layers are complementary — the local hook catches the honest mistake
 
 1. **Pull.** `git pull --rebase` on the default branch before starting work.
 2. **Branch — before any edit that might become a commit.** `git checkout -b <type>/<short-description>` where `<type>` is one of `feat`, `fix`, `chore`, `refactor`, `docs`. Do this as step one of the work, not as a cleanup step later. The check is `git branch --show-current` *before your first edit* — see "Never commit on the default branch" above for why edit time and not commit time.
-3. **Loop: change → commit → push.** Each meaningful sub-task gets its own commit and push. Stage explicit file paths (not `git add -A`), write a concise message, push to the open branch. Don't batch a session's worth of changes into one commit at the end — see the "Commit and push frequency" section below.
-4. **Ship.** `scripts/open-pr.sh --auto-merge` pushes, creates the PR, runs the final read-only Conductor merge review, squash-merges after a clean review, deletes the remote branch, and pulls the updated default branch — all in one command. Use `scripts/open-pr.sh` (without `--auto-merge`) if you want to open the PR without merging.
-5. **Clean up.** Delete the local feature branch. Run `scripts/cleanup-branches.sh` periodically for batch hygiene.
+3. **Check the tree before changing it.** Run `git status --short` and `git branch --show-current` before starting implementation. If the tree is dirty with unrelated user changes, do not stash them and do not auto-commit on the user's behalf. Ask how to proceed, or branch around the changes when the file surfaces are disjoint. `git stash` is hidden multi-agent state, not a coordination mechanism.
+4. **Loop: change → commit → push.** Each meaningful sub-task gets its own commit and push. Stage explicit file paths (not `git add -A`), write a concise message, push to the open branch. Don't batch a session's worth of changes into one commit at the end — see the "Commit and push frequency" section below.
+5. **Ship.** `scripts/open-pr.sh --auto-merge` pushes, creates the PR, runs the final read-only Conductor merge review, squash-merges after a clean review, deletes the remote branch, and pulls the updated default branch — all in one command. Use `scripts/open-pr.sh` (without `--auto-merge`) if you want to open the PR without merging.
+6. **Clean up.** Delete the local feature branch. Run `scripts/cleanup-branches.sh` periodically for batch hygiene.
 
 ## Commit discipline
 
@@ -48,7 +49,9 @@ The three layers are complementary — the local hook catches the honest mistake
 
 **Cadence guidance.** A useful rhythm for a focused work session is something like one commit per 30–60 minutes — about as often as you'd take a sip of water. If a session goes longer than that without a commit, ask whether you've passed a clean stopping point and didn't notice. If you can describe what you just finished in one sentence, that's a commit.
 
-**When *not* to commit.** Two cases: (1) a half-finished thought where the code is in a deliberately-broken intermediate state — squash that into a single sensible commit before pushing, or use `git stash` to set it aside; (2) actively-iterating exploration where commits would just be noise — fine to keep working, but reset the timer once you've found the right shape and start committing as you build out from there.
+**When *not* to commit.** Two cases: (1) a half-finished thought where the code is in a deliberately-broken intermediate state — squash that into a single sensible commit before pushing; (2) actively-iterating exploration where commits would just be noise — fine to keep working, but reset the timer once you've found the right shape and start committing as you build out from there.
+
+**No checkpoint commits in review artifacts.** Local recovery commits are fine when they keep an experiment recoverable, but pushed `WIP:`, `checkpoint`, or deliberately broken commits do not belong on real review branches. If you use them locally, squash or fix them before opening the PR or marking it ready.
 
 **Why this needs to be a rule, not a vibe.** Without an explicit cadence, "I'll commit when there's something worth committing" reliably becomes "I'll commit at the end of the day," and end-of-day commits are the ones that ship as one fat unreviewable blob. The cadence is the discipline; the discipline is what produces the legible history.
 
@@ -68,6 +71,10 @@ Behavior:
 - Blocks the push for unsafe findings (high-scrutiny paths)
 - Loops up to `max_iterations` times (default 3)
 - Gracefully skips if Conductor or the configured provider is unavailable, printing a visible "review skipped" line so the missing safety boundary isn't silent
+
+Prefer a different model or provider for AI review than the one that authored the change, when Conductor has one available. Deterministic checks — format, lint, typecheck, tests, and project-specific validators — still run before AI review; model diversity complements those checks, it does not replace them.
+
+If the project enables GitHub merge queue, `open-pr.sh --auto-merge` should enqueue the reviewed PR instead of bypassing the queue. Never use `--admin` to skip required checks or queue policy. Treat queue removal or repeated queue failure as a blocker that needs diagnosis before retrying.
 
 ## Periodic branch hygiene
 
@@ -92,7 +99,11 @@ A stacked PR is a PR whose base branch is another open PR's branch instead of th
 
 ## Parallel work with worktrees
 
-The default is one branch at a time in the main checkout. When you have N genuinely independent tasks — changes that touch disjoint files and don't logically depend on each other — `git worktree` lets them run concurrently without stepping on each other. The common case is an AI assistant being asked to "do these three things in parallel"; the right move is three branches in three worktrees, not three half-done edits interleaved on one branch.
+File-writing subagents must use isolated worktrees unless explicitly waived. The default is isolation; flat shared-checkout fan-out is the exception.
+
+The default for a single driver is one branch at a time in the main checkout. When you have N genuinely independent tasks — changes that touch disjoint files and don't logically depend on each other — `git worktree` lets them run concurrently without stepping on each other. The common case is an AI assistant being asked to "do these three things in parallel"; the right move is three branches in three worktrees, not three half-done edits interleaved on one branch.
+
+For the full fan-out playbook — slice manifests, file ownership, parent orchestration, concurrency caps, `.worktreeinclude`, and cleanup rules — see [agent-swarms.md](agent-swarms.md). This section defines the git workflow default; the swarm guide defines the operating model.
 
 **The primitive.** From the main checkout, `git worktree add ../<project>-<slug> -b <type>/<slug>` creates a second working tree on a new branch, sharing the same `.git`. Work in it the same way you'd work anywhere — the only difference is that the main checkout stays free to run tests, start another worktree, or keep serving the user's questions while the other tasks run.
 
@@ -101,7 +112,7 @@ The default is one branch at a time in the main checkout. When you have N genuin
 **Rules that make it actually parallel.**
 
 - **Disjoint file sets.** If two concurrent tasks touch the same file, they're not parallel — they're a merge conflict delivered on two branches. Before launching, name the file surface each task owns; if they overlap, sequence them.
-- **No coordination in flight.** Each worktree ships via its own `scripts/open-pr.sh --auto-merge`. PRs are independent because their branches are independent. If task B needs something from task A's PR before it can merge, that's stacked work — see the stacked-PR section above and run them sequentially instead.
+- **No coordination in flight.** Each worktree ships via its own `scripts/open-pr.sh --auto-merge` when the slice is independently shippable, or reports back to a parent-owned aggregate PR when the feature only makes sense as a unit. If task B needs something from task A's PR before it can merge, that's stacked work — see the stacked-PR section above and run them sequentially instead.
 - **Each agent burns its own budget.** Five parallel agents use roughly 5× the tokens and 5× the CPU of one. Start with 2–3 concurrent worktrees, observe, and scale from there. Practitioners report the comfortable cap without heavy orchestration is around 5–6.
 
 **Gotchas.**
@@ -110,7 +121,7 @@ The default is one branch at a time in the main checkout. When you have N genuin
 - **Shared `.git`.** Don't run destructive git ops (`git gc --prune=now`, `git worktree remove --force`) while a sibling worktree has uncommitted work — the shared object store is the same object store.
 - **Disk cost.** Each worktree is a full working tree. Not an issue for a small repo; matters for large monorepos with generated artifacts.
 
-**Cleanup.** After the PR merges, `git worktree remove <path>` from the main checkout to drop the directory. `scripts/cleanup-branches.sh` already refuses to delete branches currently checked out in worktrees, so it won't fight you — but it also won't remove the worktree directories themselves; that step is manual.
+**Cleanup.** After the PR merges, use `scripts/cleanup-worktrees.sh` from the main checkout to preview and remove clean merged-or-equivalent worktrees. It is dry-run by default and refuses dirty worktrees unless explicitly forced. `scripts/cleanup-branches.sh` already refuses to delete branches currently checked out in worktrees, so it won't fight you — but it also won't remove the worktree directories themselves.
 
 ## Emergency path
 

--- a/scripts/cleanup-worktrees.sh
+++ b/scripts/cleanup-worktrees.sh
@@ -151,8 +151,17 @@ flush_worktree() {
     reason="missing; git worktree prune handles this"
   else
     if [ -z "$current_branch" ]; then
-      removable=1
-      reason="detached or branch gone"
+      if [ -z "$current_head" ] || [ "$current_head" = "unknown" ]; then
+        reason="detached HEAD missing; investigate manually"
+      elif git merge-base --is-ancestor "$current_head" "$DEFAULT_REF" 2>/dev/null; then
+        removable=1
+        reason="detached HEAD merged into default"
+      elif is_fully_applied "$DEFAULT_REF" "$current_head"; then
+        removable=1
+        reason="detached HEAD tree-equivalent to default"
+      else
+        reason="detached HEAD has unique work; use --force to remove"
+      fi
     else
       branch_name="${current_branch#refs/heads/}"
       if ! git show-ref --verify --quiet "refs/heads/$branch_name"; then

--- a/scripts/cleanup-worktrees.sh
+++ b/scripts/cleanup-worktrees.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+#
+# scripts/cleanup-worktrees.sh — safe git worktree hygiene tool.
+#
+# Usage:
+#   bash scripts/cleanup-worktrees.sh              # dry-run (default)
+#   bash scripts/cleanup-worktrees.sh --execute    # remove clean candidates
+#   bash scripts/cleanup-worktrees.sh --force      # remove candidates even if dirty
+#
+# Safety guarantees:
+#   - Default mode is DRY RUN.
+#   - The main worktree is never removed.
+#   - The current worktree is never removed.
+#   - Clean worktrees are removable only when their branch is merged or
+#     tree-equivalent to the default branch, or when the branch is gone.
+#   - Dirty worktrees are refused unless --force is explicit.
+#   - git worktree prune is previewed before any actual prune.
+#
+set -euo pipefail
+
+DRY_RUN=1
+FORCE=0
+
+usage() {
+  awk 'NR>2 && !/^#/ { exit } NR>2 { sub(/^# ?/, ""); print }' "$0"
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --execute|-x)
+      DRY_RUN=0
+      shift
+      ;;
+    --force)
+      DRY_RUN=0
+      FORCE=1
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument '$1'" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  echo "ERROR: cleanup-worktrees.sh must run inside a git repository." >&2
+  exit 1
+fi
+
+cd "$REPO_ROOT"
+
+resolve_default_ref() {
+  local origin_head ref branch
+  origin_head="$(git symbolic-ref -q refs/remotes/origin/HEAD 2>/dev/null || true)"
+  if [ -n "$origin_head" ]; then
+    ref="$origin_head"
+    ref="${ref#refs/remotes/}"
+    if git rev-parse --verify --quiet "$ref" >/dev/null; then
+      printf '%s\n' "$ref"
+      return 0
+    fi
+  fi
+
+  for branch in main master; do
+    if git rev-parse --verify --quiet "origin/$branch" >/dev/null; then
+      printf '%s\n' "origin/$branch"
+      return 0
+    fi
+    if git rev-parse --verify --quiet "$branch" >/dev/null; then
+      printf '%s\n' "$branch"
+      return 0
+    fi
+  done
+
+  echo "ERROR: could not resolve a default branch ref (origin/HEAD, main, or master)." >&2
+  return 1
+}
+
+is_fully_applied() {
+  local upstream="$1"
+  local branch="$2"
+  local base file
+
+  base="$(git merge-base "$upstream" "$branch" 2>/dev/null)" || return 1
+  [ -z "$base" ] && return 1
+
+  while IFS= read -r -d '' file; do
+    [ -z "$file" ] && continue
+    git diff --quiet "$upstream" "$branch" -- "$file" 2>/dev/null || return 1
+  done < <(git diff --name-only --no-renames -z "$base" "$branch" 2>/dev/null)
+
+  return 0
+}
+
+DEFAULT_REF="$(resolve_default_ref)"
+CURRENT_WORKTREE="$(git rev-parse --show-toplevel)"
+
+WORKTREE_LIST="$(git worktree list --porcelain)"
+MAIN_WORKTREE="$(printf '%s\n' "$WORKTREE_LIST" | awk '/^worktree /{print substr($0, 10); exit}')"
+
+CANDIDATE_PATHS=()
+FORCE_PATHS=()
+
+echo "==> Worktrees"
+echo "    default ref: $DEFAULT_REF"
+
+current_path=""
+current_head=""
+current_branch=""
+
+flush_worktree() {
+  [ -n "$current_path" ] || return 0
+
+  local branch_label dirty_status dirty_label reason removable branch_name
+  branch_label="${current_branch:-detached}"
+
+  if dirty_status="$(git -C "$current_path" status --porcelain 2>/dev/null)"; then
+    if [ -n "$dirty_status" ]; then
+      dirty_label="dirty"
+    else
+      dirty_label="clean"
+    fi
+  else
+    dirty_label="missing"
+  fi
+
+  printf '  - path: %s\n' "$current_path"
+  printf '    branch: %s\n' "$branch_label"
+  printf '    head: %s\n' "${current_head:-unknown}"
+  printf '    status: %s\n' "$dirty_label"
+
+  removable=0
+  reason=""
+
+  if [ "$current_path" = "$MAIN_WORKTREE" ]; then
+    reason="main worktree"
+  elif [ "$current_path" = "$CURRENT_WORKTREE" ]; then
+    reason="current worktree"
+  elif [ "$dirty_label" = "dirty" ] && [ "$FORCE" -ne 1 ]; then
+    reason="dirty; use --force to remove"
+  elif [ "$dirty_label" = "missing" ]; then
+    reason="missing; git worktree prune handles this"
+  else
+    if [ -z "$current_branch" ]; then
+      removable=1
+      reason="detached or branch gone"
+    else
+      branch_name="${current_branch#refs/heads/}"
+      if ! git show-ref --verify --quiet "refs/heads/$branch_name"; then
+        removable=1
+        reason="branch gone"
+      elif git merge-base --is-ancestor "$branch_name" "$DEFAULT_REF" 2>/dev/null; then
+        removable=1
+        reason="branch merged into default"
+      elif is_fully_applied "$DEFAULT_REF" "$branch_name"; then
+        removable=1
+        reason="branch tree-equivalent to default"
+      else
+        reason="branch has unique work"
+      fi
+    fi
+  fi
+
+  printf '    decision: %s\n' "$reason"
+  if [ "$removable" -eq 1 ]; then
+    CANDIDATE_PATHS+=("$current_path")
+    if [ "$dirty_label" = "dirty" ]; then
+      FORCE_PATHS+=("$current_path")
+    fi
+  fi
+}
+
+while IFS= read -r line || [ -n "$line" ]; do
+  case "$line" in
+    worktree\ *)
+      flush_worktree
+      current_path="${line#worktree }"
+      current_head=""
+      current_branch=""
+      ;;
+    HEAD\ *)
+      current_head="${line#HEAD }"
+      ;;
+    branch\ *)
+      current_branch="${line#branch }"
+      ;;
+    "")
+      flush_worktree
+      current_path=""
+      current_head=""
+      current_branch=""
+      ;;
+  esac
+done <<< "$WORKTREE_LIST"
+flush_worktree
+
+echo ""
+echo "==> Prune preview"
+git worktree prune --dry-run --verbose || true
+
+if [ "${#CANDIDATE_PATHS[@]}" -eq 0 ]; then
+  echo ""
+  echo "==> No removable worktrees found."
+  exit 0
+fi
+
+echo ""
+echo "==> Removable worktrees"
+for path in "${CANDIDATE_PATHS[@]}"; do
+  echo "  - $path"
+done
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo ""
+  echo "==> Dry run. Pass --execute to remove the clean candidates listed above."
+  exit 0
+fi
+
+echo ""
+echo "==> Removing worktrees"
+for path in "${CANDIDATE_PATHS[@]}"; do
+  if [ "$FORCE" -eq 1 ]; then
+    git worktree remove --force "$path"
+  else
+    git worktree remove "$path"
+  fi
+  echo "    removed: $path"
+done
+
+echo ""
+echo "==> Pruning stale worktree metadata"
+git worktree prune --verbose
+
+echo ""
+echo "==> Done. Run without --execute next time to dry-run."

--- a/scripts/spawn-worktree.sh
+++ b/scripts/spawn-worktree.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+#
+# scripts/spawn-worktree.sh — create an isolated worktree for parallel work.
+#
+# Usage:
+#   bash scripts/spawn-worktree.sh <type>/<slug>
+#   bash scripts/spawn-worktree.sh <type>/<slug> ../explicit-path
+#
+# The default worktree path is ../<repo-name>-<slug-without-type>.
+# If .worktreeinclude exists at the repo root, ignored untracked files matching
+# its gitignore-style patterns are copied into the new worktree.
+#
+set -euo pipefail
+
+usage() {
+  awk 'NR>2 && !/^#/ { exit } NR>2 { sub(/^# ?/, ""); print }' "$0"
+}
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+  usage >&2
+  exit 1
+fi
+
+case "$1" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+esac
+
+BRANCH="$1"
+EXPLICIT_PATH="${2:-}"
+
+if ! REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  echo "ERROR: spawn-worktree.sh must run inside a git repository." >&2
+  exit 1
+fi
+
+cd "$REPO_ROOT"
+
+case "$BRANCH" in
+  */*)
+    TYPE="${BRANCH%%/*}"
+    SLUG="${BRANCH#*/}"
+    ;;
+  *)
+    echo "ERROR: branch must follow <type>/<slug>, got '$BRANCH'." >&2
+    exit 1
+    ;;
+esac
+
+if [ -z "$TYPE" ] || [ -z "$SLUG" ] || [ "$SLUG" = "$BRANCH" ]; then
+  echo "ERROR: branch must follow <type>/<slug>, got '$BRANCH'." >&2
+  exit 1
+fi
+
+if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  echo "ERROR: branch already exists: $BRANCH" >&2
+  exit 1
+fi
+
+REPO_NAME="$(basename "$REPO_ROOT")"
+WORKTREE_PATH="${EXPLICIT_PATH:-../$REPO_NAME-$SLUG}"
+WORKTREE_PARENT="$(dirname "$WORKTREE_PATH")"
+
+if [ -e "$WORKTREE_PATH" ]; then
+  echo "ERROR: worktree path already exists: $WORKTREE_PATH" >&2
+  exit 1
+fi
+
+if [ ! -d "$WORKTREE_PARENT" ]; then
+  echo "ERROR: parent directory does not exist: $WORKTREE_PARENT" >&2
+  exit 1
+fi
+
+resolve_default_ref() {
+  local origin_head ref branch
+  origin_head="$(git symbolic-ref -q refs/remotes/origin/HEAD 2>/dev/null || true)"
+  if [ -n "$origin_head" ]; then
+    ref="$origin_head"
+    ref="${ref#refs/remotes/}"
+    if git rev-parse --verify --quiet "$ref" >/dev/null; then
+      printf '%s\n' "$ref"
+      return 0
+    fi
+  fi
+
+  for branch in main master; do
+    if git rev-parse --verify --quiet "origin/$branch" >/dev/null; then
+      printf '%s\n' "origin/$branch"
+      return 0
+    fi
+    if git rev-parse --verify --quiet "$branch" >/dev/null; then
+      printf '%s\n' "$branch"
+      return 0
+    fi
+  done
+
+  echo "ERROR: could not resolve a default branch ref (origin/HEAD, main, or master)." >&2
+  return 1
+}
+
+# Glob matching against $pattern is intentional here — .worktreeinclude uses
+# gitignore-style globs, so we want shell pattern semantics, not literal compare.
+# shellcheck disable=SC2053
+matches_worktreeinclude_pattern() {
+  local path="$1" pattern="$2" basename_part segment
+
+  case "$pattern" in
+    */)
+      pattern="${pattern%/}"
+      [[ "$path" == "$pattern"/* || "$path" == */"$pattern"/* ]] && return 0
+      return 1
+      ;;
+  esac
+
+  if [[ "$pattern" == */* ]]; then
+    [[ "$path" == $pattern ]] && return 0
+    return 1
+  fi
+
+  basename_part="$(basename "$path")"
+  [[ "$basename_part" == $pattern ]] && return 0
+
+  IFS='/'
+  for segment in $path; do
+    [[ "$segment" == $pattern ]] && return 0
+  done
+  unset IFS
+  return 1
+}
+
+should_copy_ignored_file() {
+  local path="$1" include_file="$2" raw pattern
+
+  while IFS= read -r raw || [ -n "$raw" ]; do
+    pattern="${raw#"${raw%%[![:space:]]*}"}"
+    pattern="${pattern%"${pattern##*[![:space:]]}"}"
+    [ -z "$pattern" ] && continue
+    case "$pattern" in
+      \#*) continue ;;
+      !*)
+        echo "ERROR: negated .worktreeinclude patterns are not supported: $pattern" >&2
+        exit 1
+        ;;
+    esac
+    if matches_worktreeinclude_pattern "$path" "$pattern"; then
+      return 0
+    fi
+  done < "$include_file"
+
+  return 1
+}
+
+DEFAULT_REF="$(resolve_default_ref)"
+
+echo "==> Creating worktree"
+echo "    branch: $BRANCH"
+echo "    path:   $WORKTREE_PATH"
+echo "    base:   $DEFAULT_REF"
+git worktree add "$WORKTREE_PATH" -b "$BRANCH" "$DEFAULT_REF"
+
+COPIED=0
+INCLUDE_FILE="$REPO_ROOT/.worktreeinclude"
+if [ -f "$INCLUDE_FILE" ]; then
+  echo ""
+  echo "==> Copying ignored files from .worktreeinclude"
+  while IFS= read -r -d '' ignored_file; do
+    [ -f "$ignored_file" ] || continue
+    if should_copy_ignored_file "$ignored_file" "$INCLUDE_FILE"; then
+      mkdir -p "$WORKTREE_PATH/$(dirname "$ignored_file")"
+      cp -p "$ignored_file" "$WORKTREE_PATH/$ignored_file"
+      echo "    copied: $ignored_file"
+      COPIED=$((COPIED + 1))
+    fi
+  done < <(git ls-files --others --ignored --exclude-standard -z)
+  if [ "$COPIED" -eq 0 ]; then
+    echo "    (no matching ignored files)"
+  fi
+fi
+
+SETUP_SCRIPT="$WORKTREE_PATH/scripts/setup-worktree-local.sh"
+if [ -x "$SETUP_SCRIPT" ]; then
+  echo ""
+  echo "==> Running scripts/setup-worktree-local.sh"
+  (cd "$WORKTREE_PATH" && bash scripts/setup-worktree-local.sh)
+elif [ -f "$SETUP_SCRIPT" ]; then
+  echo ""
+  echo "==> Running scripts/setup-worktree-local.sh"
+  (cd "$WORKTREE_PATH" && bash scripts/setup-worktree-local.sh)
+fi
+
+echo ""
+echo "==> Worktree ready"
+echo "    path:   $WORKTREE_PATH"
+echo "    branch: $BRANCH"
+echo "    next:   cd $WORKTREE_PATH"

--- a/scripts/spawn-worktree.sh
+++ b/scripts/spawn-worktree.sh
@@ -100,38 +100,8 @@ resolve_default_ref() {
   return 1
 }
 
-# Glob matching against $pattern is intentional here — .worktreeinclude uses
-# gitignore-style globs, so we want shell pattern semantics, not literal compare.
-# shellcheck disable=SC2053
-matches_worktreeinclude_pattern() {
-  local path="$1" pattern="$2" basename_part segment
-
-  case "$pattern" in
-    */)
-      pattern="${pattern%/}"
-      [[ "$path" == "$pattern"/* || "$path" == */"$pattern"/* ]] && return 0
-      return 1
-      ;;
-  esac
-
-  if [[ "$pattern" == */* ]]; then
-    [[ "$path" == $pattern ]] && return 0
-    return 1
-  fi
-
-  basename_part="$(basename "$path")"
-  [[ "$basename_part" == $pattern ]] && return 0
-
-  IFS='/'
-  for segment in $path; do
-    [[ "$segment" == $pattern ]] && return 0
-  done
-  unset IFS
-  return 1
-}
-
-should_copy_ignored_file() {
-  local path="$1" include_file="$2" raw pattern
+guard_worktreeinclude_patterns() {
+  local include_file="$1" raw pattern
 
   while IFS= read -r raw || [ -n "$raw" ]; do
     pattern="${raw#"${raw%%[![:space:]]*}"}"
@@ -144,12 +114,7 @@ should_copy_ignored_file() {
         exit 1
         ;;
     esac
-    if matches_worktreeinclude_pattern "$path" "$pattern"; then
-      return 0
-    fi
   done < "$include_file"
-
-  return 1
 }
 
 DEFAULT_REF="$(resolve_default_ref)"
@@ -165,15 +130,30 @@ INCLUDE_FILE="$REPO_ROOT/.worktreeinclude"
 if [ -f "$INCLUDE_FILE" ]; then
   echo ""
   echo "==> Copying ignored files from .worktreeinclude"
-  while IFS= read -r -d '' ignored_file; do
+  guard_worktreeinclude_patterns "$INCLUDE_FILE"
+
+  # Pattern matching is delegated to git so .worktreeinclude follows real
+  # gitignore semantics (e.g. `local/*.json` does not match `local/x/y.json`).
+  # We intersect two ls-files queries: files matched by .worktreeinclude as an
+  # exclude-from, and files matched by the project's standard ignore set. The
+  # intersection is the set of explicitly allowlisted, gitignored files.
+  INCLUDE_LIST="$(mktemp)"
+  STANDARD_LIST="$(mktemp)"
+  trap 'rm -f "$INCLUDE_LIST" "$STANDARD_LIST"' EXIT
+  git ls-files --others --ignored --exclude-from="$INCLUDE_FILE" \
+    | LC_ALL=C sort > "$INCLUDE_LIST"
+  git ls-files --others --ignored --exclude-standard \
+    | LC_ALL=C sort > "$STANDARD_LIST"
+
+  while IFS= read -r ignored_file; do
+    [ -n "$ignored_file" ] || continue
     [ -f "$ignored_file" ] || continue
-    if should_copy_ignored_file "$ignored_file" "$INCLUDE_FILE"; then
-      mkdir -p "$WORKTREE_PATH/$(dirname "$ignored_file")"
-      cp -p "$ignored_file" "$WORKTREE_PATH/$ignored_file"
-      echo "    copied: $ignored_file"
-      COPIED=$((COPIED + 1))
-    fi
-  done < <(git ls-files --others --ignored --exclude-standard -z)
+    mkdir -p "$WORKTREE_PATH/$(dirname "$ignored_file")"
+    cp -p "$ignored_file" "$WORKTREE_PATH/$ignored_file"
+    echo "    copied: $ignored_file"
+    COPIED=$((COPIED + 1))
+  done < <(comm -12 "$INCLUDE_LIST" "$STANDARD_LIST")
+
   if [ "$COPIED" -eq 0 ]; then
     echo "    (no matching ignored files)"
   fi

--- a/scripts/spawn-worktree.sh
+++ b/scripts/spawn-worktree.sh
@@ -119,6 +119,14 @@ guard_worktreeinclude_patterns() {
 
 DEFAULT_REF="$(resolve_default_ref)"
 
+# Validate .worktreeinclude before any external side effect (branch creation,
+# worktree directory) so a bad pattern doesn't leave behind half-spawned state
+# that blocks retry.
+INCLUDE_FILE="$REPO_ROOT/.worktreeinclude"
+if [ -f "$INCLUDE_FILE" ]; then
+  guard_worktreeinclude_patterns "$INCLUDE_FILE"
+fi
+
 echo "==> Creating worktree"
 echo "    branch: $BRANCH"
 echo "    path:   $WORKTREE_PATH"
@@ -126,11 +134,9 @@ echo "    base:   $DEFAULT_REF"
 git worktree add "$WORKTREE_PATH" -b "$BRANCH" "$DEFAULT_REF"
 
 COPIED=0
-INCLUDE_FILE="$REPO_ROOT/.worktreeinclude"
 if [ -f "$INCLUDE_FILE" ]; then
   echo ""
   echo "==> Copying ignored files from .worktreeinclude"
-  guard_worktreeinclude_patterns "$INCLUDE_FILE"
 
   # Pattern matching is delegated to git so .worktreeinclude follows real
   # gitignore semantics (e.g. `local/*.json` does not match `local/x/y.json`).

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -44,6 +44,7 @@ Full rationale, worked examples, and the *why* behind each rule:
 - `principles/pre-implementation-checklist.md`
 - `principles/documentation-ownership.md`
 - `principles/git-workflow.md`
+- `principles/agent-swarms.md`
 
 ## Required Delivery Workflow
 
@@ -72,6 +73,8 @@ Use the normal lifecycle unless the user asks for a different flow:
 4. From a clean worktree, run `CODEX_REVIEW_FORCE=1 bash scripts/codex-review.sh` so Conductor can review and safely auto-fix before merge. If Conductor creates fix commits, let the loop finish; if it blocks, address findings, commit, and rerun until clean.
 5. Ship with `bash scripts/open-pr.sh --auto-merge`; it creates the PR, runs the final read-only Conductor merge review, squash-merges, and syncs the default branch.
 6. Clean up the feature branch if it still exists locally.
+
+File-writing subagents use isolated worktrees by default. Follow `principles/agent-swarms.md` for slice manifests, file ownership, concurrency caps, and cleanup; use `scripts/spawn-worktree.sh` and `scripts/cleanup-worktrees.sh` for local setup and teardown.
 
 ### Testing
 

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -29,10 +29,12 @@ Non-negotiable. Every code change is reviewed against them. Full rationale, work
 - **Make irreversible actions recoverable** — destructive operations need dry-run, backup, idempotency, rollback, or forward-fix plan before they run.
 - **Preserve compatibility at boundaries** — public API/config/schema/CLI/hook/template changes need a compatibility or migration plan.
 - **Audit weak-point classes** — find a structural bug → audit the class + add a guardrail. Use the `touchstone-audit-weak-points` skill.
+- **Isolate file-writing subagents** — parallel workers use dedicated worktrees, slice manifests, and disjoint file ownership by default.
 
 @principles/engineering-principles.md
 @principles/pre-implementation-checklist.md
 @principles/documentation-ownership.md
+@principles/agent-swarms.md
 
 ## Git Workflow
 
@@ -54,6 +56,7 @@ Every change — including one-liners, doc tweaks, and version bumps — starts 
 ### Housekeeping
 
 - Concise commit messages. Logically grouped changes.
+- File-writing subagents use isolated worktrees by default. Follow `principles/agent-swarms.md`; use `scripts/spawn-worktree.sh` and `scripts/cleanup-worktrees.sh` for local setup and teardown.
 - Run `/compact` at ~50% context. Start fresh sessions for unrelated work.
 
 ### Memory Hygiene

--- a/templates/GEMINI.md
+++ b/templates/GEMINI.md
@@ -21,3 +21,7 @@ Drive this automatically unless the user asks for a different flow:
 5. If Conductor creates fix commits, let the loop finish. If it blocks, address findings, commit, and rerun until clean.
 6. Ship with `bash scripts/open-pr.sh --auto-merge`; this creates the PR, runs the final read-only Conductor merge review, squash-merges, and syncs the default branch.
 7. Clean up the feature branch if it still exists locally.
+
+## Parallel Agent Work
+
+File-writing subagents use isolated worktrees by default. Follow `principles/agent-swarms.md` for slice manifests, file ownership, concurrency caps, and parent orchestration. Use `scripts/spawn-worktree.sh` to create local branch/worktree slices and `scripts/cleanup-worktrees.sh` for dry-run-first teardown.

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -106,12 +106,16 @@ assert_exists "$PROJECT/scripts/touchstone-run.sh"
 assert_exists "$PROJECT/scripts/open-pr.sh"
 assert_exists "$PROJECT/scripts/merge-pr.sh"
 assert_exists "$PROJECT/scripts/cleanup-branches.sh"
+assert_exists "$PROJECT/scripts/spawn-worktree.sh"
+assert_exists "$PROJECT/scripts/cleanup-worktrees.sh"
 assert_not_exists "$PROJECT/scripts/run-pytest-in-venv.sh"
 assert_executable "$PROJECT/scripts/codex-review.sh"
 assert_executable "$PROJECT/scripts/touchstone-run.sh"
 assert_executable "$PROJECT/scripts/open-pr.sh"
 assert_executable "$PROJECT/scripts/merge-pr.sh"
 assert_executable "$PROJECT/scripts/cleanup-branches.sh"
+assert_executable "$PROJECT/scripts/spawn-worktree.sh"
+assert_executable "$PROJECT/scripts/cleanup-worktrees.sh"
 assert_contains "$PROJECT/.pre-commit-config.yaml" 'codex-review.sh'
 assert_contains "$PROJECT/.pre-commit-config.yaml" 'touchstone-run.sh validate'
 # Cortex append-only exclusions: trailing-whitespace and end-of-file-fixer
@@ -125,6 +129,8 @@ assert_contains "$PROJECT/.touchstone-config" '^gitbutler_mcp=false$'
 assert_exists "$PROJECT/.touchstone-manifest"
 assert_contains "$PROJECT/.touchstone-manifest" '^\.touchstone-version$'
 assert_contains "$PROJECT/.touchstone-manifest" '^scripts/open-pr.sh$'
+assert_contains "$PROJECT/.touchstone-manifest" '^scripts/spawn-worktree.sh$'
+assert_contains "$PROJECT/.touchstone-manifest" '^scripts/cleanup-worktrees.sh$'
 if grep -q '^\.touchstone-config$' "$PROJECT/.gitignore"; then
   echo "FAIL: expected .touchstone-config to be commit-friendly, not ignored" >&2
   ERRORS=$((ERRORS + 1))

--- a/tests/test-cleanup-worktrees.sh
+++ b/tests/test-cleanup-worktrees.sh
@@ -34,6 +34,7 @@ MERGED_WT="$TEST_DIR/demo-merged"
 SQUASH_WT="$TEST_DIR/demo-squash"
 UNIQUE_WT="$TEST_DIR/demo-unique"
 DIRTY_WT="$TEST_DIR/demo-dirty"
+DETACHED_WT="$TEST_DIR/demo-detached"
 
 git init -q --bare -b main "$REMOTE"
 git init -q -b main "$REPO"
@@ -75,6 +76,15 @@ git -C "$REPO" checkout -q main
 git -C "$REPO" merge --no-ff -q feat/dirty -m "merge feat/dirty"
 echo "uncommitted" >> "$DIRTY_WT/dirty.txt"
 
+git -C "$REPO" worktree add -q -b feat/detached-source "$TEST_DIR/demo-detached-source" main
+echo "detached-unique" > "$TEST_DIR/demo-detached-source/detached.txt"
+git -C "$TEST_DIR/demo-detached-source" add detached.txt
+git -C "$TEST_DIR/demo-detached-source" commit -qm "feat: detached unique work"
+DETACHED_SHA="$(git -C "$TEST_DIR/demo-detached-source" rev-parse HEAD)"
+git -C "$REPO" worktree remove "$TEST_DIR/demo-detached-source" >/dev/null 2>&1
+git -C "$REPO" worktree add -q --detach "$DETACHED_WT" "$DETACHED_SHA"
+git -C "$REPO" branch -D feat/detached-source >/dev/null
+
 git -C "$REPO" push -q origin main
 
 DRY_RUN_OUTPUT="$TEST_DIR/dry-run-output.txt"
@@ -84,10 +94,12 @@ assert_contains "$DRY_RUN_OUTPUT" 'Dry run'
 assert_contains "$DRY_RUN_OUTPUT" "$MERGED_WT"
 assert_contains "$DRY_RUN_OUTPUT" "$SQUASH_WT"
 assert_contains "$DRY_RUN_OUTPUT" 'dirty; use --force to remove'
+assert_contains "$DRY_RUN_OUTPUT" 'detached HEAD has unique work'
 assert_exists "$MERGED_WT"
 assert_exists "$SQUASH_WT"
 assert_exists "$UNIQUE_WT"
 assert_exists "$DIRTY_WT"
+assert_exists "$DETACHED_WT"
 
 EXEC_OUTPUT="$TEST_DIR/execute-output.txt"
 (cd "$REPO" && bash "$TOUCHSTONE_ROOT/scripts/cleanup-worktrees.sh" --execute) >"$EXEC_OUTPUT" 2>&1
@@ -96,9 +108,11 @@ assert_not_exists "$MERGED_WT"
 assert_not_exists "$SQUASH_WT"
 assert_exists "$UNIQUE_WT"
 assert_exists "$DIRTY_WT"
+assert_exists "$DETACHED_WT"
 assert_contains "$EXEC_OUTPUT" 'removed:'
 assert_contains "$EXEC_OUTPUT" 'branch has unique work'
 assert_contains "$EXEC_OUTPUT" 'dirty; use --force to remove'
+assert_contains "$EXEC_OUTPUT" 'detached HEAD has unique work'
 
 FORCE_OUTPUT="$TEST_DIR/force-output.txt"
 (cd "$REPO" && bash "$TOUCHSTONE_ROOT/scripts/cleanup-worktrees.sh" --force) >"$FORCE_OUTPUT" 2>&1

--- a/tests/test-cleanup-worktrees.sh
+++ b/tests/test-cleanup-worktrees.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# tests/test-cleanup-worktrees.sh — verify cleanup-worktrees is dry-run first,
+# removes only clean merged/equivalent worktrees, and refuses dirty trees.
+#
+set -euo pipefail
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_DIR="$(mktemp -d -t touchstone-test-cleanup-worktrees.XXXXXX)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+echo "==> Test: cleanup-worktrees.sh removes only safe worktree candidates"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+assert_exists() {
+  [ -e "$1" ] || fail "expected $1 to exist"
+}
+
+assert_not_exists() {
+  [ ! -e "$1" ] || fail "expected $1 to NOT exist"
+}
+
+assert_contains() {
+  grep -q "$2" "$1" 2>/dev/null || fail "expected $1 to contain '$2'"
+}
+
+REMOTE="$TEST_DIR/remote.git"
+REPO="$TEST_DIR/demo"
+MERGED_WT="$TEST_DIR/demo-merged"
+SQUASH_WT="$TEST_DIR/demo-squash"
+UNIQUE_WT="$TEST_DIR/demo-unique"
+DIRTY_WT="$TEST_DIR/demo-dirty"
+
+git init -q --bare -b main "$REMOTE"
+git init -q -b main "$REPO"
+git -C "$REPO" config user.email "test@example.com"
+git -C "$REPO" config user.name "Test"
+git -C "$REPO" remote add origin "$REMOTE"
+
+echo "base" > "$REPO/base.txt"
+git -C "$REPO" add base.txt
+git -C "$REPO" commit -qm "initial"
+git -C "$REPO" push -q -u origin main
+git -C "$REPO" remote set-head origin main
+
+git -C "$REPO" worktree add -q "$MERGED_WT" -b feat/merged main
+echo "merged" > "$MERGED_WT/merged.txt"
+git -C "$MERGED_WT" add merged.txt
+git -C "$MERGED_WT" commit -qm "feat: merged"
+git -C "$REPO" checkout -q main
+git -C "$REPO" merge --no-ff -q feat/merged -m "merge feat/merged"
+
+git -C "$REPO" worktree add -q "$SQUASH_WT" -b feat/squash main
+echo "squash" > "$SQUASH_WT/squash.txt"
+git -C "$SQUASH_WT" add squash.txt
+git -C "$SQUASH_WT" commit -qm "feat: squash"
+git -C "$REPO" checkout -q main
+git -C "$REPO" merge --squash feat/squash >/dev/null
+git -C "$REPO" commit -qm "feat: squash (#1)"
+
+git -C "$REPO" worktree add -q "$UNIQUE_WT" -b feat/unique main
+echo "unique" > "$UNIQUE_WT/unique.txt"
+git -C "$UNIQUE_WT" add unique.txt
+git -C "$UNIQUE_WT" commit -qm "feat: unique"
+
+git -C "$REPO" worktree add -q "$DIRTY_WT" -b feat/dirty main
+echo "dirty" > "$DIRTY_WT/dirty.txt"
+git -C "$DIRTY_WT" add dirty.txt
+git -C "$DIRTY_WT" commit -qm "feat: dirty"
+git -C "$REPO" checkout -q main
+git -C "$REPO" merge --no-ff -q feat/dirty -m "merge feat/dirty"
+echo "uncommitted" >> "$DIRTY_WT/dirty.txt"
+
+git -C "$REPO" push -q origin main
+
+DRY_RUN_OUTPUT="$TEST_DIR/dry-run-output.txt"
+(cd "$REPO" && bash "$TOUCHSTONE_ROOT/scripts/cleanup-worktrees.sh") >"$DRY_RUN_OUTPUT" 2>&1
+
+assert_contains "$DRY_RUN_OUTPUT" 'Dry run'
+assert_contains "$DRY_RUN_OUTPUT" "$MERGED_WT"
+assert_contains "$DRY_RUN_OUTPUT" "$SQUASH_WT"
+assert_contains "$DRY_RUN_OUTPUT" 'dirty; use --force to remove'
+assert_exists "$MERGED_WT"
+assert_exists "$SQUASH_WT"
+assert_exists "$UNIQUE_WT"
+assert_exists "$DIRTY_WT"
+
+EXEC_OUTPUT="$TEST_DIR/execute-output.txt"
+(cd "$REPO" && bash "$TOUCHSTONE_ROOT/scripts/cleanup-worktrees.sh" --execute) >"$EXEC_OUTPUT" 2>&1
+
+assert_not_exists "$MERGED_WT"
+assert_not_exists "$SQUASH_WT"
+assert_exists "$UNIQUE_WT"
+assert_exists "$DIRTY_WT"
+assert_contains "$EXEC_OUTPUT" 'removed:'
+assert_contains "$EXEC_OUTPUT" 'branch has unique work'
+assert_contains "$EXEC_OUTPUT" 'dirty; use --force to remove'
+
+FORCE_OUTPUT="$TEST_DIR/force-output.txt"
+(cd "$REPO" && bash "$TOUCHSTONE_ROOT/scripts/cleanup-worktrees.sh" --force) >"$FORCE_OUTPUT" 2>&1
+assert_not_exists "$DIRTY_WT"
+assert_exists "$UNIQUE_WT"
+
+echo "==> PASS: cleanup-worktrees dry-runs, removes safe candidates, and refuses dirty worktrees by default"

--- a/tests/test-spawn-worktree.sh
+++ b/tests/test-spawn-worktree.sh
@@ -51,8 +51,9 @@ git -C "$REPO" push -q -u origin main
 git -C "$REPO" remote set-head origin main
 
 printf 'TOKEN=fake\n' > "$REPO/.env.test"
-mkdir -p "$REPO/local" "$REPO/node_modules/pkg"
+mkdir -p "$REPO/local" "$REPO/local/secrets" "$REPO/node_modules/pkg"
 printf '{"debug":true}\n' > "$REPO/local/dev.json"
+printf '{"prod":true}\n' > "$REPO/local/secrets/prod.json"
 printf 'cached\n' > "$REPO/node_modules/pkg/cache.txt"
 printf 'not ignored\n' > "$REPO/not-ignored.txt"
 cat > "$REPO/.worktreeinclude" <<'EOF'
@@ -72,6 +73,7 @@ assert_exists "$WORKTREE/.env.test"
 assert_exists "$WORKTREE/local/dev.json"
 assert_exists "$WORKTREE/node_modules/pkg/cache.txt"
 assert_not_exists "$WORKTREE/not-ignored.txt"
+assert_not_exists "$WORKTREE/local/secrets/prod.json"
 assert_contains "$OUTPUT" 'branch: feat/local-slice'
 assert_contains "$OUTPUT" 'copied: .env.test'
 assert_contains "$OUTPUT" 'copied: local/dev.json'

--- a/tests/test-spawn-worktree.sh
+++ b/tests/test-spawn-worktree.sh
@@ -91,6 +91,26 @@ if (cd "$REPO" && bash "$TOUCHSTONE_ROOT/scripts/spawn-worktree.sh" feat/exists 
 fi
 assert_contains "$TEST_DIR/exists-output.txt" 'worktree path already exists'
 
+# Negated .worktreeinclude must be rejected BEFORE the worktree is created,
+# so a corrected retry does not collide with a half-spawned branch/path.
+BAD_INCLUDE_REPO="$TEST_DIR/bad-include"
+BAD_WT="$TEST_DIR/bad-include-wt"
+git init -q -b main "$BAD_INCLUDE_REPO"
+git -C "$BAD_INCLUDE_REPO" config user.email "test@example.com"
+git -C "$BAD_INCLUDE_REPO" config user.name "Test"
+echo "tracked" > "$BAD_INCLUDE_REPO/tracked.txt"
+git -C "$BAD_INCLUDE_REPO" add tracked.txt
+git -C "$BAD_INCLUDE_REPO" commit -qm "initial"
+printf '!negated\n' > "$BAD_INCLUDE_REPO/.worktreeinclude"
+if (cd "$BAD_INCLUDE_REPO" && bash "$TOUCHSTONE_ROOT/scripts/spawn-worktree.sh" feat/will-fail "$BAD_WT") >"$TEST_DIR/bad-include-output.txt" 2>&1; then
+  fail "negated .worktreeinclude pattern should fail"
+fi
+assert_contains "$TEST_DIR/bad-include-output.txt" 'negated .worktreeinclude'
+assert_not_exists "$BAD_WT"
+if git -C "$BAD_INCLUDE_REPO" show-ref --verify --quiet refs/heads/feat/will-fail; then
+  fail "branch feat/will-fail should not exist after .worktreeinclude validation failure"
+fi
+
 (cd "$REPO" && bash "$TOUCHSTONE_ROOT/scripts/spawn-worktree.sh" feat/default-path "$DEFAULT_WORKTREE") >/dev/null 2>&1
 assert_exists "$DEFAULT_WORKTREE/.git"
 [ "$(git -C "$DEFAULT_WORKTREE" branch --show-current)" = "feat/default-path" ] || fail "default-path branch not created"

--- a/tests/test-spawn-worktree.sh
+++ b/tests/test-spawn-worktree.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# tests/test-spawn-worktree.sh — verify spawn-worktree creates isolated
+# branches and copies only explicitly allowlisted ignored local files.
+#
+set -euo pipefail
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_DIR="$(mktemp -d -t touchstone-test-spawn-worktree.XXXXXX)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+echo "==> Test: spawn-worktree.sh creates branch worktrees with local includes"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+assert_exists() {
+  [ -e "$1" ] || fail "expected $1 to exist"
+}
+
+assert_not_exists() {
+  [ ! -e "$1" ] || fail "expected $1 to NOT exist"
+}
+
+assert_contains() {
+  grep -q "$2" "$1" 2>/dev/null || fail "expected $1 to contain '$2'"
+}
+
+REMOTE="$TEST_DIR/remote.git"
+REPO="$TEST_DIR/demo"
+WORKTREE="$TEST_DIR/demo-slice"
+DEFAULT_WORKTREE="$TEST_DIR/demo-default-path"
+
+git init -q --bare -b main "$REMOTE"
+git init -q -b main "$REPO"
+git -C "$REPO" config user.email "test@example.com"
+git -C "$REPO" config user.name "Test"
+git -C "$REPO" remote add origin "$REMOTE"
+
+echo "tracked" > "$REPO/tracked.txt"
+cat > "$REPO/.gitignore" <<'EOF'
+.env.test
+local/*.json
+node_modules/
+EOF
+git -C "$REPO" add tracked.txt .gitignore
+git -C "$REPO" commit -qm "initial"
+git -C "$REPO" push -q -u origin main
+git -C "$REPO" remote set-head origin main
+
+printf 'TOKEN=fake\n' > "$REPO/.env.test"
+mkdir -p "$REPO/local" "$REPO/node_modules/pkg"
+printf '{"debug":true}\n' > "$REPO/local/dev.json"
+printf 'cached\n' > "$REPO/node_modules/pkg/cache.txt"
+printf 'not ignored\n' > "$REPO/not-ignored.txt"
+cat > "$REPO/.worktreeinclude" <<'EOF'
+# explicit local test config
+.env.test
+local/*.json
+not-ignored.txt
+node_modules/
+EOF
+
+OUTPUT="$TEST_DIR/spawn-output.txt"
+(cd "$REPO" && bash "$TOUCHSTONE_ROOT/scripts/spawn-worktree.sh" feat/local-slice "$WORKTREE") >"$OUTPUT" 2>&1
+
+assert_exists "$WORKTREE/.git"
+assert_exists "$WORKTREE/tracked.txt"
+assert_exists "$WORKTREE/.env.test"
+assert_exists "$WORKTREE/local/dev.json"
+assert_exists "$WORKTREE/node_modules/pkg/cache.txt"
+assert_not_exists "$WORKTREE/not-ignored.txt"
+assert_contains "$OUTPUT" 'branch: feat/local-slice'
+assert_contains "$OUTPUT" 'copied: .env.test'
+assert_contains "$OUTPUT" 'copied: local/dev.json'
+
+BRANCH="$(git -C "$WORKTREE" branch --show-current)"
+[ "$BRANCH" = "feat/local-slice" ] || fail "expected spawned branch feat/local-slice, got $BRANCH"
+
+if (cd "$REPO" && bash "$TOUCHSTONE_ROOT/scripts/spawn-worktree.sh" invalid "$TEST_DIR/bad") >"$TEST_DIR/invalid-output.txt" 2>&1; then
+  fail "invalid branch shape should fail"
+fi
+assert_contains "$TEST_DIR/invalid-output.txt" 'branch must follow <type>/<slug>'
+
+if (cd "$REPO" && bash "$TOUCHSTONE_ROOT/scripts/spawn-worktree.sh" feat/exists "$WORKTREE") >"$TEST_DIR/exists-output.txt" 2>&1; then
+  fail "existing worktree path should fail"
+fi
+assert_contains "$TEST_DIR/exists-output.txt" 'worktree path already exists'
+
+(cd "$REPO" && bash "$TOUCHSTONE_ROOT/scripts/spawn-worktree.sh" feat/default-path "$DEFAULT_WORKTREE") >/dev/null 2>&1
+assert_exists "$DEFAULT_WORKTREE/.git"
+[ "$(git -C "$DEFAULT_WORKTREE" branch --show-current)" = "feat/default-path" ] || fail "default-path branch not created"
+
+echo "==> PASS: spawn-worktree creates isolated branches and copies allowlisted ignored files"

--- a/tests/test-update.sh
+++ b/tests/test-update.sh
@@ -117,8 +117,12 @@ assert_contains "$TEST_DIR/update-output-2.txt" 'Creating update branch: chore/t
 assert_contains "$TEST_DIR/update-output-2.txt" 'Committed: chore: update touchstone to'
 assert_contains "$TEST_DIR/update-output-2.txt" 'bash scripts/open-pr.sh'
 assert_exists "$PROJECT/scripts/touchstone-run.sh"
+assert_exists "$PROJECT/scripts/spawn-worktree.sh"
+assert_exists "$PROJECT/scripts/cleanup-worktrees.sh"
 assert_exists "$PROJECT/.touchstone-manifest"
 assert_contains "$PROJECT/.touchstone-manifest" '^scripts/touchstone-run.sh$'
+assert_contains "$PROJECT/.touchstone-manifest" '^scripts/spawn-worktree.sh$'
+assert_contains "$PROJECT/.touchstone-manifest" '^scripts/cleanup-worktrees.sh$'
 assert_not_exists "$PROJECT/principles/engineering-principles.md.bak"
 assert_not_exists "$PROJECT/.claude/settings.json.touchstone-pre-update.bak"
 


### PR DESCRIPTION
## Summary

Bakes the "Definitely ship" + first two "Probably ship" recommendations from a Conductor research pass into Touchstone. Five atomic commits:

1. **`principles/agent-swarms.md`** (new) — concrete swarm playbook: when to spawn worktrees vs. sequence, slice manifest format with worker name / branch / files-allowed / files-forbidden / tests, parent orchestration rules (parent owns shared files: lockfiles, schemas, generated indexes, changelogs), concurrency caps, anti-coordination rules, untracked-file pattern (`.worktreeinclude`).
2. **`principles/git-workflow.md`** edits — file-writing subagents must use isolated worktrees by default; dirty-tree handling rule (no auto-stash, no auto-commit on user's behalf); cross-link to `agent-swarms.md`; reviewer-diversity guidance; merge-queue note.
3. **`scripts/spawn-worktree.sh`** + test — creates `<type>/<slug>` branch + worktree from default ref, copies allowlisted ignored files via `.worktreeinclude`, runs optional `scripts/setup-worktree-local.sh` hook, refuses if path/branch already exists. Never copies tracked files; never symlinks dependency dirs.
4. **`scripts/cleanup-worktrees.sh`** + test — dry-run by default; removes only clean worktrees whose branch is merged or tree-equivalent to the default ref, or gone entirely; `--execute` to act, `--force` for dirty trees; `git worktree prune` previewed before action.
5. **Alignment + propagation** — adds the new principle to `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, the matching templates, `principles/README.md`, and `lib/agents-principles-block.sh`. Wires both new scripts into `bootstrap/new-project.sh`, `bootstrap/update-project.sh`, and the manifest so downstream projects pick them up on next sync. Bootstrap and update self-tests assert the helpers land downstream.

This propagates to ~20 downstream projects on next `sync-all.sh`. **Maintainer review requested before merge** — no `--auto-merge`.

## Test plan

- [x] `tests/test-spawn-worktree.sh` passes (new — covers branch creation, `.worktreeinclude` copy with file/dir/glob patterns, invalid-shape rejection, existing-path rejection, default-path resolution).
- [x] `tests/test-cleanup-worktrees.sh` passes (new — covers dry-run-first, merged + squash-equivalent removal, unique-work refusal, dirty refusal, `--force` removal).
- [x] `tests/test-shellcheck.sh` clean across all 58 shipped scripts (one inline `# shellcheck disable=SC2053` on `matches_worktreeinclude_pattern` — gitignore-style glob matching is intentional).
- [x] `tests/test-bootstrap.sh` and `tests/test-update.sh` assert the new helpers land downstream with `+x` and appear in `.touchstone-manifest`.
- [x] 25 of 27 non-skipped tests pass on the branch.

### Pre-existing test flakes (unrelated, filed separately)

Three tests fail identically on `main` due to `claude -p` timeouts in the local probe harness:

- `tests/test-claude-probe-helper.sh` — exits 124 on main and on this branch.
- `tests/test-guidance-probes.sh` — same `claude -p timed out after 90s` failure on main and this branch.
- `tests/test-guidance-skill-activation.sh` — also fails on main (`touchstone-agent-swarms` 1/5 there → 5/5 on this branch; `touchstone-audit-weak-points` 0/5 on both due to probe timeouts).

Issues filed for these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)