### PR TITLE
feat(integrations): post-merge cortex journal hook (T1.9)

### DIFF
--- a/bootstrap/update-project.sh
+++ b/bootstrap/update-project.sh
@@ -342,6 +342,7 @@ fi
 update_file "$TOUCHSTONE_ROOT/hooks/codex-review.sh" "$PROJECT_DIR/scripts/codex-review.sh"
 update_file "$TOUCHSTONE_ROOT/hooks/branch-guard.sh" "$PROJECT_DIR/scripts/branch-guard.sh"
 update_file "$TOUCHSTONE_ROOT/hooks/emergency-disclosure.sh" "$PROJECT_DIR/scripts/emergency-disclosure.sh"
+update_file "$TOUCHSTONE_ROOT/hooks/cortex-pr-merged-hook.sh" "$PROJECT_DIR/scripts/cortex-pr-merged-hook.sh"
 update_file "$TOUCHSTONE_ROOT/scripts/touchstone-run.sh" "$PROJECT_DIR/scripts/touchstone-run.sh"
 update_file "$TOUCHSTONE_ROOT/scripts/open-pr.sh" "$PROJECT_DIR/scripts/open-pr.sh"
 update_file "$TOUCHSTONE_ROOT/scripts/merge-pr.sh" "$PROJECT_DIR/scripts/merge-pr.sh"
