### PR TITLE
fix: bind reviewer bypass to merge base

### DIFF
--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -1737,6 +1737,46 @@ clean_review_cache_file() {
   printf '%s/%s.clean' "$(clean_review_cache_dir)" "$key"
 }
 
+review_clean_marker_branch() {
+  local branch="${CODEX_REVIEW_BRANCH_NAME:-}"
+  if [ -z "$branch" ]; then
+    branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo '')"
+  fi
+  [ "$branch" != "HEAD" ] || branch=""
+  printf '%s' "$branch"
+}
+
+review_clean_marker_key() {
+  local branch="$1"
+  printf '%s' "$branch" | sed 's/[^A-Za-z0-9._-]/_/g'
+}
+
+review_clean_marker_dir() {
+  git rev-parse --git-path touchstone/reviewer-clean
+}
+
+write_clean_review_marker() {
+  local line_count="$1"
+  local branch marker_dir marker_file
+
+  branch="$(review_clean_marker_branch)"
+  [ -n "$branch" ] || return 0
+
+  marker_dir="$(review_clean_marker_dir)"
+  marker_file="$marker_dir/$(review_clean_marker_key "$branch").clean"
+
+  mkdir -p "$marker_dir" 2>/dev/null || return 0
+  {
+    printf 'result=CODEX_REVIEW_CLEAN\n'
+    printf 'branch=%s\n' "$branch"
+    printf 'base=%s\n' "$BASE"
+    printf 'merge_base=%s\n' "$MERGE_BASE"
+    printf 'head=%s\n' "$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+    printf 'diff_lines=%s\n' "$line_count"
+    printf 'reviewed_at=%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  } > "$marker_file" 2>/dev/null || true
+}
+
 write_clean_review_cache() {
   local key="$1"
   local line_count="$2"
@@ -2395,6 +2435,7 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
       REVIEW_EXIT_REASON="clean"
       print_summary
       write_clean_review_cache "$REVIEW_CACHE_KEY" "$DIFF_LINE_COUNT"
+      write_clean_review_marker "$DIFF_LINE_COUNT"
       # The "ran" denominator: a successful review actually executed.
       # skip-rate = log_skip_count / (log_skip_count + log_ran_count).
       log_skip_event ran "clean:iter=${iter}:lines=${DIFF_LINE_COUNT}:fix-commits=${FIX_COMMITS}"

--- a/principles/git-workflow.md
+++ b/principles/git-workflow.md
@@ -72,6 +72,8 @@ Behavior:
 - Loops up to `max_iterations` times (default 3)
 - Gracefully skips if Conductor or the configured provider is unavailable, printing a visible "review skipped" line so the missing safety boundary isn't silent
 
+If the reviewer itself wedges after the branch has already recorded a clean review iteration, use `scripts/merge-pr.sh <pr-number> --bypass-with-disclosure="<reason>"` instead of dropping to raw `gh pr merge`. The bypass refuses fresh branches, prints a visible warning, comments on the PR with the reason, and adds a `Reviewer-bypass: <reason>` trailer to the squash commit when GitHub accepts the supplied merge body. This is for a stalled reviewer gate on an already-reviewed branch, not for bypassing substantive findings.
+
 Prefer a different model or provider for AI review than the one that authored the change, when Conductor has one available. Deterministic checks — format, lint, typecheck, tests, and project-specific validators — still run before AI review; model diversity complements those checks, it does not replace them.
 
 If the project enables GitHub merge queue, `open-pr.sh --auto-merge` should enqueue the reviewed PR instead of bypassing the queue. Never use `--admin` to skip required checks or queue policy. Treat queue removal or repeated queue failure as a blocker that needs diagnosis before retrying.
@@ -126,3 +128,5 @@ For the full fan-out playbook — slice manifests, file ownership, parent orches
 ## Emergency path
 
 If a production bug requires immediate action and can't wait for the PR cycle, push directly with `git push --no-verify`. The next PR must include an "Emergency-bypass disclosure" section explaining what was bypassed and why. The convention — not the tooling — is what keeps the discipline.
+
+Do not use `git push --no-verify` for a wedged Conductor merge review when the PR path is otherwise healthy. Use `scripts/merge-pr.sh --bypass-with-disclosure="<reason>"` so the bypass remains in the PR and merge audit trail.

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -1737,6 +1737,46 @@ clean_review_cache_file() {
   printf '%s/%s.clean' "$(clean_review_cache_dir)" "$key"
 }
 
+review_clean_marker_branch() {
+  local branch="${CODEX_REVIEW_BRANCH_NAME:-}"
+  if [ -z "$branch" ]; then
+    branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo '')"
+  fi
+  [ "$branch" != "HEAD" ] || branch=""
+  printf '%s' "$branch"
+}
+
+review_clean_marker_key() {
+  local branch="$1"
+  printf '%s' "$branch" | sed 's/[^A-Za-z0-9._-]/_/g'
+}
+
+review_clean_marker_dir() {
+  git rev-parse --git-path touchstone/reviewer-clean
+}
+
+write_clean_review_marker() {
+  local line_count="$1"
+  local branch marker_dir marker_file
+
+  branch="$(review_clean_marker_branch)"
+  [ -n "$branch" ] || return 0
+
+  marker_dir="$(review_clean_marker_dir)"
+  marker_file="$marker_dir/$(review_clean_marker_key "$branch").clean"
+
+  mkdir -p "$marker_dir" 2>/dev/null || return 0
+  {
+    printf 'result=CODEX_REVIEW_CLEAN\n'
+    printf 'branch=%s\n' "$branch"
+    printf 'base=%s\n' "$BASE"
+    printf 'merge_base=%s\n' "$MERGE_BASE"
+    printf 'head=%s\n' "$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+    printf 'diff_lines=%s\n' "$line_count"
+    printf 'reviewed_at=%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  } > "$marker_file" 2>/dev/null || true
+}
+
 write_clean_review_cache() {
   local key="$1"
   local line_count="$2"
@@ -2395,6 +2435,7 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
       REVIEW_EXIT_REASON="clean"
       print_summary
       write_clean_review_cache "$REVIEW_CACHE_KEY" "$DIFF_LINE_COUNT"
+      write_clean_review_marker "$DIFF_LINE_COUNT"
       # The "ran" denominator: a successful review actually executed.
       # skip-rate = log_skip_count / (log_skip_count + log_ran_count).
       log_skip_event ran "clean:iter=${iter}:lines=${DIFF_LINE_COUNT}:fix-commits=${FIX_COMMITS}"

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -4,6 +4,7 @@
 #
 # Usage:
 #   bash scripts/merge-pr.sh <pr-number>
+#   bash scripts/merge-pr.sh <pr-number> --bypass-with-disclosure="<reason>"
 #
 # What this does:
 #   1. Verifies the PR is open and mergeable.
@@ -18,13 +19,54 @@
 #
 set -euo pipefail
 
-PR_NUMBER="${1:-}"
+PR_NUMBER=""
+BYPASS_REASON=""
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REVIEW_SCRIPT="$SCRIPT_DIR/codex-review.sh"
 REVIEWED_HEAD_OID=""
+BYPASS_REVIEW=false
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --bypass-with-disclosure=*)
+      BYPASS_REVIEW=true
+      BYPASS_REASON="${1#*=}"
+      shift
+      ;;
+    --bypass-with-disclosure)
+      echo "ERROR: --bypass-with-disclosure requires a non-empty reason." >&2
+      exit 2
+      ;;
+    --*)
+      echo "ERROR: Unknown option: $1" >&2
+      exit 2
+      ;;
+    *)
+      if [ -n "$PR_NUMBER" ]; then
+        echo "ERROR: Unexpected extra argument: $1" >&2
+        exit 2
+      fi
+      PR_NUMBER="$1"
+      shift
+      ;;
+  esac
+done
+
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+BYPASS_REASON="$(trim "$(printf '%s' "$BYPASS_REASON" | tr '\r\n\t' '   ')")"
 
 if [ -z "$PR_NUMBER" ] || ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
