### PR TITLE
fix(setup): SC1102 — disambiguate $( from $(( in uv_output capture

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -395,7 +395,7 @@ install_uv_project() {
     return 1
   fi
 
-  if uv_output="$((cd "$project_dir" && uv sync) 2>&1 | tail -1)"; then
+  if uv_output="$( (cd "$project_dir" && uv sync) 2>&1 | tail -1)"; then
     ok "$label dependencies synced: $uv_output"
   else
     fail "$label dependency sync failed: $uv_output"

--- a/templates/setup.sh
+++ b/templates/setup.sh
@@ -566,7 +566,7 @@ install_uv_project() {
     return 2
   fi
 
-  if uv_output="$((cd "$project_dir" && uv sync) 2>&1 | tail -1)"; then
+  if uv_output="$( (cd "$project_dir" && uv sync) 2>&1 | tail -1)"; then
     ok "$label dependencies synced: $uv_output"
   else
     fail "$label dependency sync failed: $uv_output"


### PR DESCRIPTION
shellcheck SC1102 (error): the construct `$((cd ...) ...)` is ambiguous
between command substitution `$( (cd ...) )` and arithmetic expansion
`$(( ... ))`. ShellCheck-py v0.11.0.1 treats this as an error and the
pre-commit hook blocks the push.

Pre-existing from PR #99 (April 28); surfaced today when re-running
`pre-commit run --all-files` after the day's SSL-bypassed `--no-verify`
pushes wrapped up. Adds one space after `$(` in both copies (setup.sh
shipped to projects + templates/setup.sh consumed by `touchstone init`)
to make the parse unambiguous as command substitution.

No behavior change — the bash parser was already interpreting it as
command substitution; this just satisfies shellcheck.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
