### PR TITLE
feat: open-pr.sh --cleanup-worktree removes the feature worktree post-merge

### DIFF
--- a/principles/git-workflow.md
+++ b/principles/git-workflow.md
@@ -125,7 +125,12 @@ For the full fan-out playbook — slice manifests, file ownership, parent orches
 - **Shared `.git`.** Don't run destructive git ops (`git gc --prune=now`, `git worktree remove --force`) while a sibling worktree has uncommitted work — the shared object store is the same object store.
 - **Disk cost.** Each worktree is a full working tree. Not an issue for a small repo; matters for large monorepos with generated artifacts.
 
-**Cleanup.** After the PR merges, use `scripts/cleanup-worktrees.sh` from the main checkout to preview and remove clean merged-or-equivalent worktrees. It is dry-run by default and refuses dirty worktrees unless explicitly forced. `scripts/cleanup-branches.sh` already refuses to delete branches currently checked out in worktrees, so it won't fight you — but it also won't remove the worktree directories themselves.
+**Cleanup.** Two paths, pick whichever fits the moment:
+
+- **Inline (preferred for fire-and-forget).** Pass `--cleanup-worktree` alongside `--auto-merge` to `scripts/open-pr.sh`. After the PR squash-merges, the helper removes the current feature worktree itself by invoking `git worktree remove` from the default-branch worktree. The worktree is gone before the script returns, so there's nothing to come back to. Failures here are reported as warnings — the merge already happened, cleanup is best-effort.
+- **Deferred sweep.** From the main checkout, run `scripts/cleanup-worktrees.sh` (dry-run by default) to preview and `--execute` to remove clean merged-or-equivalent worktrees. Use this when several worktrees accumulated across sessions, or when the inline cleanup couldn't run (dirty tree, etc.).
+
+`scripts/cleanup-branches.sh` already refuses to delete branches currently checked out in worktrees, so it won't fight you — but it also won't remove the worktree directories themselves; that is what `cleanup-worktrees.sh` and the inline `--cleanup-worktree` flag are for.
 
 ## Emergency path
 

--- a/scripts/open-pr.sh
+++ b/scripts/open-pr.sh
@@ -7,11 +7,13 @@
 # Always uses the project's PR template if one exists.
 #
 # Usage:
-#   bash scripts/open-pr.sh                # title from last commit; base = default branch
-#   bash scripts/open-pr.sh --auto-merge   # open + Codex review + squash-merge
-#   bash scripts/open-pr.sh --draft        # same, opened as draft
-#   bash scripts/open-pr.sh --base feat/X  # stacked PR: base this PR on feat/X, not main
-#   bash scripts/open-pr.sh "Custom title" # explicit title
+#   bash scripts/open-pr.sh                          # title from last commit; base = default branch
+#   bash scripts/open-pr.sh --auto-merge             # open + Codex review + squash-merge
+#   bash scripts/open-pr.sh --auto-merge \
+#                            --cleanup-worktree       # auto-merge, then remove this feature worktree
+#   bash scripts/open-pr.sh --draft                  # same, opened as draft
+#   bash scripts/open-pr.sh --base feat/X            # stacked PR: base this PR on feat/X, not main
+#   bash scripts/open-pr.sh "Custom title"           # explicit title
 #
 # Exit contract (--auto-merge):
 #   exit 0 ⇔ `gh pr view <n> --json mergedAt --jq .mergedAt` is non-empty.