-  echo "Usage: bash scripts/merge-pr.sh <pr-number>" >&2
+  echo "Usage: bash scripts/merge-pr.sh <pr-number> [--bypass-with-disclosure=\"<reason>\"]" >&2
+  exit 2
+fi
+if [ "$BYPASS_REVIEW" = true ] && [ -z "$BYPASS_REASON" ]; then
+  echo "ERROR: --bypass-with-disclosure requires a non-empty reason." >&2
   exit 2
 fi
 
@@ -41,6 +83,41 @@ truthy() {
     true|1|yes|on) return 0 ;;
     *) return 1 ;;
   esac
+}
+
+review_clean_marker_key() {
+  local branch="$1"
+  printf '%s' "$branch" | sed 's/[^A-Za-z0-9._-]/_/g'
+}
+
+review_clean_marker_file() {
+  local branch="$1"
+  printf '%s/%s.clean' \
+    "$(git rev-parse --git-path touchstone/reviewer-clean)" \
+    "$(review_clean_marker_key "$branch")"
+}
+
+branch_has_clean_review_marker() {
+  local branch="$1"
+  local marker
+  marker="$(review_clean_marker_file "$branch")"
+  [ -f "$marker" ] && grep -q '^result=CODEX_REVIEW_CLEAN$' "$marker"
+}
+
+print_bypass_banner() {
+  cat <<EOF
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!! BYPASSING REVIEWER GATE
+!! reason: $BYPASS_REASON
+!! This bypass is recorded on the PR and squash commit.
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+EOF
+}
+
+record_bypass_comment() {
+  gh pr comment "$PR_NUMBER" --body "Reviewer bypassed via \`--bypass-with-disclosure\`. Reason: $BYPASS_REASON"
 }
 
 run_merge_review() {
@@ -64,6 +141,18 @@ run_merge_review() {
   fi
 
   REVIEWED_HEAD_OID="$pr_head_oid"
+
+  if [ "$BYPASS_REVIEW" = true ]; then
+    if ! branch_has_clean_review_marker "$pr_head_branch"; then
+      echo "ERROR: Refusing reviewer bypass for PR #$PR_NUMBER." >&2
+      echo "       No prior clean review marker exists for branch '$pr_head_branch'." >&2
+      echo "       Run the reviewer cleanly once before using --bypass-with-disclosure." >&2
+      exit 1
+    fi
+    print_bypass_banner
+    record_bypass_comment
+    return 0
+  fi
 
   if truthy "${SKIP_REVIEW:-${SKIP_CODEX_REVIEW:-false}}"; then
     echo "==> Skipping merge review because SKIP_REVIEW is set."
@@ -108,6 +197,7 @@ run_merge_review() {
 
   echo "==> Running merge review ..."
   CODEX_REVIEW_BASE="$default_base_ref" \
+    CODEX_REVIEW_BRANCH_NAME="$pr_head_branch" \
     CODEX_REVIEW_FORCE=1 \
     CODEX_REVIEW_MODE=review-only \
     bash "$REVIEW_SCRIPT"
@@ -160,7 +250,12 @@ if [ -z "$REVIEWED_HEAD_OID" ]; then
   echo "ERROR: Cannot merge PR #$PR_NUMBER because no reviewed head commit was recorded." >&2
   exit 1
 fi
-gh pr merge "$PR_NUMBER" --squash --delete-branch --match-head-commit "$REVIEWED_HEAD_OID"
+if [ "$BYPASS_REVIEW" = true ]; then
+  gh pr merge "$PR_NUMBER" --squash --delete-branch --match-head-commit "$REVIEWED_HEAD_OID" \
+    --body "Reviewer-bypass: $BYPASS_REASON"
+else
+  gh pr merge "$PR_NUMBER" --squash --delete-branch --match-head-commit "$REVIEWED_HEAD_OID"
+fi
 
 # 5. Sync local default branch.
 echo "==> Merged. Updating local $DEFAULT_BRANCH ..."

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -106,13 +106,17 @@ marker_field() {
 branch_has_clean_review_marker() {
   local branch="$1"
   local head_oid="$2"
-  local marker marker_branch marker_head
+  local merge_base="$3"
+  local marker marker_branch marker_head marker_merge_base
   marker="$(review_clean_marker_file "$branch")"
   [ -f "$marker" ] || return 1
   grep -q '^result=CODEX_REVIEW_CLEAN$' "$marker" || return 1
   marker_branch="$(marker_field branch "$marker")"
   marker_head="$(marker_field head "$marker")"
-  [ "$marker_branch" = "$branch" ] && [ "$marker_head" = "$head_oid" ]
+  marker_merge_base="$(marker_field merge_base "$marker")"
+  [ "$marker_branch" = "$branch" ] \
+    && [ "$marker_head" = "$head_oid" ] \
+    && [ "$marker_merge_base" = "$merge_base" ]
 }
 
 print_bypass_banner() {
@@ -152,11 +156,30 @@ run_merge_review() {
   fi
 
   REVIEWED_HEAD_OID="$pr_head_oid"
+  default_base_ref="origin/$DEFAULT_BRANCH"
 
   if [ "$BYPASS_REVIEW" = true ]; then
-    if ! branch_has_clean_review_marker "$pr_head_branch" "$pr_head_oid"; then
+    echo "==> Refreshing $default_base_ref before reviewer bypass validation ..."
+    if ! git fetch origin "+refs/heads/$DEFAULT_BRANCH:refs/remotes/origin/$DEFAULT_BRANCH"; then
+      echo "ERROR: Failed to refresh $default_base_ref before reviewer bypass validation." >&2
+      exit 1
+    fi
+    if ! git rev-parse --verify --quiet "$default_base_ref^{commit}" >/dev/null; then
+      echo "ERROR: Could not verify $default_base_ref before reviewer bypass validation." >&2
+      exit 1
+    fi
+    if ! git cat-file -e "$pr_head_oid^{commit}" 2>/dev/null; then
+      echo "==> Checking out PR #$PR_NUMBER head ($pr_head_branch) for reviewer bypass validation ..."
+      gh pr checkout "$PR_NUMBER" --detach
+    fi
+    local current_merge_base
+    if ! current_merge_base="$(git merge-base "$default_base_ref" "$pr_head_oid" 2>/dev/null)"; then
+      echo "ERROR: Could not compute merge base for PR #$PR_NUMBER head against $default_base_ref." >&2
+      exit 1
+    fi
+    if ! branch_has_clean_review_marker "$pr_head_branch" "$pr_head_oid" "$current_merge_base"; then
       echo "ERROR: Refusing reviewer bypass for PR #$PR_NUMBER." >&2
-      echo "       No prior clean review marker matches branch '$pr_head_branch' at head '$pr_head_oid'." >&2
+      echo "       No prior clean review marker matches branch '$pr_head_branch' at head '$pr_head_oid' and merge base '$current_merge_base'." >&2
       echo "       Run the reviewer cleanly once before using --bypass-with-disclosure." >&2
       exit 1
     fi
@@ -175,7 +198,6 @@ run_merge_review() {
     return 0
   fi
 
-  default_base_ref="origin/$DEFAULT_BRANCH"
   echo "==> Refreshing $default_base_ref for merge review ..."
   if ! git fetch origin "+refs/heads/$DEFAULT_BRANCH:refs/remotes/origin/$DEFAULT_BRANCH"; then
     echo "ERROR: Failed to refresh $default_base_ref before merge review." >&2

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -97,11 +97,22 @@ review_clean_marker_file() {
     "$(review_clean_marker_key "$branch")"
 }
 
+marker_field() {
+  local field="$1"
+  local marker="$2"
+  awk -F= -v key="$field" '$1 == key { sub(/^[^=]*=/, ""); print; exit }' "$marker"
+}
+
 branch_has_clean_review_marker() {
   local branch="$1"
-  local marker
+  local head_oid="$2"
+  local marker marker_branch marker_head
   marker="$(review_clean_marker_file "$branch")"
-  [ -f "$marker" ] && grep -q '^result=CODEX_REVIEW_CLEAN$' "$marker"
+  [ -f "$marker" ] || return 1
+  grep -q '^result=CODEX_REVIEW_CLEAN$' "$marker" || return 1
+  marker_branch="$(marker_field branch "$marker")"
+  marker_head="$(marker_field head "$marker")"
+  [ "$marker_branch" = "$branch" ] && [ "$marker_head" = "$head_oid" ]
 }
 
 print_bypass_banner() {
@@ -143,9 +154,9 @@ run_merge_review() {
   REVIEWED_HEAD_OID="$pr_head_oid"
 
   if [ "$BYPASS_REVIEW" = true ]; then
-    if ! branch_has_clean_review_marker "$pr_head_branch"; then
+    if ! branch_has_clean_review_marker "$pr_head_branch" "$pr_head_oid"; then
       echo "ERROR: Refusing reviewer bypass for PR #$PR_NUMBER." >&2
-      echo "       No prior clean review marker exists for branch '$pr_head_branch'." >&2
+      echo "       No prior clean review marker matches branch '$pr_head_branch' at head '$pr_head_oid'." >&2
       echo "       Run the reviewer cleanly once before using --bypass-with-disclosure." >&2
       exit 1
     fi

--- a/tests/test-merge-pr.sh
+++ b/tests/test-merge-pr.sh
@@ -102,6 +102,11 @@ case "$*" in
   "rev-parse --git-path touchstone/reviewer-clean")
     printf '%s\n' "$GIT_PATH_ROOT/touchstone/reviewer-clean"
     ;;
+  "cat-file -e pr-head-oid^{commit}")
+    ;;
+  "merge-base origin/main pr-head-oid")
+    echo "base-oid"
+    ;;
   "fetch origin +refs/heads/main:refs/remotes/origin/main")
     echo "fetched main"
     ;;
@@ -191,7 +196,7 @@ if run_merge_pr "$TEST_DIR/output-fresh.txt" 123 --bypass-with-disclosure="revie
   echo "FAIL: bypass on fresh branch unexpectedly succeeded" >&2
   exit 1
 fi
-if grep -q "No prior clean review marker matches branch 'feature/test' at head 'pr-head-oid'" "$TEST_DIR/output-fresh.txt" \
+if grep -q "No prior clean review marker matches branch 'feature/test' at head 'pr-head-oid' and merge base 'base-oid'" "$TEST_DIR/output-fresh.txt" \
   && [ ! -f "$TEST_DIR/gh-merge-head" ] \
   && [ ! -f "$TEST_DIR/gh-comment" ] \
   && [ ! -f "$TEST_DIR/codex-review.log" ]; then
@@ -205,7 +210,7 @@ fi
 echo "==> Test: bypass after clean marker records disclosure and trailer"
 reset_case_files
 mkdir -p "$GIT_PATH_ROOT/touchstone/reviewer-clean"
-printf 'result=CODEX_REVIEW_CLEAN\nbranch=feature/test\nhead=pr-head-oid\n' > "$GIT_PATH_ROOT/touchstone/reviewer-clean/feature_test.clean"
+printf 'result=CODEX_REVIEW_CLEAN\nbranch=feature/test\nhead=pr-head-oid\nmerge_base=base-oid\n' > "$GIT_PATH_ROOT/touchstone/reviewer-clean/feature_test.clean"
 run_merge_pr "$TEST_DIR/output-bypass.txt" 123 --bypass-with-disclosure="reviewer timed out after prior clean review"
 if grep -q 'BYPASSING REVIEWER GATE' "$TEST_DIR/output-bypass.txt" \
   && grep -q 'reason: reviewer timed out after prior clean review' "$TEST_DIR/output-bypass.txt" \
@@ -228,13 +233,31 @@ if run_merge_pr "$TEST_DIR/output-stale.txt" 123 --bypass-with-disclosure="revie
   echo "FAIL: bypass with stale marker unexpectedly succeeded" >&2
   exit 1
 fi
-if grep -q "No prior clean review marker matches branch 'feature/test' at head 'pr-head-oid'" "$TEST_DIR/output-stale.txt" \
+if grep -q "No prior clean review marker matches branch 'feature/test' at head 'pr-head-oid' and merge base 'base-oid'" "$TEST_DIR/output-stale.txt" \
   && [ ! -f "$TEST_DIR/gh-merge-head" ] \
   && [ ! -f "$TEST_DIR/gh-comment" ]; then
   echo "==> PASS: stale clean marker rejected"
+else
+  echo "FAIL: stale marker did not fail safely" >&2
+  cat "$TEST_DIR/output-stale.txt" >&2
+  exit 1
+fi
+
+echo "==> Test: old-base clean marker is rejected"
+reset_case_files
+mkdir -p "$GIT_PATH_ROOT/touchstone/reviewer-clean"
+printf 'result=CODEX_REVIEW_CLEAN\nbranch=feature/test\nhead=pr-head-oid\nmerge_base=old-base\n' > "$GIT_PATH_ROOT/touchstone/reviewer-clean/feature_test.clean"
+if run_merge_pr "$TEST_DIR/output-old-base.txt" 123 --bypass-with-disclosure="reviewer timed out"; then
+  echo "FAIL: bypass with old-base marker unexpectedly succeeded" >&2
+  exit 1
+fi
+if grep -q "No prior clean review marker matches branch 'feature/test' at head 'pr-head-oid' and merge base 'base-oid'" "$TEST_DIR/output-old-base.txt" \
+  && [ ! -f "$TEST_DIR/gh-merge-head" ] \
+  && [ ! -f "$TEST_DIR/gh-comment" ]; then
+  echo "==> PASS: old-base clean marker rejected"
   exit 0
 fi
 
-echo "FAIL: stale marker did not fail safely" >&2
-cat "$TEST_DIR/output-stale.txt" >&2
+echo "FAIL: old-base marker did not fail safely" >&2
+cat "$TEST_DIR/output-old-base.txt" >&2
 exit 1

--- a/tests/test-merge-pr.sh
+++ b/tests/test-merge-pr.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# tests/test-merge-pr.sh — verify merge-pr.sh does not depend on local jq.
+# tests/test-merge-pr.sh — verify merge-pr.sh and reviewer-bypass behavior.
 #
 set -euo pipefail
 
@@ -8,11 +8,10 @@ TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TEST_DIR="$(mktemp -d -t touchstone-test-merge-pr.XXXXXX)"
 trap 'rm -rf "$TEST_DIR"' EXIT
 
-echo "==> Test: merge script works without jq in PATH"
-
 FAKE_BIN="$TEST_DIR/bin"
 MERGE_SCRIPT_DIR="$TEST_DIR/scripts"
-mkdir -p "$FAKE_BIN" "$MERGE_SCRIPT_DIR"
+GIT_PATH_ROOT="$TEST_DIR/git-path"
+mkdir -p "$FAKE_BIN" "$MERGE_SCRIPT_DIR" "$GIT_PATH_ROOT"
 cp "$TOUCHSTONE_ROOT/scripts/merge-pr.sh" "$MERGE_SCRIPT_DIR/merge-pr.sh"
 cat > "$MERGE_SCRIPT_DIR/codex-review.sh" <<'EOF'
 #!/usr/bin/env bash
@@ -21,6 +20,7 @@ set -euo pipefail
   printf 'CODEX_REVIEW_BASE=%s\n' "${CODEX_REVIEW_BASE:-}"
   printf 'CODEX_REVIEW_FORCE=%s\n' "${CODEX_REVIEW_FORCE:-}"
   printf 'CODEX_REVIEW_MODE=%s\n' "${CODEX_REVIEW_MODE:-}"
+  printf 'CODEX_REVIEW_BRANCH_NAME=%s\n' "${CODEX_REVIEW_BRANCH_NAME:-}"
 } > "$CODEX_REVIEW_LOG"
 EOF
 chmod +x "$MERGE_SCRIPT_DIR/merge-pr.sh" "$MERGE_SCRIPT_DIR/codex-review.sh"
@@ -29,23 +29,21 @@ cat > "$FAKE_BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
-case "$1 $2" in
+case "${1:-} ${2:-}" in
   "repo view")
     echo "main"
     ;;
   "pr view")
-    if [ "$5" = "state" ]; then
-      echo "OPEN"
-    elif [ "$5" = "headRefName" ]; then
-      echo "feature/test"
-    elif [ "$5" = "headRefOid" ]; then
-      echo "pr-head-oid"
-    elif [ "$5" = "mergeStateStatus,mergeable" ]; then
-      echo "CLEAN MERGEABLE"
-    else
-      echo "unexpected gh pr view args: $*" >&2
-      exit 1
-    fi
+    case "${5:-}" in
+      state) echo "OPEN" ;;
+      headRefName) echo "feature/test" ;;
+      headRefOid) echo "pr-head-oid" ;;
+      mergeStateStatus,mergeable) echo "CLEAN MERGEABLE" ;;
+      *)
+        echo "unexpected gh pr view args: $*" >&2
+        exit 1
+        ;;
+    esac
     ;;
   "pr checkout")
     if [ "${4:-}" != "--detach" ]; then
