### PR TITLE
test: add PASS messages for visibility and hardening against terminal prompts

### DIFF
--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -1654,6 +1654,8 @@ YES_MODE=false bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_WIZARD
 if grep -q 'Equivalent to rerun:' "$TEST_DIR/wizard-non-tty.txt" 2>/dev/null; then
   echo "FAIL: non-TTY bootstrap must not print the wizard 'Equivalent to rerun' block" >&2
   ERRORS=$((ERRORS + 1))
+else
+  echo "    PASS: non-TTY bootstrap correctly suppressed the wizard block"
 fi
 assert_exists "$PROJECT_WIZARD_NON_TTY/.touchstone-version"
 assert_exists "$PROJECT_WIZARD_NON_TTY/CLAUDE.md"
@@ -1661,6 +1663,8 @@ assert_exists "$PROJECT_WIZARD_NON_TTY/CLAUDE.md"
 if grep -q '{{PROJECT_NAME}}' "$PROJECT_WIZARD_NON_TTY/CLAUDE.md" 2>/dev/null; then
   echo "FAIL: non-TTY wizard must still substitute {{PROJECT_NAME}}" >&2
   ERRORS=$((ERRORS + 1))
+else
+  echo "    PASS: non-TTY wizard correctly substituted {{PROJECT_NAME}}"
 fi
 
 # --yes with all defaults must produce the same filesystem shape as a

--- a/tests/test-update.sh
+++ b/tests/test-update.sh
@@ -4,6 +4,9 @@
 #
 set -euo pipefail
 
+# Doctrine 0002: ensure all bootstrap/update calls run non-interactively.
+exec </dev/null
+
 TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TEST_DIR="$(mktemp -d -t touchstone-test-update.XXXXXX)"
 trap 'rm -rf "$TEST_DIR"' EXIT
@@ -298,6 +301,8 @@ if ! git -C "$PROJECT" log -1 --name-only --pretty=format: | grep -qx 'AGENTS.md
   echo "FAIL: update commit must include AGENTS.md when the block was refreshed" >&2
   ERRORS=$((ERRORS + 1))
 fi
+
+echo "    PASS: AGENTS.md was backfilled with shared principles"
 
 # --------------------------------------------------------------------------
 # Test 4: dirty worktrees fail before branching or patching.

--- a/tests/test-update.sh
+++ b/tests/test-update.sh
@@ -300,9 +300,9 @@ fi
 if ! git -C "$PROJECT" log -1 --name-only --pretty=format: | grep -qx 'AGENTS.md'; then
   echo "FAIL: update commit must include AGENTS.md when the block was refreshed" >&2
   ERRORS=$((ERRORS + 1))
+else
+  echo "    PASS: AGENTS.md was backfilled with shared principles"
 fi
-
-echo "    PASS: AGENTS.md was backfilled with shared principles"
 
 # --------------------------------------------------------------------------
 # Test 4: dirty worktrees fail before branching or patching.


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
