### PR TITLE
fix: clean up after auto-merge

### DIFF
--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -10,7 +10,8 @@
 #   1. Verifies the PR is open and mergeable.
 #   2. Runs AI code review as a merge gate.
 #   3. Squash-merges and deletes the remote branch.
-#   4. Checks out the default branch and pulls the updated state.
+#   4. Checks out/syncs the default branch where the local topology permits.
+#   5. Deletes the verified-merged local feature branch when safe.
 #
 # Exit codes:
 #   0 — merged cleanly
@@ -24,6 +25,7 @@ BYPASS_REASON=""
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REVIEW_SCRIPT="$SCRIPT_DIR/codex-review.sh"
 REVIEWED_HEAD_OID=""
+PR_HEAD_BRANCH=""
 BYPASS_REVIEW=false
 
 while [ "$#" -gt 0 ]; do
@@ -157,7 +159,10 @@ sync_default_branch_after_merge() {
   current_branch="$(git rev-parse --abbrev-ref HEAD)"
 
   if [ "$current_branch" = "$DEFAULT_BRANCH" ]; then
-    git pull --rebase
+    if ! git pull --rebase; then
+      echo "WARNING: PR #$PR_NUMBER merged remotely, but local $DEFAULT_BRANCH could not pull --rebase." >&2
+      echo "WARNING: Run this when convenient: git pull --rebase" >&2
+    fi
     return 0
   fi
 
@@ -180,8 +185,94 @@ sync_default_branch_after_merge() {
     return 0
   fi
 
-  git checkout "$DEFAULT_BRANCH"
-  git pull --rebase
+  if ! git checkout "$DEFAULT_BRANCH"; then
+    echo "WARNING: PR #$PR_NUMBER merged remotely, but this worktree could not check out $DEFAULT_BRANCH." >&2
+    echo "WARNING: Run this when convenient: git checkout '$DEFAULT_BRANCH' && git pull --rebase" >&2
+    return 0
+  fi
+  if ! git pull --rebase; then
+    echo "WARNING: PR #$PR_NUMBER merged remotely, but local $DEFAULT_BRANCH could not pull --rebase." >&2
+    echo "WARNING: Run this when convenient: git pull --rebase" >&2
+  fi
+}
+
+checkout_default_ref_for_cleanup() {
+  local branch="$1"
+  local reviewed_head="$2"
+  local current_branch current_head current_worktree default_worktree
+
+  current_branch="$(git rev-parse --abbrev-ref HEAD)"
+  current_head="$(git rev-parse HEAD 2>/dev/null || echo "")"
+  if [ "$current_branch" != "$branch" ]; then
+    if [ "$current_branch" != "HEAD" ] || [ "$current_head" != "$reviewed_head" ]; then
+      return 0
+    fi
+  fi
+
+  current_worktree="$(git rev-parse --show-toplevel)"
+  default_worktree="$(worktree_path_for_branch "$DEFAULT_BRANCH" | head -n 1)"
+  if [ -n "$default_worktree" ] && [ "$default_worktree" != "$current_worktree" ]; then
+    echo "==> $DEFAULT_BRANCH is checked out elsewhere; detaching this worktree at $DEFAULT_BRANCH before local branch cleanup ..."
+    if git checkout --detach "$DEFAULT_BRANCH"; then
+      return 0
+    fi
+    echo "WARNING: Could not detach this worktree at $DEFAULT_BRANCH; leaving local branch '$branch' intact." >&2
+    return 1
+  fi
+
+  if git checkout "$DEFAULT_BRANCH"; then
+    return 0
+  fi
+  if git checkout --detach "$DEFAULT_BRANCH"; then
+    echo "==> Detached this worktree at $DEFAULT_BRANCH before local branch cleanup."
+    return 0
+  fi
+  echo "WARNING: Could not move off local branch '$branch'; leaving it intact." >&2
+  return 1
+}
+
+cleanup_local_pr_branch_after_merge() {
+  local branch="$PR_HEAD_BRANCH"
+  local reviewed_head="$REVIEWED_HEAD_OID"
+  local local_head pr_state
+
+  if [ -z "$branch" ] || [ -z "$reviewed_head" ]; then
+    echo "WARNING: Missing reviewed PR head metadata; skipping local branch cleanup." >&2
+    return 0
+  fi
+  if [ "$branch" = "$DEFAULT_BRANCH" ] || [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+    echo "WARNING: Refusing to delete protected branch '$branch' after PR #$PR_NUMBER." >&2
+    return 0
+  fi
+  if ! git show-ref --verify --quiet "refs/heads/$branch"; then
+    echo "==> Local branch '$branch' is already absent."
+    return 0
+  fi
+  if ! local_head="$(git rev-parse "$branch" 2>/dev/null)"; then
+    echo "WARNING: Could not resolve local branch '$branch'; leaving it intact." >&2
+    return 0
+  fi
+  if [ "$local_head" != "$reviewed_head" ]; then
+    echo "WARNING: Local branch '$branch' is at $local_head, not reviewed PR head $reviewed_head; leaving it intact." >&2
+    return 0
+  fi
+  pr_state="$(gh pr view "$PR_NUMBER" --json state --jq '.state' 2>/dev/null || echo "")"
+  if [ "$pr_state" != "MERGED" ]; then
+    echo "WARNING: PR #$PR_NUMBER is not confirmed MERGED (state: ${pr_state:-unknown}); leaving local branch '$branch' intact." >&2
+    return 0
+  fi
+
+  if ! checkout_default_ref_for_cleanup "$branch" "$reviewed_head"; then
+    return 0
+  fi
+
+  echo "==> Deleting local branch '$branch' after verified squash merge of $reviewed_head ..."
+  if git branch -D "$branch"; then
+    echo "==> Local branch '$branch' deleted."
+  else
+    echo "WARNING: Could not delete local branch '$branch' after verified merge." >&2
+    echo "WARNING: Run this when convenient after moving off the branch: git branch -D '$branch'" >&2
+  fi
 }
 
 print_bypass_banner() {
@@ -220,6 +311,7 @@ run_merge_review() {
     exit 1
   fi
 
+  PR_HEAD_BRANCH="$pr_head_branch"
   REVIEWED_HEAD_OID="$pr_head_oid"
   default_base_ref="origin/$DEFAULT_BRANCH"
 
@@ -405,5 +497,7 @@ if [ -n "$CORTEX_HOOK_SCRIPT" ]; then
     echo "         The PR merged cleanly; only the auto-draft journal step had a problem." >&2
   fi
 fi
+
+cleanup_local_pr_branch_after_merge
 
 echo "==> Done."

--- a/scripts/open-pr.sh
+++ b/scripts/open-pr.sh
@@ -314,6 +314,9 @@ if [ -n "$EXISTING_PR_URL" ]; then
       echo "ERROR: merge-pr.sh exited 0 but PR #$PR_NUMBER is not merged on GitHub." >&2
       exit 1
     fi
+    if [ "$CLEANUP_WORKTREE" = true ]; then
+      cleanup_feature_worktree
+    fi
     exit 0
   fi
   exit 0

--- a/tests/test-merge-pr.sh
+++ b/tests/test-merge-pr.sh
@@ -22,6 +22,7 @@ set -euo pipefail
   printf 'CODEX_REVIEW_MODE=%s\n' "${CODEX_REVIEW_MODE:-}"
   printf 'CODEX_REVIEW_BRANCH_NAME=%s\n' "${CODEX_REVIEW_BRANCH_NAME:-}"
 } > "$CODEX_REVIEW_LOG"
+exit "${CODEX_REVIEW_EXIT:-0}"
 EOF
 chmod +x "$MERGE_SCRIPT_DIR/merge-pr.sh" "$MERGE_SCRIPT_DIR/codex-review.sh"
 
@@ -113,14 +114,22 @@ fi
 
 case "$*" in
   "rev-parse --abbrev-ref HEAD")
-    if [ -f "$GH_CHECKOUT_FILE" ]; then
+    if [ -f "$GIT_CHECKOUT_MAIN_FILE" ]; then
+      echo "main"
+    elif [ -f "$GIT_DETACHED_DEFAULT_FILE" ]; then
+      echo "HEAD"
+    elif [ -f "$GH_CHECKOUT_FILE" ]; then
       echo "HEAD"
     else
       echo "feature/test"
     fi
     ;;
   "rev-parse HEAD")
-    if [ -f "$GH_CHECKOUT_FILE" ]; then
+    if [ -f "$GIT_CHECKOUT_MAIN_FILE" ]; then
+      echo "main-oid"
+    elif [ -f "$GIT_DETACHED_DEFAULT_FILE" ]; then
+      echo "main-oid"
+    elif [ -f "$GH_CHECKOUT_FILE" ]; then
       echo "pr-head-oid"
     else
       echo "stale-local-oid"
@@ -131,6 +140,17 @@ case "$*" in
     ;;
   "rev-parse --show-toplevel")
     printf '%s\n' "${TEST_CURRENT_WORKTREE:-/tmp/touchstone-feature-worktree}"