@@ -55,10 +53,22 @@ case "$1 $2" in
     echo "checked-out" > "$GH_CHECKOUT_FILE"
     echo "checked out PR $3"
     ;;
+  "pr comment")
+    if [ "${4:-}" != "--body" ]; then
+      echo "unexpected gh pr comment args: $*" >&2
+      exit 1
+    fi
+    printf '%s\n' "${5:-}" > "$GH_COMMENT_FILE"
+    echo "commented"
+    ;;
   "pr merge")
-    if [ "$4 $5 $6 $7" != "--squash --delete-branch --match-head-commit pr-head-oid" ]; then
+    printf '%s\n' "$*" > "$GH_MERGE_ARGS_FILE"
+    if [ "${4:-} ${5:-} ${6:-} ${7:-}" != "--squash --delete-branch --match-head-commit pr-head-oid" ]; then
       echo "unexpected gh pr merge args: $*" >&2
       exit 1
+    fi
+    if [ "${8:-}" = "--body" ]; then
+      printf '%s\n' "${9:-}" > "$GH_MERGE_BODY_FILE"
     fi
     echo "$7" > "$GH_MERGE_HEAD_FILE"
     echo "merged"
@@ -89,6 +99,9 @@ case "$*" in
       echo "stale-local-oid"
     fi
     ;;