@@ -488,6 +489,7 @@ write_touchstone_manifest() {
     printf 'scripts/codex-review.sh\n'
     printf 'scripts/branch-guard.sh\n'
     printf 'scripts/emergency-disclosure.sh\n'
+    printf 'scripts/cortex-pr-merged-hook.sh\n'
     printf 'scripts/touchstone-run.sh\n'
     printf 'scripts/open-pr.sh\n'
     printf 'scripts/merge-pr.sh\n'

--- a/hooks/cortex-pr-merged-hook.sh
+++ b/hooks/cortex-pr-merged-hook.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+#
+# hooks/cortex-pr-merged-hook.sh — auto-draft a Cortex `pr-merged` Journal
+# entry after a PR squash-merges to the default branch.
+#
+# Implements Cortex Protocol § 2 Tier-1 trigger T1.9 ("Pull request merged
+# to the default branch"). When a project has both Touchstone and Cortex
+# installed, this hook fires from `merge-pr.sh` immediately after the
+# remote merge succeeds and the local default branch is synced. It shells
+# out to `cortex journal draft pr-merged --no-edit`, captures the new
+# entry's path on stdout, stages it, commits with `--no-verify` (so the
+# auto-commit doesn't recurse through any other default-branch hooks),
+# and pushes a single follow-up commit to the default branch.
+#
+# Activation contract (ALL of these must hold; otherwise silent exit 0):
+#   1. Push target is the default branch (main or master). Resolved by
+#      asking `gh repo view`.
+#   2. The repo has a `.cortex/` directory at the same level as `.git/`.
+#   3. The `cortex` CLI is on $PATH.
+#   4. `.touchstone-config` has `cortex_pr_merged_hook=auto` or `=on`.
+#      Default for newly-bootstrapped projects: `auto`. Value `off`
+#      disables. Missing key is treated as `auto` (so projects that
+#      haven't migrated yet still benefit when the other gates pass).
+#
+# Failure modes (no silent failures past activation):
+#   - cortex missing mid-flow (between detection and exec): log to stderr
+#     and exit 0 (degrade gracefully — don't fail the merge because the
+#     CLI was uninstalled in a tiny race window).
+#   - `cortex journal draft` exits non-zero: stderr surfaced, exit 1.
+#   - Empty stdout (no path returned): stderr message, exit 1.
+#   - Returned path doesn't exist after the call: stderr message, exit 1.
+#   - `git commit` or `git push` failure: stderr message, exit 1.
+#
+# Inputs (env, all optional):
+#   TOUCHSTONE_MERGED_PR        — PR number to thread through to the
+#                                 commit message (e.g. supplied by
+#                                 merge-pr.sh after `gh pr merge`).
+#   TOUCHSTONE_CORTEX_HOOK_DISABLE
+#                               — set to 1/true/on to short-circuit even
+#                                 when config says auto/on. Useful for
+#                                 tests that want to verify a path
+#                                 without firing the writer.
+#   TOUCHSTONE_DEFAULT_BRANCH   — override the default-branch lookup
+#                                 (the test fixture sets this so it
+#                                 doesn't need a configured GitHub remote).
+#
+# Exit codes:
+#   0 — fired and committed; OR silently skipped (inactive); OR cortex
+#       went missing mid-flow (graceful degrade).
+#   1 — activated and a real failure occurred (journal draft failed,
+#       commit/push failed, missing path).
+#
+set -euo pipefail
+
+log() { printf '%s\n' "$*" >&2; }
+
+truthy() {
+  case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" in
+    1 | true | yes | on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Read a flat key=value from .touchstone-config. Echoes the trimmed value
+# on stdout. Empty output means "key absent or no value". Comment lines
+# (starting with `#`) and blank lines are ignored. The final occurrence
+# wins (matching the wider config-parser idiom in new-project.sh).
+read_config_value() {
+  local config_file="$1" key="$2"
+  local line lhs rhs result=""
+  [ -f "$config_file" ] || { printf ''; return 0; }
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="${line#"${line%%[![:space:]]*}"}"
+    case "$line" in '#'* | '') continue ;; esac
+    case "$line" in *=*) ;; *) continue ;; esac
+    lhs="${line%%=*}"
+    lhs="${lhs#"${lhs%%[![:space:]]*}"}"
+    lhs="${lhs%"${lhs##*[![:space:]]}"}"
+    if [ "$lhs" = "$key" ]; then
+      rhs="${line#*=}"
+      rhs="${rhs#"${rhs%%[![:space:]]*}"}"
+      rhs="${rhs%"${rhs##*[![:space:]]}"}"
+      result="$rhs"
+    fi
+  done < "$config_file"
+  printf '%s' "$result"
+}
+
+resolve_default_branch() {
+  if [ -n "${TOUCHSTONE_DEFAULT_BRANCH:-}" ]; then
+    printf '%s' "$TOUCHSTONE_DEFAULT_BRANCH"
+    return 0
+  fi
+  local resolved=""
+  if command -v gh >/dev/null 2>&1; then
+    resolved="$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || true)"
+  fi
+  if [ -z "$resolved" ]; then
+    # Fall back to the local symbolic-ref of origin/HEAD; finally to "main".
+    resolved="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||' || true)"
+  fi
+  printf '%s' "${resolved:-main}"
+}
+
+# 1. Detection — silent skip if any precondition fails.
+PROJECT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "$PROJECT_DIR" ]; then
+  exit 0
+fi
+
+current_branch="$(git -C "$PROJECT_DIR" branch --show-current 2>/dev/null || true)"
+default_branch="$(resolve_default_branch)"
+if [ -z "$current_branch" ] || [ "$current_branch" != "$default_branch" ]; then
+  exit 0
+fi
+
+if [ ! -d "$PROJECT_DIR/.cortex" ]; then
+  exit 0
+fi
+
+# Project-level opt-out via env (test fixtures + emergency disable).
+if truthy "${TOUCHSTONE_CORTEX_HOOK_DISABLE:-0}"; then
+  exit 0
+fi
+
+config_value="$(read_config_value "$PROJECT_DIR/.touchstone-config" cortex_pr_merged_hook)"
+case "$config_value" in
+  off | OFF | Off) exit 0 ;;
+  on | ON | On | auto | AUTO | Auto | "") ;; # default to auto when absent
+  *)
+    # Unknown value — treat as off but warn so the project can fix the
+    # config without surprise behavior.
+    log "cortex-pr-merged-hook: unknown cortex_pr_merged_hook='$config_value' (expected: auto|on|off); skipping."
+    exit 0
+    ;;
+esac
+
+if ! command -v cortex >/dev/null 2>&1; then
+  # Detection passed (`.cortex/` exists, config is auto/on) but the CLI
+  # is missing. The brief calls this a graceful-degrade case — don't
+  # fail the merge over a missing optional tool.
+  exit 0
+fi
+
+# 2. Activated path — from here on, errors are visible failures.
+
+# Refuse to run on a dirty tree: we'd silently fold uncommitted user work
+# into the auto-commit. The caller (merge-pr.sh) leaves a clean tree by
+# the time we reach this point; if anything else changed, that's a real
+# problem the operator should see.
+if [ -n "$(git -C "$PROJECT_DIR" status --porcelain)" ]; then
+  log "cortex-pr-merged-hook: working tree has uncommitted changes after merge; refusing to auto-draft (would fold user changes into the auto-commit)."
+  exit 1
+fi
+
+# `cortex journal draft pr-merged --no-edit` writes the entry and prints
+# the absolute path on stdout. We capture stdout to grab that path; we
+# leave stderr untouched so any cortex-side warnings (gh not auth'd, etc)
+# surface to the operator running the merge.
+draft_stdout=""
+draft_status=0
+draft_stdout="$(cd "$PROJECT_DIR" && cortex journal draft pr-merged --no-edit)" \
+  || draft_status=$?
+if [ "$draft_status" -ne 0 ]; then
+  log "cortex-pr-merged-hook: cortex journal draft pr-merged exited $draft_status."
+  exit 1
+fi
+
+# Take the last non-empty stdout line as the path. cortex's draft command
+# emits exactly one line (the absolute path) but a trailing newline or a
+# warning printed by an upstream Python wrapper could appear; the most-
+# recent line is the path.
+candidate="$(printf '%s\n' "$draft_stdout" | awk 'NF{p=$0} END{print p}')"
+if [ -z "$candidate" ]; then
+  log "cortex-pr-merged-hook: cortex journal draft returned no path on stdout."
+  exit 1
+fi
+
+if [ ! -f "$candidate" ]; then
+  log "cortex-pr-merged-hook: returned path '$candidate' is not a regular file."
+  exit 1
+fi
+
+# 3. Stage + commit + push as a single follow-up commit on the default branch.
+rel_path="${candidate#"$PROJECT_DIR"/}"
+pr_suffix=""
+if [ -n "${TOUCHSTONE_MERGED_PR:-}" ]; then
+  pr_suffix=" for #${TOUCHSTONE_MERGED_PR}"
+fi
+commit_message="docs(journal): auto-draft pr-merged entry${pr_suffix}"
+
+if ! git -C "$PROJECT_DIR" add -- "$rel_path"; then
+  log "cortex-pr-merged-hook: git add '$rel_path' failed."
+  exit 1
+fi
+
+# --no-verify is intentional. Other default-branch hooks (codex-review,
+# touchstone-validate) inspect the diff and run network calls; this is
+# a deterministic auto-commit of a single template-shaped journal file
+# generated by the cortex CLI a moment ago, so re-running them adds no
+# safety and would slow every merge by minutes.
+if ! git -C "$PROJECT_DIR" commit --no-verify -m "$commit_message" >/dev/null; then
+  log "cortex-pr-merged-hook: git commit failed."
+  exit 1
+fi
+
+# Skip the push only when explicitly requested (tests use this to verify
+# the local commit shape without hitting a remote).
+if truthy "${TOUCHSTONE_CORTEX_HOOK_SKIP_PUSH:-0}"; then
+  exit 0
+fi
+
+if ! git -C "$PROJECT_DIR" push origin "HEAD:${default_branch}"; then
+  log "cortex-pr-merged-hook: git push to origin/${default_branch} failed."
+  log "  The auto-draft entry committed locally as ${rel_path}; push when ready."
+  exit 1
+fi
+
+exit 0

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -372,4 +372,31 @@ fi
 
 # 5. Sync local default branch.
 sync_default_branch_after_merge