@@ -96,6 +98,46 @@ verify_pr_merged() {
     return 0
   fi
   return 1
+}
+
+# Locate the worktree that has the default branch checked out, by parsing
+# `git worktree list --porcelain`. Returns empty when no sibling worktree
+# owns the default branch (single-checkout case).
+default_branch_worktree_path() {
+  local default_branch="$1"
+  local current_path=""
+  awk -v target="refs/heads/$default_branch" '
+    /^worktree / { path = substr($0, length("worktree ") + 1) }
+    /^branch /   { if ($2 == target) { print path; exit } }
+  ' < <(git worktree list --porcelain)
+}
+
+# Remove the current feature worktree from the default-branch worktree.
+# Called after a successful auto-merge when --cleanup-worktree is set.
+# The cleanup is a best-effort convenience: failures are reported but do
+# not fail the script — the merge already happened, and a leftover
+# worktree is recoverable via `scripts/cleanup-worktrees.sh`.
+cleanup_feature_worktree() {
+  local current_path default_path
+  current_path="$(git rev-parse --show-toplevel)"
+  default_path="$(default_branch_worktree_path "$DEFAULT_BRANCH")"
+
+  if [ -z "$default_path" ]; then
+    echo "==> --cleanup-worktree: no sibling worktree owns $DEFAULT_BRANCH; nothing to remove."
+    return 0
+  fi
+  if [ "$current_path" = "$default_path" ]; then
+    echo "==> --cleanup-worktree: already in $DEFAULT_BRANCH worktree; nothing to remove."
+    return 0
+  fi
+
+  echo "==> Removing feature worktree $current_path (from $default_path) ..."
+  if ( cd "$default_path" && git worktree remove "$current_path" ); then
+    echo "==> Worktree removed."
+  else
+    echo "WARNING: git worktree remove failed for $current_path." >&2
+    echo "         Run 'bash scripts/cleanup-worktrees.sh' from $default_path to inspect and clean up." >&2
+  fi
 }
 
 find_base_merge_commit() {
@@ -187,6 +229,7 @@ fi
 # Parse flags early (needed before the existing-PR check).
 DRAFT_FLAG=""
 AUTO_MERGE=false
+CLEANUP_WORKTREE=false
 BASE_OVERRIDE=""
 POSITIONAL=()
 
@@ -194,6 +237,7 @@ while [ "$#" -gt 0 ]; do
   case "$1" in
     --draft) DRAFT_FLAG="--draft"; shift ;;
     --auto-merge) AUTO_MERGE=true; shift ;;
+    --cleanup-worktree) CLEANUP_WORKTREE=true; shift ;;
     --base)
       if [ "$#" -lt 2 ]; then
         echo "ERROR: --base requires a branch name." >&2
@@ -206,6 +250,14 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 set -- "${POSITIONAL[@]+"${POSITIONAL[@]}"}"
+
+# --cleanup-worktree is only meaningful with --auto-merge: without a merge
+# there is nothing to clean up to. Reject the combination loudly so the user
+# notices instead of getting silent no-op behavior.
+if [ "$CLEANUP_WORKTREE" = true ] && [ "$AUTO_MERGE" != true ]; then
+  echo "ERROR: --cleanup-worktree requires --auto-merge (cleanup runs only after a successful merge)." >&2
+  exit 1
+fi
 
 # Resolve the actual base branch: --base overrides the repo default.
 BASE_BRANCH="${BASE_OVERRIDE:-$DEFAULT_BRANCH}"
@@ -400,6 +452,10 @@ if [ "$AUTO_MERGE" = true ]; then
   if ! verify_pr_merged "$PR_NUMBER"; then
     echo "ERROR: merge-pr.sh exited 0 but PR #$PR_NUMBER is not merged on GitHub." >&2
     exit 1
+  fi
+
+  if [ "$CLEANUP_WORKTREE" = true ]; then
+    cleanup_feature_worktree
   fi
 fi
 