+  "rev-parse --git-path touchstone/reviewer-clean")
+    printf '%s\n' "$GIT_PATH_ROOT/touchstone/reviewer-clean"
+    ;;
   "fetch origin +refs/heads/main:refs/remotes/origin/main")
     echo "fetched main"
     ;;
@@ -112,30 +125,98 @@ EOF
 
 chmod +x "$FAKE_BIN/gh" "$FAKE_BIN/git"
 
-OUTPUT_FILE="$TEST_DIR/output.txt"
-CODEX_REVIEW_LOG="$TEST_DIR/codex-review.log"
-GH_CHECKOUT_FILE="$TEST_DIR/gh-checkout"
-GH_MERGE_HEAD_FILE="$TEST_DIR/gh-merge-head"
-PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
-  CODEX_REVIEW_LOG="$CODEX_REVIEW_LOG" \
-  GH_CHECKOUT_FILE="$GH_CHECKOUT_FILE" \
-  GH_MERGE_HEAD_FILE="$GH_MERGE_HEAD_FILE" \
-  bash "$MERGE_SCRIPT_DIR/merge-pr.sh" 123 >"$OUTPUT_FILE" 2>&1
+reset_case_files() {
+  rm -f "$TEST_DIR"/output*.txt "$TEST_DIR"/codex-review*.log \
+    "$TEST_DIR"/gh-checkout* "$TEST_DIR"/gh-merge-head* \
+    "$TEST_DIR"/gh-merge-args* "$TEST_DIR"/gh-merge-body* \
+    "$TEST_DIR"/gh-comment*
+  rm -rf "$GIT_PATH_ROOT"
+  mkdir -p "$GIT_PATH_ROOT"
+}
 