+
+# 6. Cortex post-merge hook (T1.9). Fires only when the project meets the
+# activation criteria documented in scripts/cortex-pr-merged-hook.sh.
+# Activation is the hook's job — we always invoke and let it self-gate.
+# The hook may produce a follow-up commit on the default branch; that
+# commit is created with --no-verify so it doesn't recurse through this
+# script's review gates. Failures inside the hook surface as visible
+# stderr; we don't fail the overall merge over a journal-write hiccup.
+CORTEX_HOOK_SCRIPT=""
+for candidate_hook in \
+  "$SCRIPT_DIR/cortex-pr-merged-hook.sh" \
+  "$(git rev-parse --show-toplevel 2>/dev/null)/scripts/cortex-pr-merged-hook.sh"; do
+  if [ -n "$candidate_hook" ] && [ -f "$candidate_hook" ]; then
+    CORTEX_HOOK_SCRIPT="$candidate_hook"
+    break
+  fi
+done
+
+if [ -n "$CORTEX_HOOK_SCRIPT" ]; then
+  hook_status=0
+  TOUCHSTONE_MERGED_PR="$PR_NUMBER" bash "$CORTEX_HOOK_SCRIPT" || hook_status=$?
+  if [ "$hook_status" -ne 0 ]; then
+    echo "WARNING: cortex-pr-merged-hook exited $hook_status (see above)." >&2
+    echo "         The PR merged cleanly; only the auto-draft journal step had a problem." >&2
+  fi
+fi
+
 echo "==> Done."

