### PR TITLE
fix: handle stale worktree locks

### DIFF
--- a/scripts/cleanup-worktrees.sh
+++ b/scripts/cleanup-worktrees.sh
@@ -5,6 +5,8 @@
 # Usage:
 #   bash scripts/cleanup-worktrees.sh              # dry-run (default)
 #   bash scripts/cleanup-worktrees.sh --execute    # remove clean candidates
+#   bash scripts/cleanup-worktrees.sh --unlock-stale --execute
+#                                                     unlock dead-PID locks, then remove safe candidates
 #   bash scripts/cleanup-worktrees.sh --force      # remove candidates even if dirty
 #
 # Safety guarantees:
@@ -14,12 +16,15 @@
 #   - Clean worktrees are removable only when their branch is merged or
 #     tree-equivalent to the default branch, or when the branch is gone.
 #   - Dirty worktrees are refused unless --force is explicit.
+#   - Locked worktrees are refused unless their lock reason contains a dead
+#     `pid <number>` and --unlock-stale is explicit.
 #   - git worktree prune is previewed before any actual prune.
 #
 set -euo pipefail
 
 DRY_RUN=1
 FORCE=0
+UNLOCK_STALE=0
 
 usage() {
   awk 'NR>2 && !/^#/ { exit } NR>2 { sub(/^# ?/, ""); print }' "$0"
@@ -34,6 +39,10 @@ while [ "$#" -gt 0 ]; do
     --force)
       DRY_RUN=0
       FORCE=1
+      shift
+      ;;
+    --unlock-stale)
+      UNLOCK_STALE=1
       shift
       ;;
     --dry-run)
@@ -109,6 +118,7 @@ MAIN_WORKTREE="$(printf '%s\n' "$WORKTREE_LIST" | awk '/^worktree /{print substr
 
 CANDIDATE_PATHS=()
 FORCE_PATHS=()
+UNLOCK_STALE_PATHS=()
 
 echo "==> Worktrees"
 echo "    default ref: $DEFAULT_REF"
@@ -116,12 +126,60 @@ echo "    default ref: $DEFAULT_REF"
 current_path=""
 current_head=""
 current_branch=""
+current_locked=0
+current_lock_reason=""
+
+pid_is_alive() {
+  local pid="$1"
+
+  [ -n "$pid" ] || return 1
+  case "$pid" in
+    *[!0-9]*) return 1 ;;
+  esac
+
+  if kill -0 "$pid" 2>/dev/null; then
+    return 0
+  fi
+  # If kill(2) is denied but the process exists, treat it as alive.
+  ps -p "$pid" >/dev/null 2>&1
+}
+
+classify_lock() {
+  local reason="$1"
+  local pid
+
+  if [[ "$reason" =~ [Pp][Ii][Dd][[:space:]]+([0-9]+) ]]; then
+    pid="${BASH_REMATCH[1]}"
+    if pid_is_alive "$pid"; then
+      printf 'alive|%s|alive (pid %s)' "$pid" "$pid"
+    else
+      printf 'stale|%s|stale (pid %s dead)' "$pid" "$pid"
+    fi
+  else
+    printf 'unknown||present, no PID'
+  fi
+}
+
+path_needs_stale_unlock() {
+  local target="$1"
+  local path
+
+  for path in ${UNLOCK_STALE_PATHS[@]+"${UNLOCK_STALE_PATHS[@]}"}; do
+    [ "$path" = "$target" ] && return 0
+  done
+  return 1
+}
 
 flush_worktree() {
   [ -n "$current_path" ] || return 0
 
   local branch_label dirty_status dirty_label reason removable branch_name
+  local lock_state lock_pid lock_label unlock_before_remove
   branch_label="${current_branch:-detached}"
+  lock_state="none"
+  lock_pid=""
+  lock_label=""
+  unlock_before_remove=0
 
   if dirty_status="$(git -C "$current_path" status --porcelain 2>/dev/null)"; then
     if [ -n "$dirty_status" ]; then
@@ -137,6 +195,10 @@ flush_worktree() {
   printf '    branch: %s\n' "$branch_label"
   printf '    head: %s\n' "${current_head:-unknown}"
   printf '    status: %s\n' "$dirty_label"
+  if [ "$current_locked" -eq 1 ]; then
+    IFS='|' read -r lock_state lock_pid lock_label <<< "$(classify_lock "$current_lock_reason")"
+    printf '    lock: %s\n' "$lock_label"
+  fi
 
   removable=0
   reason=""
@@ -149,7 +211,17 @@ flush_worktree() {
     reason="dirty; use --force to remove"
   elif [ "$dirty_label" = "missing" ]; then
     reason="missing; git worktree prune handles this"
+  elif [ "$current_locked" -eq 1 ] && [ "$lock_state" = "alive" ]; then
+    reason="locked by live process (pid $lock_pid); not removing"
+  elif [ "$current_locked" -eq 1 ] && [ "$lock_state" = "unknown" ]; then
+    reason="locked without PID; unlock manually after inspection"
+  elif [ "$current_locked" -eq 1 ] && [ "$lock_state" = "stale" ] && [ "$UNLOCK_STALE" -ne 1 ]; then
+    reason="locked by dead process (pid $lock_pid); pass --unlock-stale --execute to remove"
   else
+    if [ "$current_locked" -eq 1 ] && [ "$lock_state" = "stale" ]; then
+      unlock_before_remove=1
+    fi
+
     if [ -z "$current_branch" ]; then
       if [ -z "$current_head" ] || [ "$current_head" = "unknown" ]; then
         reason="detached HEAD missing; investigate manually"
@@ -185,6 +257,9 @@ flush_worktree() {
     if [ "$dirty_label" = "dirty" ]; then
       FORCE_PATHS+=("$current_path")
     fi
+    if [ "$unlock_before_remove" -eq 1 ]; then
+      UNLOCK_STALE_PATHS+=("$current_path")
+    fi
   fi
 }
 
@@ -195,6 +270,8 @@ while IFS= read -r line || [ -n "$line" ]; do
       current_path="${line#worktree }"
       current_head=""
       current_branch=""
+      current_locked=0
+      current_lock_reason=""
       ;;
     HEAD\ *)
       current_head="${line#HEAD }"
@@ -202,11 +279,21 @@ while IFS= read -r line || [ -n "$line" ]; do
     branch\ *)
       current_branch="${line#branch }"
       ;;
+    locked\ *)
+      current_locked=1
+      current_lock_reason="${line#locked }"
+      ;;
+    locked)
+      current_locked=1
+      current_lock_reason=""
+      ;;
     "")
       flush_worktree
       current_path=""
       current_head=""
       current_branch=""
