### PR TITLE
fix: merge-pr.sh treats gh local-delete failure on MERGED PR as warning

### DIFF
--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -342,11 +342,32 @@ if [ -z "$REVIEWED_HEAD_OID" ]; then
   echo "ERROR: Cannot merge PR #$PR_NUMBER because no reviewed head commit was recorded." >&2
   exit 1
 fi
+gh_merge_exit=0
 if [ "$BYPASS_REVIEW" = true ]; then
   gh pr merge "$PR_NUMBER" --squash --delete-branch --match-head-commit "$REVIEWED_HEAD_OID" \
-    --body "Reviewer-bypass: $BYPASS_REASON"
+    --body "Reviewer-bypass: $BYPASS_REASON" || gh_merge_exit=$?
 else
-  gh pr merge "$PR_NUMBER" --squash --delete-branch --match-head-commit "$REVIEWED_HEAD_OID"
+  gh pr merge "$PR_NUMBER" --squash --delete-branch --match-head-commit "$REVIEWED_HEAD_OID" \
+    || gh_merge_exit=$?
+fi
+
+# `gh pr merge --delete-branch` does the squash AND tries to delete the
+# local feature branch. The local-delete fails when the branch is checked
+# out in the current worktree (the common case for parallel-worktree work).
+# When that happens, the remote merge succeeded server-side — only the
+# local cleanup didn't. Verify by asking the API; if MERGED, treat as
+# success with a warning so the script doesn't claim the PR failed.
+if [ "$gh_merge_exit" -ne 0 ]; then
+  pr_state="$(gh pr view "$PR_NUMBER" --json state --jq '.state' 2>/dev/null || echo "")"
+  if [ "$pr_state" = "MERGED" ]; then
+    echo "WARNING: gh pr merge exited $gh_merge_exit, but PR #$PR_NUMBER is MERGED on GitHub."
+    echo "         Likely cause: local feature branch is checked out in the current worktree,"
+    echo "         which blocks --delete-branch's local-delete step. Remote branch is gone."
+    echo "         Run 'bash scripts/cleanup-worktrees.sh --execute' from $DEFAULT_BRANCH to tidy up."
+  else
+    echo "ERROR: gh pr merge exited $gh_merge_exit and PR #$PR_NUMBER is not MERGED." >&2
+    exit "$gh_merge_exit"
+  fi
 fi
 
 # 5. Sync local default branch.

--- a/tests/test-merge-pr.sh
+++ b/tests/test-merge-pr.sh
@@ -35,7 +35,13 @@ case "${1:-} ${2:-}" in
     ;;
   "pr view")
     case "${5:-}" in
-      state) echo "OPEN" ;;
+      state)
+        if [ -f "${GH_MERGED_MARKER:-/dev/null/never}" ]; then
+          echo "MERGED"
+        else
+          echo "OPEN"
+        fi
+        ;;
       headRefName) echo "feature/test" ;;
       headRefOid) echo "pr-head-oid" ;;
       mergeStateStatus,mergeable) echo "CLEAN MERGEABLE" ;;
@@ -71,6 +77,13 @@ case "${1:-} ${2:-}" in
       printf '%s\n' "${9:-}" > "$GH_MERGE_BODY_FILE"
     fi
     echo "$7" > "$GH_MERGE_HEAD_FILE"
+    if [ -n "${GH_MERGED_MARKER:-}" ]; then
+      touch "$GH_MERGED_MARKER"
+    fi
+    if [ "${GH_PR_MERGE_FAIL_LOCAL:-false}" = "true" ]; then
+      echo "failed to delete local branch feature/test: failed to run git: error: cannot delete branch 'feature/test' used by worktree at '/tmp/touchstone-feature-worktree'" >&2
+      exit 1
+    fi
     echo "merged"
     ;;
   *)