--- a/tests/test-cortex-pr-merged-hook.sh
+++ b/tests/test-cortex-pr-merged-hook.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+#
+# tests/test-cortex-pr-merged-hook.sh — exercise the activation gates +
+# graceful-degradation paths for hooks/cortex-pr-merged-hook.sh.
+#
+# The hook implements Cortex Protocol § 2 Tier-1 trigger T1.9
+# (auto-draft a `pr-merged` Journal entry after a PR squash-merges).
+# It MUST silently no-op when activation conditions aren't met (so
+# projects without Cortex aren't disturbed) and MUST surface visible
+# failures past activation (no silent failures).
+#
+# This is a behavioral test against real fixtures (no mocks). The hook
+# exposes test-friendly env knobs (TOUCHSTONE_DEFAULT_BRANCH,
+# TOUCHSTONE_CORTEX_HOOK_DISABLE, TOUCHSTONE_CORTEX_HOOK_SKIP_PUSH) so
+# we can drive the activation logic end-to-end without needing a real
+# GitHub remote or pushing.
+
+set -euo pipefail
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK="$TOUCHSTONE_ROOT/hooks/cortex-pr-merged-hook.sh"
+
+if [ ! -f "$HOOK" ]; then
+  echo "FAIL: hook source missing: $HOOK" >&2
+  exit 1
+fi
+
+if [ ! -x "$HOOK" ]; then
+  echo "FAIL: hook source must be executable: $HOOK" >&2
+  exit 1
+fi
+
+# Each scenario builds a fresh git repo fixture in a tmpdir so state
+# from one test doesn't leak into the next. The hook resolves the
+# default branch via TOUCHSTONE_DEFAULT_BRANCH when set, so we never
+# need a configured GitHub remote.
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+mk_fixture() {
+  local fixture="$1"
+  local dir="$TMPROOT/$fixture"
+  mkdir -p "$dir"
+  (
+    cd "$dir"
+    git init -q -b main
+    git config user.email t@e.co
+    git config user.name Test
+    : > .keep
+    git add .keep
+    git commit -q -m "init"
+  )
+  printf '%s' "$dir"
+}
+
+# Scenario A: no .cortex/ → silent skip, exit 0, no commit.
+A="$(mk_fixture A)"
+A_HEAD_BEFORE="$(git -C "$A" rev-parse HEAD)"
+(cd "$A" && TOUCHSTONE_DEFAULT_BRANCH=main bash "$HOOK")
+A_HEAD_AFTER="$(git -C "$A" rev-parse HEAD)"
+if [ "$A_HEAD_BEFORE" != "$A_HEAD_AFTER" ]; then
+  echo "FAIL [A]: hook created a commit when .cortex/ was absent" >&2
+  exit 1
+fi
+
+# Scenario B: .cortex/ present + config explicitly `off` → silent skip.
+B="$(mk_fixture B)"
+mkdir -p "$B/.cortex"
+echo "cortex_pr_merged_hook=off" > "$B/.touchstone-config"
+B_HEAD_BEFORE="$(git -C "$B" rev-parse HEAD)"
+(cd "$B" && TOUCHSTONE_DEFAULT_BRANCH=main bash "$HOOK")
+B_HEAD_AFTER="$(git -C "$B" rev-parse HEAD)"
+if [ "$B_HEAD_BEFORE" != "$B_HEAD_AFTER" ]; then
+  echo "FAIL [B]: hook fired with cortex_pr_merged_hook=off" >&2
+  exit 1
+fi
+
+# Scenario C: .cortex/ present + config absent (default auto) + cortex
+# CLI absent → graceful exit 0 (degrade, don't fail merge). We force
+# cortex absence by stripping PATH down to nothing that contains it.
+C="$(mk_fixture C)"
+mkdir -p "$C/.cortex"
+C_HEAD_BEFORE="$(git -C "$C" rev-parse HEAD)"
+(
+  cd "$C"
+  PATH="/usr/bin:/bin" \
+  TOUCHSTONE_DEFAULT_BRANCH=main \
+    bash "$HOOK"
+)
+C_HEAD_AFTER="$(git -C "$C" rev-parse HEAD)"
+if [ "$C_HEAD_BEFORE" != "$C_HEAD_AFTER" ]; then
+  echo "FAIL [C]: hook produced a commit when cortex CLI was missing" >&2
+  exit 1
+fi
+
+# Scenario D: not on the default branch → silent skip even with all
+# other gates passing. (The hook gates on `git branch --show-current`
+# matching the resolved default.)
+D="$(mk_fixture D)"
+mkdir -p "$D/.cortex"
+(cd "$D" && git checkout -q -b feature/x)
+D_HEAD_BEFORE="$(git -C "$D" rev-parse HEAD)"
+(cd "$D" && TOUCHSTONE_DEFAULT_BRANCH=main bash "$HOOK")
+D_HEAD_AFTER="$(git -C "$D" rev-parse HEAD)"
+if [ "$D_HEAD_BEFORE" != "$D_HEAD_AFTER" ]; then
+  echo "FAIL [D]: hook fired when current branch != default branch" >&2
+  exit 1
+fi
+
+# Scenario E: TOUCHSTONE_CORTEX_HOOK_DISABLE=1 short-circuits even when
+# all other gates would pass. Used by the test fixture above to probe
+# without firing the writer.
+E="$(mk_fixture E)"
+mkdir -p "$E/.cortex"
+echo "cortex_pr_merged_hook=on" > "$E/.touchstone-config"
+E_HEAD_BEFORE="$(git -C "$E" rev-parse HEAD)"
+(
+  cd "$E"
+  TOUCHSTONE_DEFAULT_BRANCH=main \
+  TOUCHSTONE_CORTEX_HOOK_DISABLE=1 \
+    bash "$HOOK"
+)
+E_HEAD_AFTER="$(git -C "$E" rev-parse HEAD)"
+if [ "$E_HEAD_BEFORE" != "$E_HEAD_AFTER" ]; then
+  echo "FAIL [E]: TOUCHSTONE_CORTEX_HOOK_DISABLE=1 didn't short-circuit" >&2
+  exit 1
+fi
+
+# Scenario F: unknown config value → log + skip (don't fire with
+# surprise behavior). We can't observe the log line directly without
+# capturing stderr, but we can confirm exit 0 + no commit.
+F="$(mk_fixture F)"
+mkdir -p "$F/.cortex"
+echo "cortex_pr_merged_hook=maybe" > "$F/.touchstone-config"
+F_HEAD_BEFORE="$(git -C "$F" rev-parse HEAD)"
+F_STDERR="$TMPROOT/F-stderr"
+(cd "$F" && TOUCHSTONE_DEFAULT_BRANCH=main bash "$HOOK") 2> "$F_STDERR"
+F_HEAD_AFTER="$(git -C "$F" rev-parse HEAD)"
+if [ "$F_HEAD_BEFORE" != "$F_HEAD_AFTER" ]; then
+  echo "FAIL [F]: hook fired on unknown config value 'maybe'" >&2
+  exit 1
+fi
+if ! grep -q "unknown" "$F_STDERR"; then
+  echo "FAIL [F]: expected stderr to mention the unknown value (no silent failures)" >&2
+  cat "$F_STDERR" >&2
+  exit 1
+fi
+
+# Scenario G: source-vs-bootstrap consistency. update-project.sh writes
+# the hook from `hooks/` to projects' `scripts/`, and merge-pr.sh's call
+# site looks for `scripts/cortex-pr-merged-hook.sh`. Confirm the
+# bootstrap wiring references the correct source path so an update
+# doesn't silently fail to install the hook.
+if ! grep -q 'hooks/cortex-pr-merged-hook.sh.*scripts/cortex-pr-merged-hook.sh' \
+  "$TOUCHSTONE_ROOT/bootstrap/update-project.sh"; then
+  echo "FAIL [G]: bootstrap/update-project.sh missing cortex-pr-merged-hook wiring" >&2
+  exit 1
+fi
+if ! grep -q 'cortex-pr-merged-hook' "$TOUCHSTONE_ROOT/scripts/merge-pr.sh"; then
+  echo "FAIL [G]: scripts/merge-pr.sh missing cortex-pr-merged-hook invocation" >&2
+  exit 1
+fi
+
+echo "==> PASS: cortex-pr-merged-hook activation gates + graceful-degradation paths verified (A-G)"


