### PR TITLE
feat: principle directs LLMs to file upstream autumngarage bugs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ Full rationale, worked examples, and the *why* behind each rule:
 - `principles/documentation-ownership.md`
 - `principles/git-workflow.md`
 - `principles/agent-swarms.md`
+- `principles/file-upstream-bugs.md`
 
 ## Required Delivery Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ Non-negotiable. Every code change is reviewed against them. Full rationale, work
 @principles/pre-implementation-checklist.md
 @principles/documentation-ownership.md
 @principles/agent-swarms.md
+@principles/file-upstream-bugs.md
 
 ## Git Workflow
 

--- a/lib/agents-principles-block.sh
+++ b/lib/agents-principles-block.sh
@@ -63,6 +63,7 @@ Full rationale, worked examples, and the *why* behind each rule:
 - `principles/documentation-ownership.md`
 - `principles/git-workflow.md`
 - `principles/agent-swarms.md`
+- `principles/file-upstream-bugs.md`
 
 ## Required Delivery Workflow
 

--- a/lib/claude-md-principles-ref.sh
+++ b/lib/claude-md-principles-ref.sh
@@ -95,6 +95,7 @@ claude_md_has_principles_ref() {
 @principles/pre-implementation-checklist.md
 @principles/documentation-ownership.md
 @principles/git-workflow.md
+@principles/file-upstream-bugs.md
 EOF
   return 0
 }
@@ -121,6 +122,7 @@ claude_md_insert_missing_principles_refs() {
 @principles/pre-implementation-checklist.md
 @principles/documentation-ownership.md
 @principles/git-workflow.md
+@principles/file-upstream-bugs.md
 EOF
 
   if [ ! -s "$missing_file" ]; then
@@ -158,6 +160,7 @@ them are touchstone-owned and refresh on every `touchstone update`.
 @principles/pre-implementation-checklist.md
 @principles/documentation-ownership.md
 @principles/git-workflow.md
+@principles/file-upstream-bugs.md
 
 ---
 BLOCK

--- a/principles/file-upstream-bugs.md
+++ b/principles/file-upstream-bugs.md
@@ -1,0 +1,40 @@
+# Filing bugs in autumngarage tools
+
+If you hit what looks like a bug in an autumngarage tool while working — actual unexpected behavior in the tool itself, not your project's misuse of it — file an issue upstream. Don't silently work around it; the same bug will bite the next user.
+
+## The repos
+
+- **touchstone** — `bin/touchstone`, the synced `scripts/`, `hooks/`, `principles/`, the bootstrap/update flow → https://github.com/autumngarage/touchstone/issues
+- **conductor** — the `conductor` CLI, provider routing, `conductor exec` / `call` / `ask` / `review` → https://github.com/autumngarage/conductor/issues
+- **cortex** — `.cortex/journal/`, `.cortex/doctrine/`, the Cortex Protocol → https://github.com/autumngarage/cortex/issues
+
+## How
+
+`gh issue create --repo autumngarage/<tool>` with this body shape:
+
+```
+## Symptom
+<what happened, with the exact error / output verbatim>
+
+## Repro
+<minimal sequence to trigger it>
+
+## Why this matters
+<one paragraph on impact / who or what it blocks>
+
+## Suggested fixes
+<cheapest first; optional but appreciated>
+
+## Discovered
+<while shipping <what>, on YYYY-MM-DD>
+```
+
+Search before filing: `gh issue list --repo autumngarage/<tool> --search "<keywords>"`. If a matching issue exists, comment with your repro instead of opening a duplicate.
+
+## When NOT to file
+
+- The bug is in your project's *use* of the tool, not the tool itself.
+- The bug is upstream of autumngarage (Anthropic / OpenAI / Google CLIs, `gh`, OS-level git, terminal emulators) — file with that vendor instead.
+- It's a question, not a bug — open a discussion or ask in the project's chat surface rather than filing.
+
+The point of this rule is that bugs in the autumngarage stack propagate to every project that uses it. Logging them upstream is how the ecosystem stays sharp; working around them silently is how the same bug bites the next person.

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -45,6 +45,7 @@ Full rationale, worked examples, and the *why* behind each rule:
 - `principles/documentation-ownership.md`
 - `principles/git-workflow.md`
 - `principles/agent-swarms.md`
+- `principles/file-upstream-bugs.md`
 
 ## Required Delivery Workflow
 

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -35,6 +35,7 @@ Non-negotiable. Every code change is reviewed against them. Full rationale, work
 @principles/pre-implementation-checklist.md
 @principles/documentation-ownership.md
 @principles/agent-swarms.md
+@principles/file-upstream-bugs.md
 
 ## Git Workflow
 

--- a/tests/test-claude-md-principles-ref.sh
+++ b/tests/test-claude-md-principles-ref.sh
@@ -66,6 +66,7 @@ cat > "$TEST_DIR/case-detect/CLAUDE.md" <<'EOF'
 @principles/pre-implementation-checklist.md
 @principles/documentation-ownership.md
 @principles/git-workflow.md
+@principles/file-upstream-bugs.md
 EOF
 if ! claude_md_has_principles_ref "$TEST_DIR/case-detect/CLAUDE.md"; then
   fail "should detect full required @principles/ import set"
@@ -178,6 +179,7 @@ setup_existing_repo() {
 @principles/pre-implementation-checklist.md
 @principles/documentation-ownership.md
 @principles/git-workflow.md
+@principles/file-upstream-bugs.md
 EOF
   elif [ "$with_imports" = partial ]; then
     cat > "$dir/CLAUDE.md" <<'EOF'


### PR DESCRIPTION
## Linked Issues

Closes #123

Add principles/file-upstream-bugs.md naming the three autumngarage
repos explicitly (touchstone, conductor, cortex), with the
gh-issue-create command and the house-style body shape (Symptom /
Repro / Why / Suggested fixes / Discovered). Wired through the
@principles import set in CLAUDE.md and the AGENTS.md managed block,
plus the templates/ copies and the lib helpers that touchstone uses
to refresh those refs in downstream projects.

LLMs are already capable of filing well-shaped issues; what was
missing was the baseline instruction telling them yes, file it, and
here is exactly which repo gets it. Adds ~150 tokens to the
always-loaded context across every bootstrapped project — cheap
relative to bugs going unfiled and biting the next user.

Test fixture in test-claude-md-principles-ref.sh updated to include
the new ref in the "complete imports" cases.

Closes-issue: #123

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
