### PR TITLE
fix: merge-pr.sh post-merge sync handles sibling worktree owning main

### DIFF
--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -103,6 +103,37 @@ marker_field() {
   awk -F= -v key="$field" '$1 == key { sub(/^[^=]*=/, ""); print; exit }' "$marker"
 }
 
+worktree_path_for_branch() {
+  local branch="$1"
+  local current_path=""
+  local current_branch=""
+  local line key value
+
+  git worktree list --porcelain | while IFS= read -r line || [ -n "$line" ]; do
+    if [ -z "$line" ]; then
+      if [ "$current_branch" = "refs/heads/$branch" ]; then
+        printf '%s\n' "$current_path"
+        exit 0
+      fi
+      current_path=""
+      current_branch=""
+      continue
+    fi
+
+    key="${line%% *}"
+    value="${line#* }"
+    case "$key" in
+      worktree) current_path="$value" ;;
+      branch) current_branch="$value" ;;
+    esac
+  done
+
+  if [ "$current_branch" = "refs/heads/$branch" ]; then
+    printf '%s\n' "$current_path"
+  fi
+  return 0
+}
+
 branch_has_clean_review_marker() {
   local branch="$1"
   local head_oid="$2"
@@ -117,6 +148,34 @@ branch_has_clean_review_marker() {
   [ "$marker_branch" = "$branch" ] \
     && [ "$marker_head" = "$head_oid" ] \
     && [ "$marker_merge_base" = "$merge_base" ]
+}
+
+sync_default_branch_after_merge() {
+  local current_branch current_worktree default_worktree
+
+  echo "==> Merged. Updating local $DEFAULT_BRANCH ..."
+  current_branch="$(git rev-parse --abbrev-ref HEAD)"
+
+  if [ "$current_branch" = "$DEFAULT_BRANCH" ]; then
+    git pull --rebase
+    return 0
+  fi
+
+  current_worktree="$(git rev-parse --show-toplevel)"
+  default_worktree="$(worktree_path_for_branch "$DEFAULT_BRANCH" | head -n 1)"
+  if [ -n "$default_worktree" ] && [ "$default_worktree" != "$current_worktree" ]; then
+    echo "==> $DEFAULT_BRANCH is checked out in sibling worktree: $default_worktree"
+    echo "==> Fast-forwarding that worktree after remote merge ..."
+    if git -C "$default_worktree" pull --ff-only; then
+      return 0
+    fi
+    echo "WARNING: PR #$PR_NUMBER merged remotely, but sibling worktree '$default_worktree' could not fast-forward." >&2
+    echo "WARNING: Run this when convenient: git -C '$default_worktree' pull --ff-only" >&2
+    return 0
+  fi
+
+  git checkout "$DEFAULT_BRANCH"
+  git pull --rebase
 }
 
 print_bypass_banner() {
@@ -291,10 +350,5 @@ else
 fi
 
 # 5. Sync local default branch.
-echo "==> Merged. Updating local $DEFAULT_BRANCH ..."
-CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-if [ "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" ]; then
-  git checkout "$DEFAULT_BRANCH"
-fi
-git pull --rebase
+sync_default_branch_after_merge
 echo "==> Done."

--- a/tests/test-merge-pr.sh
+++ b/tests/test-merge-pr.sh
@@ -84,6 +84,20 @@ cat > "$FAKE_BIN/git" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [ "${1:-}" = "-C" ]; then
+  if [ "${3:-} ${4:-}" != "pull --ff-only" ]; then
+    echo "unexpected git -C args: $*" >&2
+    exit 1
+  fi
+  printf '%s\n' "$2" > "$GIT_SIBLING_PULL_FILE"
+  if [ "${GIT_SIBLING_PULL_FAIL:-false}" = "true" ]; then
+    echo "sibling pull failed" >&2
+    exit 1
+  fi
+  echo "Already up to date."
+  exit 0
+fi
+
 case "$*" in
   "rev-parse --abbrev-ref HEAD")
     if [ -f "$GH_CHECKOUT_FILE" ]; then
@@ -102,6 +116,9 @@ case "$*" in
   "rev-parse --git-path touchstone/reviewer-clean")
     printf '%s\n' "$GIT_PATH_ROOT/touchstone/reviewer-clean"
     ;;
+  "rev-parse --show-toplevel")
+    printf '%s\n' "${TEST_CURRENT_WORKTREE:-/tmp/touchstone-feature-worktree}"
+    ;;
   "cat-file -e pr-head-oid^{commit}")
     ;;
   "merge-base origin/main pr-head-oid")
@@ -115,7 +132,11 @@ case "$*" in
     ;;
   "status --porcelain")
     ;;
+  "worktree list --porcelain")
+    printf '%s' "${GIT_WORKTREE_LIST:-}"
+    ;;
   "checkout main")
+    echo "checkout main" > "$GIT_CHECKOUT_MAIN_FILE"
     echo "Switched to branch 'main'"
     ;;
   "pull --rebase")
