### PR TITLE
docs: encourage filing GitHub issues for bugs (own project + autumngarage tools)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ Driver fallback is shared-contract fallback: Codex and other AGENTS.md-native to
 - **Make irreversible actions recoverable** — destructive operations need a dry-run, backup, idempotency, rollback, or forward-fix plan before they run.
 - **Preserve compatibility at boundaries** — public API/config/schema/CLI/hook/template changes need a compatibility or migration plan.
 - **Audit weak-point classes** — when a structural bug is found, audit the class and add a guardrail; don't fix only the one instance.
+- **File issues for bugs** — open a GitHub issue when you find a bug, in this project or in an autumngarage tool. Don't silently work around it.
 
 Full rationale, worked examples, and the *why* behind each rule:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ Non-negotiable. Every code change is reviewed against them. Full rationale, work
 - **Preserve compatibility at boundaries** — public API/config/schema/CLI/hook/template changes need a compatibility or migration plan.
 - **Audit weak-point classes** — find a structural bug → audit the class + add a guardrail. Use the `touchstone-audit-weak-points` skill.
 - **Isolate file-writing subagents** — parallel workers use dedicated worktrees, slice manifests, and disjoint file ownership by default.
+- **File issues for bugs** — open a GitHub issue when you find a bug, in this project or in an autumngarage tool. Don't silently work around it.
 
 @principles/engineering-principles.md
 @principles/pre-implementation-checklist.md

--- a/lib/agents-principles-block.sh
+++ b/lib/agents-principles-block.sh
@@ -55,6 +55,7 @@ Driver fallback is shared-contract fallback: Codex and other AGENTS.md-native to
 - **Make irreversible actions recoverable** — destructive operations need a dry-run, backup, idempotency, rollback, or forward-fix plan before they run.
 - **Preserve compatibility at boundaries** — public API/config/schema/CLI/hook/template changes need a compatibility or migration plan.
 - **Audit weak-point classes** — when a structural bug is found, audit the class and add a guardrail; don't fix only the one instance.
+- **File issues for bugs** — open a GitHub issue when you find a bug, in this project or in an autumngarage tool. Don't silently work around it.
 
 Full rationale, worked examples, and the *why* behind each rule:
 

--- a/principles/file-upstream-bugs.md
+++ b/principles/file-upstream-bugs.md
@@ -1,16 +1,21 @@
-# Filing bugs in autumngarage tools
+# Filing bugs as issues
 
-If you hit what looks like a bug in an autumngarage tool while working — actual unexpected behavior in the tool itself, not your project's misuse of it — file an issue upstream. Don't silently work around it; the same bug will bite the next user.
+When you find a bug, file a GitHub issue. Don't silently work around it. Two cases — bugs in the project you're working on, and bugs in the autumngarage tools you depend on — and the discipline is the same in both: write down what's broken so the next person doesn't trip over it.
 
-## The repos
+The cost of filing an issue is two minutes. The cost of the next person rediscovering the same bug is hours.
 
-- **touchstone** — `bin/touchstone`, the synced `scripts/`, `hooks/`, `principles/`, the bootstrap/update flow → https://github.com/autumngarage/touchstone/issues
-- **conductor** — the `conductor` CLI, provider routing, `conductor exec` / `call` / `ask` / `review` → https://github.com/autumngarage/conductor/issues
-- **cortex** — `.cortex/journal/`, `.cortex/doctrine/`, the Cortex Protocol → https://github.com/autumngarage/cortex/issues
+## Bugs in this project
 
-## How
+If you find a bug in the project you're working on, file an issue against that project — even one you can't fix right now, even one you're about to fix in the same session. The issue is the durable record; the fix commit is the resolution. A bug that lives only in conversation gets rediscovered.
 