-if grep -q 'attempt 1: mergeStateStatus=CLEAN mergeable=MERGEABLE' "$OUTPUT_FILE" \
-  && grep -q '==> Refreshing origin/main for merge review' "$OUTPUT_FILE" \
-  && grep -q '==> Checking out PR #123 head (feature/test) for merge review' "$OUTPUT_FILE" \
-  && grep -q '==> Running merge review' "$OUTPUT_FILE" \
-  && grep -q '==> Done\.' "$OUTPUT_FILE" \
-  && grep -q '^checked-out$' "$GH_CHECKOUT_FILE" \
-  && grep -q '^pr-head-oid$' "$GH_MERGE_HEAD_FILE" \
-  && grep -q '^CODEX_REVIEW_BASE=origin/main$' "$CODEX_REVIEW_LOG" \
-  && grep -q '^CODEX_REVIEW_FORCE=1$' "$CODEX_REVIEW_LOG" \
-  && grep -q '^CODEX_REVIEW_MODE=review-only$' "$CODEX_REVIEW_LOG"; then
+run_merge_pr() {
+  local output_file="$1"
+  shift
+  PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    GIT_PATH_ROOT="$GIT_PATH_ROOT" \
+    CODEX_REVIEW_LOG="$TEST_DIR/codex-review.log" \
+    GH_CHECKOUT_FILE="$TEST_DIR/gh-checkout" \
+    GH_MERGE_HEAD_FILE="$TEST_DIR/gh-merge-head" \
+    GH_MERGE_ARGS_FILE="$TEST_DIR/gh-merge-args" \
+    GH_MERGE_BODY_FILE="$TEST_DIR/gh-merge-body" \
+    GH_COMMENT_FILE="$TEST_DIR/gh-comment" \
+    bash "$MERGE_SCRIPT_DIR/merge-pr.sh" "$@" >"$output_file" 2>&1
+}
+
+echo "==> Test: merge script works without jq in PATH"
+reset_case_files
+run_merge_pr "$TEST_DIR/output-normal.txt" 123
+if grep -q 'attempt 1: mergeStateStatus=CLEAN mergeable=MERGEABLE' "$TEST_DIR/output-normal.txt" \
+  && grep -q '==> Refreshing origin/main for merge review' "$TEST_DIR/output-normal.txt" \
+  && grep -q '==> Checking out PR #123 head (feature/test) for merge review' "$TEST_DIR/output-normal.txt" \
+  && grep -q '==> Running merge review' "$TEST_DIR/output-normal.txt" \
+  && grep -q '==> Done\.' "$TEST_DIR/output-normal.txt" \
+  && grep -q '^checked-out$' "$TEST_DIR/gh-checkout" \
+  && grep -q '^pr-head-oid$' "$TEST_DIR/gh-merge-head" \
+  && grep -q '^CODEX_REVIEW_BASE=origin/main$' "$TEST_DIR/codex-review.log" \
+  && grep -q '^CODEX_REVIEW_FORCE=1$' "$TEST_DIR/codex-review.log" \
+  && grep -q '^CODEX_REVIEW_MODE=review-only$' "$TEST_DIR/codex-review.log" \
+  && grep -q '^CODEX_REVIEW_BRANCH_NAME=feature/test$' "$TEST_DIR/codex-review.log"; then
   echo "==> PASS: merge-pr.sh completed without jq"