+    ;;
+  "rev-parse feature/test")
+    if [ -f "$GIT_BRANCH_DELETED_FILE" ]; then
+      exit 1
+    fi
+    printf '%s\n' "${GIT_LOCAL_BRANCH_HEAD:-pr-head-oid}"
+    ;;
+  "show-ref --verify --quiet refs/heads/feature/test")
+    if [ -f "$GIT_BRANCH_DELETED_FILE" ]; then
+      exit 1
+    fi
     ;;
   "cat-file -e pr-head-oid^{commit}")
     ;;
@@ -152,8 +172,16 @@ case "$*" in
     echo "checkout main" > "$GIT_CHECKOUT_MAIN_FILE"
     echo "Switched to branch 'main'"
     ;;
+  "checkout --detach main")
+    echo "checkout --detach main" > "$GIT_DETACHED_DEFAULT_FILE"
+    echo "HEAD is now at main"
+    ;;
   "pull --rebase")
     echo "Already up to date."
+    ;;
+  "branch -D feature/test")
+    echo "deleted feature/test" > "$GIT_BRANCH_DELETED_FILE"
+    echo "Deleted branch feature/test (was pr-head-oid)."
     ;;
   *)
     echo "unexpected git args: $*" >&2
@@ -169,6 +197,7 @@ reset_case_files() {
     "$TEST_DIR"/gh-checkout* "$TEST_DIR"/gh-merge-head* \
     "$TEST_DIR"/gh-merge-args* "$TEST_DIR"/gh-merge-body* \
     "$TEST_DIR"/gh-comment* "$TEST_DIR"/git-checkout-main* \
+    "$TEST_DIR"/git-detached-default* "$TEST_DIR"/git-branch-deleted* \
     "$TEST_DIR"/git-sibling-pull* "$TEST_DIR"/gh-merged-marker*
   rm -rf "$GIT_PATH_ROOT"
   mkdir -p "$GIT_PATH_ROOT"
@@ -176,6 +205,8 @@ reset_case_files() {
   unset GIT_SIBLING_PULL_FAIL
   unset TEST_CURRENT_WORKTREE
   unset GH_PR_MERGE_FAIL_LOCAL
+  unset CODEX_REVIEW_EXIT
+  unset GIT_LOCAL_BRANCH_HEAD
 }
 
 run_merge_pr() {
@@ -192,9 +223,13 @@ run_merge_pr() {
     GH_MERGED_MARKER="$TEST_DIR/gh-merged-marker" \
     GH_PR_MERGE_FAIL_LOCAL="${GH_PR_MERGE_FAIL_LOCAL:-false}" \
     GIT_CHECKOUT_MAIN_FILE="$TEST_DIR/git-checkout-main" \
+    GIT_DETACHED_DEFAULT_FILE="$TEST_DIR/git-detached-default" \
+    GIT_BRANCH_DELETED_FILE="$TEST_DIR/git-branch-deleted" \
     GIT_SIBLING_PULL_FILE="$TEST_DIR/git-sibling-pull" \
     GIT_WORKTREE_LIST="${GIT_WORKTREE_LIST:-}" \
     GIT_SIBLING_PULL_FAIL="${GIT_SIBLING_PULL_FAIL:-false}" \
+    CODEX_REVIEW_EXIT="${CODEX_REVIEW_EXIT:-0}" \
+    GIT_LOCAL_BRANCH_HEAD="${GIT_LOCAL_BRANCH_HEAD:-pr-head-oid}" \
     TEST_CURRENT_WORKTREE="${TEST_CURRENT_WORKTREE:-/tmp/touchstone-feature-worktree}" \
     bash "$MERGE_SCRIPT_DIR/merge-pr.sh" "$@" >"$output_file" 2>&1
 }
@@ -212,11 +247,31 @@ if grep -q 'attempt 1: mergeStateStatus=CLEAN mergeable=MERGEABLE' "$TEST_DIR/ou
   && grep -q '^CODEX_REVIEW_BASE=origin/main$' "$TEST_DIR/codex-review.log" \
   && grep -q '^CODEX_REVIEW_FORCE=1$' "$TEST_DIR/codex-review.log" \
   && grep -q '^CODEX_REVIEW_MODE=review-only$' "$TEST_DIR/codex-review.log" \
-  && grep -q '^CODEX_REVIEW_BRANCH_NAME=feature/test$' "$TEST_DIR/codex-review.log"; then
+  && grep -q '^CODEX_REVIEW_BRANCH_NAME=feature/test$' "$TEST_DIR/codex-review.log" \
+  && grep -q "==> Deleting local branch 'feature/test' after verified squash merge of pr-head-oid" "$TEST_DIR/output-normal.txt" \
+  && grep -q '^deleted feature/test$' "$TEST_DIR/git-branch-deleted"; then
   echo "==> PASS: merge-pr.sh completed without jq"
 else
   echo "FAIL: merge-pr.sh output did not show a successful jq-free merge path" >&2
   cat "$TEST_DIR/output-normal.txt" >&2
+  exit 1
+fi
+
+echo "==> Test: blocked review preserves the local feature branch"
+reset_case_files
+if CODEX_REVIEW_EXIT=1 run_merge_pr "$TEST_DIR/output-review-blocked.txt" 123; then
+  echo "FAIL: merge-pr.sh unexpectedly succeeded when review blocked" >&2
+  exit 1
+fi
+if grep -q '==> Running merge review' "$TEST_DIR/output-review-blocked.txt" \
+  && [ ! -f "$TEST_DIR/gh-merge-head" ] \
+  && [ ! -f "$TEST_DIR/git-checkout-main" ] \
+  && [ ! -f "$TEST_DIR/git-detached-default" ] \
+  && [ ! -f "$TEST_DIR/git-branch-deleted" ]; then
+  echo "==> PASS: blocked review leaves local branch intact"
+else
+  echo "FAIL: blocked review should not merge, sync, detach, or delete the branch" >&2
+  cat "$TEST_DIR/output-review-blocked.txt" >&2
   exit 1
 fi
 
@@ -242,12 +297,27 @@ if grep -q "==> main is checked out in sibling worktree: $MAIN_WORKTREE" "$TEST_
   && grep -q '==> Fast-forwarding that worktree after remote merge' "$TEST_DIR/output-sibling-worktree.txt" \
   && grep -q '==> Done\.' "$TEST_DIR/output-sibling-worktree.txt" \
   && grep -q "^$MAIN_WORKTREE$" "$TEST_DIR/git-sibling-pull" \
+  && grep -q '^checkout --detach main$' "$TEST_DIR/git-detached-default" \
+  && grep -q '^deleted feature/test$' "$TEST_DIR/git-branch-deleted" \
   && [ ! -f "$TEST_DIR/git-checkout-main" ] \
   && ! grep -q 'ERROR:' "$TEST_DIR/output-sibling-worktree.txt"; then
   echo "==> PASS: sibling default worktree sync avoids false merge failure"
 else
   echo "FAIL: sibling worktree sync did not avoid the checkout-main failure path" >&2
   cat "$TEST_DIR/output-sibling-worktree.txt" >&2
+  exit 1
+fi
+
+echo "==> Test: local branch that moved after review is preserved"
+reset_case_files
+GIT_LOCAL_BRANCH_HEAD="new-local-oid" run_merge_pr "$TEST_DIR/output-moved-branch.txt" 123
+if grep -q "WARNING: Local branch 'feature/test' is at new-local-oid, not reviewed PR head pr-head-oid; leaving it intact." "$TEST_DIR/output-moved-branch.txt" \
+  && [ ! -f "$TEST_DIR/git-branch-deleted" ] \
+  && grep -q '==> Done\.' "$TEST_DIR/output-moved-branch.txt"; then
+  echo "==> PASS: moved local branch is not deleted"
+else
+  echo "FAIL: moved local branch should be preserved after merge" >&2
+  cat "$TEST_DIR/output-moved-branch.txt" >&2
   exit 1
 fi
 

--- a/tests/test-open-pr-cleanup-worktree.sh
+++ b/tests/test-open-pr-cleanup-worktree.sh
@@ -8,6 +8,8 @@
 #   2. --cleanup-worktree with --auto-merge from a feature worktree → after
 #      successful merge, the feature worktree is removed by `git worktree
 #      remove`.
+#   3. The same cleanup also runs when --auto-merge attaches to an already
+#      open PR for the current branch.
 #
 set -euo pipefail
 
@@ -36,7 +38,13 @@ cat > "$FAKE_BIN/gh" <<'EOF'
 set -euo pipefail
 case "$1 $2" in
   "repo view") echo "main" ;;
-  "pr list") echo "" ;;
+  "pr list")
+    if [ "${GH_HAS_EXISTING_PR:-0}" = "1" ]; then
+      echo "https://example.test/touchstone/pull/9999"
+    else
+      echo ""
+    fi
+    ;;
   "pr create") echo "https://example.test/touchstone/pull/9999" ;;
   "pr view") echo "2026-04-30T05:00:00Z" ;;
   *) echo "unexpected gh args: $*" >&2; exit 1 ;;