+      current_locked=0
+      current_lock_reason=""
       ;;
   esac
 done <<< "$WORKTREE_LIST"
@@ -237,6 +324,10 @@ fi
 echo ""
 echo "==> Removing worktrees"
 for path in "${CANDIDATE_PATHS[@]}"; do
+  if path_needs_stale_unlock "$path"; then
+    git worktree unlock "$path"
+    echo "    unlocked stale lock: $path"
+  fi
   if [ "$FORCE" -eq 1 ]; then
     git worktree remove --force "$path"
   else

--- a/tests/test-cleanup-worktrees.sh
+++ b/tests/test-cleanup-worktrees.sh
@@ -35,6 +35,18 @@ SQUASH_WT="$TEST_DIR/demo-squash"
 UNIQUE_WT="$TEST_DIR/demo-unique"
 DIRTY_WT="$TEST_DIR/demo-dirty"
 DETACHED_WT="$TEST_DIR/demo-detached"
+LOCKED_STALE_WT="$TEST_DIR/demo-locked-stale"
+LOCKED_ALIVE_WT="$TEST_DIR/demo-locked-alive"
+LOCKED_NOPID_WT="$TEST_DIR/demo-locked-nopid"
+
+dead_pid() {
+  local pid
+  pid=999999
+  while kill -0 "$pid" 2>/dev/null; do
+    pid=$((pid - 1))
+  done
+  printf '%s\n' "$pid"
+}
 
 git init -q --bare -b main "$REMOTE"
 git init -q -b main "$REPO"
@@ -76,6 +88,31 @@ git -C "$REPO" checkout -q main
 git -C "$REPO" merge --no-ff -q feat/dirty -m "merge feat/dirty"
 echo "uncommitted" >> "$DIRTY_WT/dirty.txt"
 
+git -C "$REPO" worktree add -q "$LOCKED_STALE_WT" -b feat/locked-stale main
+echo "locked stale" > "$LOCKED_STALE_WT/locked-stale.txt"
+git -C "$LOCKED_STALE_WT" add locked-stale.txt
+git -C "$LOCKED_STALE_WT" commit -qm "feat: locked stale"
+git -C "$REPO" checkout -q main
+git -C "$REPO" merge --no-ff -q feat/locked-stale -m "merge feat/locked-stale"
+DEAD_PID="$(dead_pid)"
+git -C "$REPO" worktree lock --reason "agent pid $DEAD_PID" "$LOCKED_STALE_WT"
+
+git -C "$REPO" worktree add -q "$LOCKED_ALIVE_WT" -b feat/locked-alive main
+echo "locked alive" > "$LOCKED_ALIVE_WT/locked-alive.txt"
+git -C "$LOCKED_ALIVE_WT" add locked-alive.txt
+git -C "$LOCKED_ALIVE_WT" commit -qm "feat: locked alive"
+git -C "$REPO" checkout -q main
+git -C "$REPO" merge --no-ff -q feat/locked-alive -m "merge feat/locked-alive"
+git -C "$REPO" worktree lock --reason "agent pid $$" "$LOCKED_ALIVE_WT"
+
+git -C "$REPO" worktree add -q "$LOCKED_NOPID_WT" -b feat/locked-nopid main
+echo "locked no pid" > "$LOCKED_NOPID_WT/locked-nopid.txt"
+git -C "$LOCKED_NOPID_WT" add locked-nopid.txt
+git -C "$REPO" checkout -q main
+git -C "$LOCKED_NOPID_WT" commit -qm "feat: locked no pid"
+git -C "$REPO" merge --no-ff -q feat/locked-nopid -m "merge feat/locked-nopid"
+git -C "$REPO" worktree lock --reason "manual inspection" "$LOCKED_NOPID_WT"
+
 git -C "$REPO" worktree add -q -b feat/detached-source "$TEST_DIR/demo-detached-source" main
 echo "detached-unique" > "$TEST_DIR/demo-detached-source/detached.txt"
 git -C "$TEST_DIR/demo-detached-source" add detached.txt