+else
+  echo "FAIL: merge-pr.sh output did not show a successful jq-free merge path" >&2
+  cat "$TEST_DIR/output-normal.txt" >&2
+  exit 1
+fi
+
+echo "==> Test: bypass without reason is rejected before merge"
+reset_case_files
+if run_merge_pr "$TEST_DIR/output-no-reason.txt" 123 --bypass-with-disclosure; then
+  echo "FAIL: bypass without reason unexpectedly succeeded" >&2
+  exit 1
+fi
+if grep -q 'requires a non-empty reason' "$TEST_DIR/output-no-reason.txt" \
+  && [ ! -f "$TEST_DIR/gh-merge-head" ] \
+  && [ ! -f "$TEST_DIR/gh-comment" ]; then
+  echo "==> PASS: missing bypass reason rejected"
+else
+  echo "FAIL: missing bypass reason did not fail safely" >&2
+  cat "$TEST_DIR/output-no-reason.txt" >&2
+  exit 1
+fi
+
+echo "==> Test: bypass on fresh branch is rejected"
+reset_case_files
+if run_merge_pr "$TEST_DIR/output-fresh.txt" 123 --bypass-with-disclosure="reviewer timed out"; then
+  echo "FAIL: bypass on fresh branch unexpectedly succeeded" >&2
+  exit 1
+fi
+if grep -q "No prior clean review marker exists for branch 'feature/test'" "$TEST_DIR/output-fresh.txt" \
+  && [ ! -f "$TEST_DIR/gh-merge-head" ] \
+  && [ ! -f "$TEST_DIR/gh-comment" ] \
+  && [ ! -f "$TEST_DIR/codex-review.log" ]; then
+  echo "==> PASS: fresh-branch bypass rejected"
+else
+  echo "FAIL: fresh-branch bypass did not fail safely" >&2
+  cat "$TEST_DIR/output-fresh.txt" >&2
+  exit 1
+fi
+
+echo "==> Test: bypass after clean marker records disclosure and trailer"
+reset_case_files
+mkdir -p "$GIT_PATH_ROOT/touchstone/reviewer-clean"
+printf 'result=CODEX_REVIEW_CLEAN\nbranch=feature/test\n' > "$GIT_PATH_ROOT/touchstone/reviewer-clean/feature_test.clean"
+run_merge_pr "$TEST_DIR/output-bypass.txt" 123 --bypass-with-disclosure="reviewer timed out after prior clean review"
+if grep -q 'BYPASSING REVIEWER GATE' "$TEST_DIR/output-bypass.txt" \
+  && grep -q 'reason: reviewer timed out after prior clean review' "$TEST_DIR/output-bypass.txt" \
+  && grep -q 'Reviewer bypassed via `--bypass-with-disclosure`. Reason: reviewer timed out after prior clean review' "$TEST_DIR/gh-comment" \
+  && grep -q '^Reviewer-bypass: reviewer timed out after prior clean review$' "$TEST_DIR/gh-merge-body" \
+  && grep -q '^pr-head-oid$' "$TEST_DIR/gh-merge-head" \
+  && [ ! -f "$TEST_DIR/codex-review.log" ]; then
+  echo "==> PASS: bypass is disclosed and merged with trailer"
   exit 0
 fi
 