--- a/tests/test-open-pr-cleanup-worktree.sh
+++ b/tests/test-open-pr-cleanup-worktree.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# tests/test-open-pr-cleanup-worktree.sh — guard the --cleanup-worktree flag.
+#
+# Cases covered:
+#   1. --cleanup-worktree without --auto-merge → exits non-zero with a clear
+#      error (the cleanup runs only post-merge; the combo is meaningless).
+#   2. --cleanup-worktree with --auto-merge from a feature worktree → after
+#      successful merge, the feature worktree is removed by `git worktree
+#      remove`.
+#
+set -euo pipefail
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_DIR="$(mktemp -d -t touchstone-test-open-pr-cleanup.XXXXXX)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+ERRORS=0
+
+REPO_DIR="$TEST_DIR/repo"
+SCRIPT_DIR="$TEST_DIR/scripts"
+FAKE_BIN="$TEST_DIR/bin"
+mkdir -p "$SCRIPT_DIR" "$FAKE_BIN"
+
+cp "$TOUCHSTONE_ROOT/scripts/open-pr.sh" "$SCRIPT_DIR/open-pr.sh"
+# merge-pr.sh is invoked by open-pr.sh on --auto-merge; stub it.
+cat > "$SCRIPT_DIR/merge-pr.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$SCRIPT_DIR/open-pr.sh" "$SCRIPT_DIR/merge-pr.sh"
+
+# Mock gh: returns a stable PR URL on create, claims mergedAt is non-empty.
+cat > "$FAKE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$1 $2" in
+  "repo view") echo "main" ;;
+  "pr list") echo "" ;;
+  "pr create") echo "https://example.test/touchstone/pull/9999" ;;
+  "pr view") echo "2026-04-30T05:00:00Z" ;;
+  *) echo "unexpected gh args: $*" >&2; exit 1 ;;
+esac
+EOF
+chmod +x "$FAKE_BIN/gh"
+
+# Real git: bare remote + main worktree + feature worktree, so
+# `git worktree list --porcelain` reflects an actual sibling.
+REMOTE_DIR="$TEST_DIR/remote.git"
+git init --bare "$REMOTE_DIR" >/dev/null 2>&1
+git clone "$REMOTE_DIR" "$REPO_DIR" >/dev/null 2>&1
+git -C "$REPO_DIR" switch -c main >/dev/null 2>&1
+git -C "$REPO_DIR" config user.name "Touchstone Test"
+git -C "$REPO_DIR" config user.email "touchstone@example.com"
+mkdir -p "$REPO_DIR/.github"
+printf '## Summary\n' > "$REPO_DIR/.github/pull_request_template.md"
+printf 'base\n' > "$REPO_DIR/file.txt"
+git -C "$REPO_DIR" add .github/pull_request_template.md file.txt
+git -C "$REPO_DIR" commit -m "base" >/dev/null 2>&1
+git -C "$REPO_DIR" push -u origin main >/dev/null 2>&1
+
+FEATURE_DIR="$TEST_DIR/repo-feature"
+git -C "$REPO_DIR" worktree add "$FEATURE_DIR" -b feat/cleanup-test >/dev/null 2>&1
+printf 'change\n' >> "$FEATURE_DIR/file.txt"
+git -C "$FEATURE_DIR" add file.txt
+git -C "$FEATURE_DIR" commit -m "test change" >/dev/null 2>&1
+
+# Case 1 — flag combo validation
+echo "==> Case 1: --cleanup-worktree without --auto-merge is rejected"
+RC=0
+OUT="$TEST_DIR/case1.out"
+(
+  cd "$FEATURE_DIR"
+  PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    bash "$SCRIPT_DIR/open-pr.sh" --cleanup-worktree
+) >"$OUT" 2>&1 || RC=$?
+
+if [ "$RC" != "0" ] && grep -q -- '--cleanup-worktree requires --auto-merge' "$OUT"; then
+  echo "    PASS"
+else
+  echo "    FAIL: expected non-zero exit + clear error message" >&2
+  echo "    rc=$RC" >&2
+  cat "$OUT" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# Case 2 — happy path: feature worktree gets removed after merge
+echo "==> Case 2: --cleanup-worktree --auto-merge removes the feature worktree"
+RC=0
+OUT="$TEST_DIR/case2.out"
+(
+  cd "$FEATURE_DIR"
+  PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    bash "$SCRIPT_DIR/open-pr.sh" --auto-merge --cleanup-worktree
+) >"$OUT" 2>&1 || RC=$?
+
+if [ "$RC" = "0" ] \
+  && grep -q '==> Worktree removed.' "$OUT" \
+  && [ ! -d "$FEATURE_DIR" ]; then
+  echo "    PASS"
+else
+  echo "    FAIL: expected exit 0, 'Worktree removed.' in output, and \$FEATURE_DIR gone" >&2
+  echo "    rc=$RC" >&2
+  echo "    feature dir exists? $([ -d "$FEATURE_DIR" ] && echo yes || echo no)" >&2
+  cat "$OUT" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+if [ "$ERRORS" = "0" ]; then
+  echo "==> PASS: open-pr.sh --cleanup-worktree behaves correctly"
+  exit 0
+fi
+echo "==> FAIL: $ERRORS case(s) regressed" >&2
+exit 1


### PR DESCRIPTION
## Linked Issues

Closes #114

The fire-and-forget swarm flow leaves N worktree directories on disk
after the PRs merge — the operator has to remember each one and run
git worktree remove manually. Add --cleanup-worktree as an inline
companion to --auto-merge: after the PR squash-merges, the helper
locates the default-branch worktree and runs git worktree remove
on the current feature worktree from there. Failures degrade to a
WARNING (the merge already happened; cleanup is best-effort).

Refuses --cleanup-worktree without --auto-merge so the combo can't
silently no-op. New tests/test-open-pr-cleanup-worktree.sh exercises
both the rejection and the happy path against a real worktree.

Doc the two cleanup paths in principles/git-workflow.md: inline
--cleanup-worktree for the fire-and-forget case, deferred
cleanup-worktrees.sh sweep for accumulated cruft.

Closes-issue: #114

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