@@ -102,6 +110,36 @@ else
   echo "    FAIL: expected exit 0, 'Worktree removed.' in output, and \$FEATURE_DIR gone" >&2
   echo "    rc=$RC" >&2
   echo "    feature dir exists? $([ -d "$FEATURE_DIR" ] && echo yes || echo no)" >&2
+  cat "$OUT" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# Case 3 — existing PR path: cleanup still runs after verified merge
+echo "==> Case 3: existing PR --auto-merge --cleanup-worktree removes the feature worktree"
+EXISTING_FEATURE_DIR="$TEST_DIR/repo-feature-existing"
+git -C "$REPO_DIR" worktree add "$EXISTING_FEATURE_DIR" -b feat/cleanup-existing >/dev/null 2>&1
+printf 'existing\n' >> "$EXISTING_FEATURE_DIR/file.txt"
+git -C "$EXISTING_FEATURE_DIR" add file.txt
+git -C "$EXISTING_FEATURE_DIR" commit -m "test existing change" >/dev/null 2>&1
+
+RC=0
+OUT="$TEST_DIR/case3.out"
+(
+  cd "$EXISTING_FEATURE_DIR"
+  PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    GH_HAS_EXISTING_PR=1 \
+    bash "$SCRIPT_DIR/open-pr.sh" --auto-merge --cleanup-worktree
+) >"$OUT" 2>&1 || RC=$?
+
+if [ "$RC" = "0" ] \
+  && grep -q '==> PR already open for feat/cleanup-existing' "$OUT" \
+  && grep -q '==> Worktree removed.' "$OUT" \
+  && [ ! -d "$EXISTING_FEATURE_DIR" ]; then
+  echo "    PASS"
+else
+  echo "    FAIL: expected existing-PR auto-merge cleanup to remove the worktree" >&2
+  echo "    rc=$RC" >&2
+  echo "    existing feature dir exists? $([ -d "$EXISTING_FEATURE_DIR" ] && echo yes || echo no)" >&2
   cat "$OUT" >&2
   ERRORS=$((ERRORS + 1))
 fi


### PR DESCRIPTION
## Linked Issues

Closes #141

Closes #141

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