-echo "FAIL: merge-pr.sh output did not show a successful jq-free merge path" >&2
-cat "$OUTPUT_FILE" >&2
+echo "FAIL: bypass path did not disclose and merge as expected" >&2
+cat "$TEST_DIR/output-bypass.txt" >&2
 exit 1

--- a/tests/test-merge-pr.sh
+++ b/tests/test-merge-pr.sh
@@ -191,7 +191,7 @@ if run_merge_pr "$TEST_DIR/output-fresh.txt" 123 --bypass-with-disclosure="revie
   echo "FAIL: bypass on fresh branch unexpectedly succeeded" >&2
   exit 1
 fi
-if grep -q "No prior clean review marker exists for branch 'feature/test'" "$TEST_DIR/output-fresh.txt" \
+if grep -q "No prior clean review marker matches branch 'feature/test' at head 'pr-head-oid'" "$TEST_DIR/output-fresh.txt" \
   && [ ! -f "$TEST_DIR/gh-merge-head" ] \
   && [ ! -f "$TEST_DIR/gh-comment" ] \
   && [ ! -f "$TEST_DIR/codex-review.log" ]; then
@@ -205,7 +205,7 @@ fi
 echo "==> Test: bypass after clean marker records disclosure and trailer"
 reset_case_files
 mkdir -p "$GIT_PATH_ROOT/touchstone/reviewer-clean"