@@ -134,9 +155,13 @@ reset_case_files() {
   rm -f "$TEST_DIR"/output*.txt "$TEST_DIR"/codex-review*.log \
     "$TEST_DIR"/gh-checkout* "$TEST_DIR"/gh-merge-head* \
     "$TEST_DIR"/gh-merge-args* "$TEST_DIR"/gh-merge-body* \
-    "$TEST_DIR"/gh-comment*
+    "$TEST_DIR"/gh-comment* "$TEST_DIR"/git-checkout-main* \
+    "$TEST_DIR"/git-sibling-pull*
   rm -rf "$GIT_PATH_ROOT"
   mkdir -p "$GIT_PATH_ROOT"
+  unset GIT_WORKTREE_LIST
+  unset GIT_SIBLING_PULL_FAIL
+  unset TEST_CURRENT_WORKTREE
 }
 
 run_merge_pr() {
@@ -150,6 +175,11 @@ run_merge_pr() {
     GH_MERGE_ARGS_FILE="$TEST_DIR/gh-merge-args" \
     GH_MERGE_BODY_FILE="$TEST_DIR/gh-merge-body" \
     GH_COMMENT_FILE="$TEST_DIR/gh-comment" \
+    GIT_CHECKOUT_MAIN_FILE="$TEST_DIR/git-checkout-main" \
+    GIT_SIBLING_PULL_FILE="$TEST_DIR/git-sibling-pull" \
+    GIT_WORKTREE_LIST="${GIT_WORKTREE_LIST:-}" \
+    GIT_SIBLING_PULL_FAIL="${GIT_SIBLING_PULL_FAIL:-false}" \
+    TEST_CURRENT_WORKTREE="${TEST_CURRENT_WORKTREE:-/tmp/touchstone-feature-worktree}" \
     bash "$MERGE_SCRIPT_DIR/merge-pr.sh" "$@" >"$output_file" 2>&1
 }
 
@@ -171,6 +201,34 @@ if grep -q 'attempt 1: mergeStateStatus=CLEAN mergeable=MERGEABLE' "$TEST_DIR/ou
 else
   echo "FAIL: merge-pr.sh output did not show a successful jq-free merge path" >&2
   cat "$TEST_DIR/output-normal.txt" >&2
+  exit 1
+fi
+
+echo "==> Test: sibling worktree owning main is fast-forwarded without false merge failure"
+reset_case_files
+TEST_CURRENT_WORKTREE="/tmp/touchstone-feature-worktree"
+GIT_WORKTREE_LIST="$(cat <<'EOF'
+worktree /tmp/touchstone-main-worktree
+HEAD main-oid
+branch refs/heads/main
+
+worktree /tmp/touchstone-feature-worktree
+HEAD feature-oid
+branch refs/heads/feature/test
+
+EOF
+)"
+run_merge_pr "$TEST_DIR/output-sibling-worktree.txt" 123
+if grep -q '==> main is checked out in sibling worktree: /tmp/touchstone-main-worktree' "$TEST_DIR/output-sibling-worktree.txt" \
+  && grep -q '==> Fast-forwarding that worktree after remote merge' "$TEST_DIR/output-sibling-worktree.txt" \
+  && grep -q '==> Done\.' "$TEST_DIR/output-sibling-worktree.txt" \
+  && grep -q '^/tmp/touchstone-main-worktree$' "$TEST_DIR/git-sibling-pull" \
+  && [ ! -f "$TEST_DIR/git-checkout-main" ] \
+  && ! grep -q 'ERROR:' "$TEST_DIR/output-sibling-worktree.txt"; then
+  echo "==> PASS: sibling default worktree sync avoids false merge failure"
+else
+  echo "FAIL: sibling worktree sync did not avoid the checkout-main failure path" >&2
+  cat "$TEST_DIR/output-sibling-worktree.txt" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Fix `scripts/merge-pr.sh` post-merge sync to handle the case where the default branch is checked out in a sibling worktree. Before this change, the squash-merge succeeded remotely but the local sync printed `fatal: 'main' is already used by worktree at <path>` followed by misleading `ERROR: merge-pr.sh failed for PR #N` and `ORPHAN RISK` messages — even though the PR was merged successfully.

## Changes
- `scripts/merge-pr.sh`: new `worktree_path_for_branch` helper using `git worktree list --porcelain`; new `sync_default_branch_after_merge` that fast-forwards the sibling worktree via `git -C <sibling> pull --ff-only` instead of `git checkout` in the current worktree.
- `tests/test-merge-pr.sh`: extend the fake-git harness with `worktree list --porcelain` and `-C <path> pull --ff-only` mocks; new test asserts the sibling-worktree path produces no false `ERROR` and fast-forwards the sibling's default branch.

## Testing
- `bash tests/test-merge-pr.sh` — all scenarios pass including the new sibling-worktree case.
- Existing scenarios (no sibling, single-worktree case) still pass via the unchanged code paths.

## Emergency-bypass disclosure
Same as #115: Conductor reviewer wedged across providers (Vesper hook). Pushed with `--no-verify`; merging without merge-time review.

Closes #111.