### PR TITLE
fix: branch-guard.sh recognizes 'cd <worktree> && git commit'

### DIFF
--- a/hooks/branch-guard.sh
+++ b/hooks/branch-guard.sh
@@ -53,13 +53,35 @@ if ! printf '%s' "$command" | grep -qE '\bgit([[:space:]]+-c[[:space:]]+[^[:spac
   exit 0
 fi
 
-# Worktree-aware: when commit targets a different repo via `-C <path>`,
-# check that branch instead. The previous version saw `main` as the
-# current branch even when the commit was being directed at a feature
-# worktree via `git -C <worktree> commit`, blocking legitimate work.
+# Worktree-aware: when commit targets a different repo via `-C <path>` OR
+# the operator wrote `cd <path> && git commit`, check that branch instead.
+# The previous version saw `main` as the current branch even when the commit
+# was being directed at a feature worktree, blocking legitimate work.
 # Lowercase `-c` (the config-override flag) does not change directory
 # and so does NOT trigger this override.
-target_cwd="$(printf '%s' "$command" | grep -oE '\-C[[:space:]]+[^[:space:]]+' | sed -E 's/^-C[[:space:]]+//' | tail -1 || true)"
+target_cwd_from_C="$(printf '%s' "$command" | grep -oE '\-C[[:space:]]+[^[:space:]]+' | sed -E 's/^-C[[:space:]]+//' | tail -1 || true)"
+
+# `cd <path> && git commit` shape: walk shell-statement boundaries (&&, ||,
+# ;) and remember the last `cd <path>` from segments BEFORE the segment
+# that runs `git commit`. cds AFTER the commit (e.g. `git commit; cd
+# elsewhere`) don't affect the commit's cwd and must be ignored — otherwise
+# they'd silently bypass the guard on main.
+target_cwd_from_cd=""
+while IFS= read -r segment; do
+  trimmed="$(printf '%s' "$segment" | sed -E 's/^[[:space:]]+//')"
+  if printf '%s' "$trimmed" | grep -qE '^git([[:space:]]+-[cC][[:space:]]+[^[:space:]]+)*[[:space:]]+commit([[:space:]]|$)'; then
+    break
+  fi
+  cd_target="$(printf '%s' "$trimmed" | grep -oE '^cd[[:space:]]+[^[:space:]]+' | sed -E 's/^cd[[:space:]]+//' || true)"
+  if [ -n "$cd_target" ]; then
+    target_cwd_from_cd="$cd_target"
+  fi
+done < <(printf '%s' "$command" | tr '&;|' '\n')
+
+# `-C` is the more explicit form; prefer it. Fall back to the last `cd`
+# target seen before the commit.
+target_cwd="${target_cwd_from_C:-$target_cwd_from_cd}"
+
 if [ -n "$target_cwd" ]; then
   if [ -n "$cwd" ] && [ -d "$cwd/$target_cwd" ]; then
     cwd="$cwd/$target_cwd"

--- a/tests/test-guidance-hooks.sh
+++ b/tests/test-guidance-hooks.sh
@@ -150,6 +150,38 @@ assert "allows 'git -C <worktree>' commit when worktree is on a feature branch" 
 assert "lowercase -c (config flag) does not bypass the guard on main" "2" \
   "$(run_hook "$BRANCH_GUARD" "$(mkjson "git -c core.editor=foo commit -m 'wip'")")"
 
+# 9. cd <worktree> && git commit — same worktree-aware idea as case 7, but
+#    using `cd` instead of `git -C`. Operators and agents both write this
+#    shape more naturally. The hook should follow the cd target to the
+#    feature-branch worktree and allow the commit.
+CD_JSON="$(jq -nc \
+  --arg cmd "cd $WORKTREE && git commit -m 'wip'" \
+  --arg cwd "$TMPDIR" \
+  '{tool_name: "Bash", tool_input: {command: $cmd}, cwd: $cwd}')"
+assert "allows 'cd <worktree> && git commit' when worktree is on a feature branch" "0" \
+  "$(run_hook "$BRANCH_GUARD" "$CD_JSON")"
+
+# 10. cd AFTER the commit must NOT bypass the guard. `git commit; cd
+#     <feature-worktree>` is a commit on main followed by an unrelated
+#     cd; the cd doesn't affect the commit's cwd, so the guard must
+#     still block.
+POST_CD_JSON="$(jq -nc \
+  --arg cmd "git commit -m 'wip' ; cd $WORKTREE" \
+  --arg cwd "$TMPDIR" \
+  '{tool_name: "Bash", tool_input: {command: $cmd}, cwd: $cwd}')"
+assert "blocks 'git commit; cd <feature>' on main (cd after commit is ignored)" "2" \
+  "$(run_hook "$BRANCH_GUARD" "$POST_CD_JSON")"
+
+# 11. chained cd — last one before git commit wins (matches `-C` semantics).
+#     `cd /tmp && cd <worktree> && git commit` should resolve to the
+#     worktree's branch, not /tmp's.
+CHAIN_JSON="$(jq -nc \
+  --arg cmd "cd /tmp && cd $WORKTREE && git commit -m 'wip'" \
+  --arg cwd "$TMPDIR" \
+  '{tool_name: "Bash", tool_input: {command: $cmd}, cwd: $cwd}')"
+assert "chained cd: last cd before commit wins (allows feature-branch commit)" "0" \
+  "$(run_hook "$BRANCH_GUARD" "$CHAIN_JSON")"
+
 # ----------------------------------------------------------------------
 # emergency-disclosure
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Linked Issues

Closes #122

The hook already followed `git -C <path>` to the right repo for the
worktree-aware case, but operators and AI agents both write `cd
<worktree> && git commit -m "..."` more naturally. The old parser
only saw the parent shell's branch (main) and blocked.

Walk shell-statement boundaries (&&, ||, ;), extract leading `cd
<path>` from each segment, and stop at the segment that actually
runs `git commit`. cds AFTER the commit (e.g. `git commit; cd
elsewhere`) are explicitly NOT honored — they don't affect the
commit's cwd, and accepting them would silently allow main commits.

`-C` is the more explicit form; prefer it. Fall back to the last cd
target seen before the commit. Three new test cases cover: cd
before commit (allow), cd after commit (block), chained cds (last
wins).

Closes-issue: #122

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