@@ -95,11 +132,20 @@ assert_contains "$DRY_RUN_OUTPUT" "$MERGED_WT"
 assert_contains "$DRY_RUN_OUTPUT" "$SQUASH_WT"
 assert_contains "$DRY_RUN_OUTPUT" 'dirty; use --force to remove'
 assert_contains "$DRY_RUN_OUTPUT" 'detached HEAD has unique work'
+assert_contains "$DRY_RUN_OUTPUT" "lock: stale (pid $DEAD_PID dead)"
+assert_contains "$DRY_RUN_OUTPUT" "lock: alive (pid $$)"
+assert_contains "$DRY_RUN_OUTPUT" 'lock: present, no PID'
+assert_contains "$DRY_RUN_OUTPUT" 'pass --unlock-stale --execute to remove'
+assert_contains "$DRY_RUN_OUTPUT" 'locked by live process'
+assert_contains "$DRY_RUN_OUTPUT" 'locked without PID'
 assert_exists "$MERGED_WT"
 assert_exists "$SQUASH_WT"
 assert_exists "$UNIQUE_WT"
 assert_exists "$DIRTY_WT"
 assert_exists "$DETACHED_WT"
+assert_exists "$LOCKED_STALE_WT"
+assert_exists "$LOCKED_ALIVE_WT"
+assert_exists "$LOCKED_NOPID_WT"
 
 EXEC_OUTPUT="$TEST_DIR/execute-output.txt"
 (cd "$REPO" && bash "$TOUCHSTONE_ROOT/scripts/cleanup-worktrees.sh" --execute) >"$EXEC_OUTPUT" 2>&1
@@ -109,14 +155,29 @@ assert_not_exists "$SQUASH_WT"
 assert_exists "$UNIQUE_WT"
 assert_exists "$DIRTY_WT"
 assert_exists "$DETACHED_WT"
+assert_exists "$LOCKED_STALE_WT"
+assert_exists "$LOCKED_ALIVE_WT"
+assert_exists "$LOCKED_NOPID_WT"
 assert_contains "$EXEC_OUTPUT" 'removed:'
 assert_contains "$EXEC_OUTPUT" 'branch has unique work'
 assert_contains "$EXEC_OUTPUT" 'dirty; use --force to remove'
 assert_contains "$EXEC_OUTPUT" 'detached HEAD has unique work'
+assert_contains "$EXEC_OUTPUT" "locked by dead process (pid $DEAD_PID)"
+
+UNLOCK_OUTPUT="$TEST_DIR/unlock-stale-output.txt"
+(cd "$REPO" && bash "$TOUCHSTONE_ROOT/scripts/cleanup-worktrees.sh" --unlock-stale --execute) >"$UNLOCK_OUTPUT" 2>&1
+assert_not_exists "$LOCKED_STALE_WT"
+assert_exists "$LOCKED_ALIVE_WT"
+assert_exists "$LOCKED_NOPID_WT"
+assert_contains "$UNLOCK_OUTPUT" 'unlocked stale lock:'
+assert_contains "$UNLOCK_OUTPUT" 'locked by live process'
+assert_contains "$UNLOCK_OUTPUT" 'locked without PID'
 
 FORCE_OUTPUT="$TEST_DIR/force-output.txt"
 (cd "$REPO" && bash "$TOUCHSTONE_ROOT/scripts/cleanup-worktrees.sh" --force) >"$FORCE_OUTPUT" 2>&1
 assert_not_exists "$DIRTY_WT"
 assert_exists "$UNIQUE_WT"
+assert_exists "$LOCKED_ALIVE_WT"
+assert_exists "$LOCKED_NOPID_WT"
 
-echo "==> PASS: cleanup-worktrees dry-runs, removes safe candidates, and refuses dirty worktrees by default"
+echo "==> PASS: cleanup-worktrees dry-runs, removes safe candidates, refuses dirty worktrees by default, and handles PID locks safely"


### PR DESCRIPTION
## Linked Issues

Closes #156

Closes #156

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