### PR DESCRIPTION
## Summary

First v0.9.0 dogfood-gate work item from Cortex's launch roadmap ([cortex-v1.md](https://github.com/autumngarage/cortex/blob/main/.cortex/plans/cortex-v1.md)). Adds a Touchstone-managed post-merge hook that auto-drafts a Cortex `Type: pr-merged` Journal entry after every default-branch squash-merge. Implements [Cortex Protocol § 2 Tier-1 trigger T1.9](https://github.com/autumngarage/cortex/blob/main/.cortex/protocol.md) for any project that has both Touchstone and Cortex installed.

## Why this matters

Without this hook, T1.9 only fires when an agent or human happens to run `cortex journal draft pr-merged --no-edit` by hand after a merge. That's exactly the silent-staleness failure mode the [conductor case study](https://github.com/autumngarage/cortex/blob/main/docs/case-studies/2026-04-24-stale-claude-md-steered-agent-wrong.md) documented for T1.10 — reality changes, no record gets written, downstream docs go stale. The hook closes the loop deterministically.

## Pieces

- **`hooks/cortex-pr-merged-hook.sh`** (NEW). Activation contract: silent-skip unless ALL of {default branch, `.cortex/` exists, cortex on PATH, `.touchstone-config cortex_pr_merged_hook=auto|on`}. Past activation, "no silent failures" — every error surfaces to stderr and exits 1. Test-friendly env knobs (`TOUCHSTONE_DEFAULT_BRANCH`, `TOUCHSTONE_CORTEX_HOOK_DISABLE`, `TOUCHSTONE_CORTEX_HOOK_SKIP_PUSH`). Refuses to run on dirty tree (would fold user changes into the auto-commit). Uses `--no-verify` on the auto-commit so it doesn't recurse through other default-branch hooks.
- **`scripts/merge-pr.sh`** — invokes the hook as step 6 after sync; warning-only on hook failure (the PR merged cleanly; hook hiccup doesn't fail the overall merge).
- **`bootstrap/update-project.sh`** — wires the hook into the bootstrap so `touchstone update` syncs it to projects' `scripts/`.
- **`tests/test-cortex-pr-merged-hook.sh`** — 7 scenarios (A–G) covering activation gates + bootstrap-wiring consistency. All pass.

## Activation defaults

- Newly-bootstrapped projects: `cortex_pr_merged_hook=auto` in `.touchstone-config`.
- Existing projects upgrading via `touchstone update`: `auto` if they have `.cortex/` AND cortex CLI when they update; explicit `off` preserved across updates.

## Test plan
- [x] `for t in tests/test-*.sh; do bash $t || exit 1; done` — all touchstone tests pass (15 tests, 0 failures including the new one)
- [x] New `tests/test-cortex-pr-merged-hook.sh` validates: A=no-cortex-skip, B=config-off-skip, C=cortex-missing-graceful-exit, D=non-default-branch-skip, E=env-disable-shortcircuit, F=unknown-config-warn-and-skip, G=bootstrap-wiring-present
- [ ] Post-merge: enable on cortex's repo as the canary (per the v0.9.0 brief — accumulate ≥3 auto-drafted `pr-merged` entries before opening the 3 install PRs on conductor + touchstone + vesper)

## Emergency-bypass disclosure

Pre-commit + pre-push hooks intermittently failing today with `URLError: SSL: WRONG_VERSION_NUMBER` (transient infra issue installing gitleaks/codex-review env). Used `--no-verify` per emergency path. Local quality gates passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)