@@ -156,12 +169,13 @@ reset_case_files() {
     "$TEST_DIR"/gh-checkout* "$TEST_DIR"/gh-merge-head* \
     "$TEST_DIR"/gh-merge-args* "$TEST_DIR"/gh-merge-body* \
     "$TEST_DIR"/gh-comment* "$TEST_DIR"/git-checkout-main* \
-    "$TEST_DIR"/git-sibling-pull*
+    "$TEST_DIR"/git-sibling-pull* "$TEST_DIR"/gh-merged-marker*
   rm -rf "$GIT_PATH_ROOT"
   mkdir -p "$GIT_PATH_ROOT"
   unset GIT_WORKTREE_LIST
   unset GIT_SIBLING_PULL_FAIL
   unset TEST_CURRENT_WORKTREE
+  unset GH_PR_MERGE_FAIL_LOCAL
 }
 
 run_merge_pr() {
@@ -175,6 +189,8 @@ run_merge_pr() {
     GH_MERGE_ARGS_FILE="$TEST_DIR/gh-merge-args" \
     GH_MERGE_BODY_FILE="$TEST_DIR/gh-merge-body" \
     GH_COMMENT_FILE="$TEST_DIR/gh-comment" \
+    GH_MERGED_MARKER="$TEST_DIR/gh-merged-marker" \
+    GH_PR_MERGE_FAIL_LOCAL="${GH_PR_MERGE_FAIL_LOCAL:-false}" \
     GIT_CHECKOUT_MAIN_FILE="$TEST_DIR/git-checkout-main" \
     GIT_SIBLING_PULL_FILE="$TEST_DIR/git-sibling-pull" \
     GIT_WORKTREE_LIST="${GIT_WORKTREE_LIST:-}" \
@@ -229,6 +245,35 @@ if grep -q '==> main is checked out in sibling worktree: /tmp/touchstone-main-wo
 else
   echo "FAIL: sibling worktree sync did not avoid the checkout-main failure path" >&2
   cat "$TEST_DIR/output-sibling-worktree.txt" >&2
+  exit 1
+fi
+
+echo "==> Test: gh local-branch-delete failure on a MERGED PR is a warning, not an error"
+reset_case_files
+TEST_CURRENT_WORKTREE="/tmp/touchstone-feature-worktree"
+GIT_WORKTREE_LIST="$(cat <<'EOF'
+worktree /tmp/touchstone-main-worktree
+HEAD main-oid
+branch refs/heads/main
+
+worktree /tmp/touchstone-feature-worktree
+HEAD feature-oid
+branch refs/heads/feature/test
+
+EOF
+)"
+GH_PR_MERGE_FAIL_LOCAL=true \
+  run_merge_pr "$TEST_DIR/output-gh-local-fail.txt" 123
+rc=$?
+if [ "$rc" = "0" ] \
+  && grep -q 'WARNING: gh pr merge exited 1, but PR #123 is MERGED on GitHub.' "$TEST_DIR/output-gh-local-fail.txt" \
+  && grep -q '==> Done\.' "$TEST_DIR/output-gh-local-fail.txt" \
+  && ! grep -q '^ERROR:' "$TEST_DIR/output-gh-local-fail.txt"; then
+  echo "==> PASS: local-delete failure on MERGED PR degrades to warning"
+else
+  echo "FAIL: gh local-delete failure should warn, not error, when PR is MERGED" >&2
+  echo "    rc=$rc" >&2
+  cat "$TEST_DIR/output-gh-local-fail.txt" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Linked Issues

Closes #121

gh pr merge --squash --delete-branch does the squash AND tries to
delete the local feature branch. The local-delete fails when the
branch is checked out in the current worktree (the common case for
parallel-worktree work) — but the remote merge already succeeded
server-side. The previous behavior exited non-zero and let
open-pr.sh print "ERROR: merge-pr.sh failed" + ORPHAN RISK, even
though the PR was actually merged.

Now: capture gh's exit code, query the PR state, and if MERGED,
print a WARNING with cleanup guidance and proceed. Only treat the
exit as a real failure when the PR is genuinely not merged.

Pairs with #117's worktree-aware sync_default_branch_after_merge
(which handles merge-pr.sh's own post-merge step but couldn't see
gh's earlier exit).

Closes-issue: #121

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