-`gh issue create --repo autumngarage/<tool>` with this body shape:
+When to file:
+
+- **Discovered while doing unrelated work, not fixing now** → file an issue. Note it in the current PR description if relevant ("noticed in passing — see #123").
+- **Fixing in the current session** → file the issue first, then close it via the PR with a `Closes #<n>` trailer (see `principles/git-workflow.md` for trailer conventions; `scripts/open-pr.sh` will auto-inject the closing line).
+- **Suspect a bug but unsure** → file it as a question / "needs repro" issue rather than letting it sit in chat. Re-discovery later is more expensive than a wrong-flagged issue you close.
+- **Hard-won lesson worth capturing** → if the bug taught a generalizable lesson, file the issue and link it from `CLAUDE.md`'s "Hard-Won Lessons" section.
+
+`gh issue create` (no `--repo` flag — it defaults to the current project's repo). Body shape:
 
 ```
 ## Symptom
@@ -26,15 +31,27 @@ If you hit what looks like a bug in an autumngarage tool while working — actua
 <cheapest first; optional but appreciated>
 
 ## Discovered
-<while shipping <what>, on YYYY-MM-DD>
+<while doing <what>, on YYYY-MM-DD>
 ```
 
-Search before filing: `gh issue list --repo autumngarage/<tool> --search "<keywords>"`. If a matching issue exists, comment with your repro instead of opening a duplicate.
+Search before filing: `gh issue list --search "<keywords>"`. If a matching issue exists, comment with your repro instead of opening a duplicate.
+
+## Bugs in autumngarage tools
+
+If you hit what looks like a bug in an autumngarage tool — actual unexpected behavior in the tool itself, not your project's misuse of it — file the issue **upstream against the tool's repo**, not against your project. The same bug will bite the next user; logging it in the tool's repo is how the ecosystem stays sharp.
+
+The repos:
+
+- **touchstone** — `bin/touchstone`, the synced `scripts/`, `hooks/`, `principles/`, the bootstrap/update flow → https://github.com/autumngarage/touchstone/issues
+- **conductor** — the `conductor` CLI, provider routing, `conductor exec` / `call` / `ask` / `review` → https://github.com/autumngarage/conductor/issues
+- **cortex** — `.cortex/journal/`, `.cortex/doctrine/`, the Cortex Protocol → https://github.com/autumngarage/cortex/issues
+
+`gh issue create --repo autumngarage/<tool>` with the same body shape as above. Search first: `gh issue list --repo autumngarage/<tool> --search "<keywords>"`. If a matching issue exists, comment with your repro instead of opening a duplicate.
 
 ## When NOT to file
 
-- The bug is in your project's *use* of the tool, not the tool itself.
-- The bug is upstream of autumngarage (Anthropic / OpenAI / Google CLIs, `gh`, OS-level git, terminal emulators) — file with that vendor instead.
-- It's a question, not a bug — open a discussion or ask in the project's chat surface rather than filing.
+- The bug is in your project's *use* of the tool, not the tool itself → the issue belongs against your project, not the tool.
+- The bug is upstream of autumngarage (Anthropic / OpenAI / Google CLIs, `gh`, OS-level git, terminal emulators) → file with that vendor instead.
+- It's a question, not a bug → open a discussion or ask in the project's chat surface rather than filing.
 
-The point of this rule is that bugs in the autumngarage stack propagate to every project that uses it. Logging them upstream is how the ecosystem stays sharp; working around them silently is how the same bug bites the next person.
+The point of this rule is that bugs you don't write down propagate silently. Logging them — wherever they live — is how the work compounds instead of churning.

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -37,6 +37,7 @@ Driver fallback is shared-contract fallback: Codex and other AGENTS.md-native to
 - **Make irreversible actions recoverable** — destructive operations need a dry-run, backup, idempotency, rollback, or forward-fix plan before they run.
 - **Preserve compatibility at boundaries** — public API/config/schema/CLI/hook/template changes need a compatibility or migration plan.
 - **Audit weak-point classes** — when a structural bug is found, audit the class and add a guardrail; don't fix only the one instance.
+- **File issues for bugs** — open a GitHub issue when you find a bug, in this project or in an autumngarage tool. Don't silently work around it.
 
 Full rationale, worked examples, and the *why* behind each rule:
 

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -30,6 +30,7 @@ Non-negotiable. Every code change is reviewed against them. Full rationale, work
 - **Preserve compatibility at boundaries** — public API/config/schema/CLI/hook/template changes need a compatibility or migration plan.
 - **Audit weak-point classes** — find a structural bug → audit the class + add a guardrail. Use the `touchstone-audit-weak-points` skill.
 - **Isolate file-writing subagents** — parallel workers use dedicated worktrees, slice manifests, and disjoint file ownership by default.
+- **File issues for bugs** — open a GitHub issue when you find a bug, in this project or in an autumngarage tool. Don't silently work around it.
 
 @principles/engineering-principles.md
 @principles/pre-implementation-checklist.md


### PR DESCRIPTION
Broaden principles/file-upstream-bugs.md from "file upstream against
autumngarage tools" to the more general "file an issue when you find a
bug, wherever it lives." The two cases — bugs in the project you're
working on and bugs in shared autumngarage tools — get distinct sections,
but the discipline is the same: write down what's broken so the next
person doesn't trip over it.

Add a one-line "File issues for bugs" bullet to the engineering-
principles daily-reminder list in CLAUDE.md, AGENTS.md (via the managed
block in lib/agents-principles-block.sh), and the templates so downstream
projects pick it up on `touchstone update`. Filename of the principle
file stays `file-upstream-bugs.md` to keep existing @-imports in
downstream CLAUDE.md files working.

Why: bugs that live only in conversation get rediscovered. The cost of
filing an issue is two minutes; the cost of a re-discovery is hours.

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