-printf 'result=CODEX_REVIEW_CLEAN\nbranch=feature/test\n' > "$GIT_PATH_ROOT/touchstone/reviewer-clean/feature_test.clean"
+printf 'result=CODEX_REVIEW_CLEAN\nbranch=feature/test\nhead=pr-head-oid\n' > "$GIT_PATH_ROOT/touchstone/reviewer-clean/feature_test.clean"
 run_merge_pr "$TEST_DIR/output-bypass.txt" 123 --bypass-with-disclosure="reviewer timed out after prior clean review"
 if grep -q 'BYPASSING REVIEWER GATE' "$TEST_DIR/output-bypass.txt" \
   && grep -q 'reason: reviewer timed out after prior clean review' "$TEST_DIR/output-bypass.txt" \
@@ -214,9 +214,27 @@ if grep -q 'BYPASSING REVIEWER GATE' "$TEST_DIR/output-bypass.txt" \
   && grep -q '^pr-head-oid$' "$TEST_DIR/gh-merge-head" \
   && [ ! -f "$TEST_DIR/codex-review.log" ]; then
   echo "==> PASS: bypass is disclosed and merged with trailer"
+else
+  echo "FAIL: bypass path did not disclose and merge as expected" >&2
+  cat "$TEST_DIR/output-bypass.txt" >&2
+  exit 1
+fi
+
+echo "==> Test: stale clean marker is rejected"
+reset_case_files
+mkdir -p "$GIT_PATH_ROOT/touchstone/reviewer-clean"
+printf 'result=CODEX_REVIEW_CLEAN\nbranch=feature/test\nhead=old-head\n' > "$GIT_PATH_ROOT/touchstone/reviewer-clean/feature_test.clean"
+if run_merge_pr "$TEST_DIR/output-stale.txt" 123 --bypass-with-disclosure="reviewer timed out"; then
+  echo "FAIL: bypass with stale marker unexpectedly succeeded" >&2
+  exit 1
+fi
+if grep -q "No prior clean review marker matches branch 'feature/test' at head 'pr-head-oid'" "$TEST_DIR/output-stale.txt" \
+  && [ ! -f "$TEST_DIR/gh-merge-head" ] \
+  && [ ! -f "$TEST_DIR/gh-comment" ]; then
+  echo "==> PASS: stale clean marker rejected"
   exit 0
 fi
 
-echo "FAIL: bypass path did not disclose and merge as expected" >&2
-cat "$TEST_DIR/output-bypass.txt" >&2
+echo "FAIL: stale marker did not fail safely" >&2
+cat "$TEST_DIR/output-stale.txt" >&2
 exit 1

--- a/tests/test-review-clean-marker.sh
+++ b/tests/test-review-clean-marker.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# tests/test-review-clean-marker.sh — clean reviews record branch-level markers.
+#
+set -euo pipefail
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_DIR="$(mktemp -d -t touchstone-test-review-clean-marker.XXXXXX)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+echo "==> Test: clean review writes branch marker"
+
+REPO="$TEST_DIR/repo"
+FAKE_BIN="$TEST_DIR/bin"
+mkdir -p "$REPO" "$FAKE_BIN"
+
+cat > "$FAKE_BIN/conductor" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  doctor)
+    printf '{"configured": true}\n'
+    ;;
+  exec|call)
+    cat >/dev/null
+    printf 'No blocking issues found.\n'
+    printf 'CODEX_REVIEW_CLEAN\n'
+    ;;
+  *)
+    echo "unexpected conductor args: $*" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "$FAKE_BIN/conductor"
+
+if (
+  cd "$REPO"
+  git init -q
+  git config user.email test@example.com
+  git config user.name "Touchstone Test"
+  printf '[review]\nreviewer = "conductor"\nmode = "review-only"\n' > .codex-review.toml
+  printf 'base\n' > example.txt
+  git add .codex-review.toml example.txt
+  git commit -q -m "base"
+  printf 'change\n' >> example.txt
+  git add example.txt
+  git commit -q -m "change"
+
+  PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CODEX_REVIEW_BASE=HEAD~1 \
+    CODEX_REVIEW_BRANCH_NAME="feature/clean-marker" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    TOUCHSTONE_REVIEW_LOG=/dev/null \
+    bash "$TOUCHSTONE_ROOT/scripts/codex-review.sh" > "$TEST_DIR/output.txt" 2>&1
+
+  MARKER="$(git rev-parse --git-path touchstone/reviewer-clean/feature_clean-marker.clean)"
+  if [ -f "$MARKER" ] \
+    && grep -q '^result=CODEX_REVIEW_CLEAN$' "$MARKER" \
+    && grep -q '^branch=feature/clean-marker$' "$MARKER" \
+    && grep -q '^head=' "$MARKER"; then
+    exit 0
+  fi
+  exit 1
+); then
+  echo "==> PASS: clean review marker written"
+  exit 0
+fi
+
+echo "FAIL: clean review marker was not written" >&2
+cat "$TEST_DIR/output.txt" >&2
+exit 1


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
