### PR TITLE
Make review routing size-aware by default

### DIFF
--- a/bootstrap/review.sh
+++ b/bootstrap/review.sh
@@ -81,15 +81,15 @@ CONDUCTOR_PREFER=""
 CONDUCTOR_EFFORT=""
 CONDUCTOR_TAGS=""
 CONDUCTOR_EXCLUDE=""
-ROUTING_ENABLED=false
+ROUTING_ENABLED=true
 ROUTING_SMALL_MAX_DIFF_LINES=400
 ROUTING_SMALL_WITH=""
-ROUTING_SMALL_PREFER=""
-ROUTING_SMALL_EFFORT=""
+ROUTING_SMALL_PREFER="cheapest"
+ROUTING_SMALL_EFFORT="minimal"
 ROUTING_SMALL_TAGS=""
 ROUTING_LARGE_WITH=""
-ROUTING_LARGE_PREFER=""
-ROUTING_LARGE_EFFORT=""
+ROUTING_LARGE_PREFER="best"
+ROUTING_LARGE_EFFORT="max"
 ROUTING_LARGE_TAGS=""
 CONFIG_MODE=""
 
@@ -101,6 +101,18 @@ strip_quotes() {
     \'*\') v="${v#\'}"; v="${v%\'}" ;;
   esac
   printf '%s' "$v"
+}
+
+normalize_bool() {
+  local value
+  value="$(strip_quotes "$1")"
+  value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
+
+  case "$value" in
+    true|1|yes|on) printf 'true' ;;
+    false|0|no|off) printf 'false' ;;
+    *) printf '%s' "$value" ;;
+  esac
 }
 
 # Parse .codex-review.toml if it exists.
@@ -131,8 +143,8 @@ if [ -f "$CONFIG_FILE" ]; then
         ;;
       "review.routing")
         case "$key" in
-          enabled) [ "$(normalize_bool "$value")" = "true" ] && ROUTING_ENABLED=true ;;
-          small_max_diff_lines) ROUTING_SMALL_MAX_DIFF_LINES="$value" ;;
+          enabled) ROUTING_ENABLED="$(normalize_bool "$value")" ;;
+          small_max_diff_lines|small_diff_lines) ROUTING_SMALL_MAX_DIFF_LINES="$value" ;;
           small_with)    ROUTING_SMALL_WITH="$(toml_unquote "$value")" ;;
           small_prefer)  ROUTING_SMALL_PREFER="$(toml_unquote "$value")" ;;
           small_effort)  ROUTING_SMALL_EFFORT="$(toml_unquote "$value")" ;;
@@ -195,25 +207,38 @@ BASE="${base_override:-${CODEX_REVIEW_BASE:-origin/$(default_branch)}}"
 # Try to compute diff line count for size-based routing. Best-effort:
 # if the base ref doesn't exist locally we skip the small/large bucket.
 DIFF_LINE_COUNT=0
+diff_line_count_available=false
 if git rev-parse --verify "$BASE" >/dev/null 2>&1; then
   DIFF_LINE_COUNT="$(git diff "$BASE"..HEAD 2>/dev/null | wc -l | tr -d ' ')"
+  diff_line_count_available=true
 fi
 
 routing_decision="default"
-if [ "$ROUTING_ENABLED" = true ] && [ "$DIFF_LINE_COUNT" -gt 0 ]; then
-  if [ "$DIFF_LINE_COUNT" -le "$ROUTING_SMALL_MAX_DIFF_LINES" ] 2>/dev/null; then
-    routing_decision="small"
-    [ -n "$ROUTING_SMALL_WITH" ]   && CONDUCTOR_WITH="${TOUCHSTONE_CONDUCTOR_WITH:-$ROUTING_SMALL_WITH}"
-    [ -n "$ROUTING_SMALL_PREFER" ] && CONDUCTOR_PREFER="${TOUCHSTONE_CONDUCTOR_PREFER:-$ROUTING_SMALL_PREFER}"
-    [ -n "$ROUTING_SMALL_EFFORT" ] && CONDUCTOR_EFFORT="${TOUCHSTONE_CONDUCTOR_EFFORT:-$ROUTING_SMALL_EFFORT}"
-    [ -n "$ROUTING_SMALL_TAGS" ]   && CONDUCTOR_TAGS="${TOUCHSTONE_CONDUCTOR_TAGS:-$ROUTING_SMALL_TAGS}"
-  else
-    routing_decision="large"
-    [ -n "$ROUTING_LARGE_WITH" ]   && CONDUCTOR_WITH="${TOUCHSTONE_CONDUCTOR_WITH:-$ROUTING_LARGE_WITH}"
-    [ -n "$ROUTING_LARGE_PREFER" ] && CONDUCTOR_PREFER="${TOUCHSTONE_CONDUCTOR_PREFER:-$ROUTING_LARGE_PREFER}"
-    [ -n "$ROUTING_LARGE_EFFORT" ] && CONDUCTOR_EFFORT="${TOUCHSTONE_CONDUCTOR_EFFORT:-$ROUTING_LARGE_EFFORT}"
-    [ -n "$ROUTING_LARGE_TAGS" ]   && CONDUCTOR_TAGS="${TOUCHSTONE_CONDUCTOR_TAGS:-$ROUTING_LARGE_TAGS}"
-  fi
+routing_reason="review.routing.enabled=false"
+if [ "$ROUTING_ENABLED" = true ]; then
+  routing_reason="diff line count unavailable for base $BASE"
+  case "$ROUTING_SMALL_MAX_DIFF_LINES" in
+    ''|*[!0-9]*)
+      routing_reason="invalid review.routing.small_max_diff_lines='$ROUTING_SMALL_MAX_DIFF_LINES'"
+      ;;
+    *)
+      if [ "$diff_line_count_available" = true ] && [ "$DIFF_LINE_COUNT" -le "$ROUTING_SMALL_MAX_DIFF_LINES" ] 2>/dev/null; then
+        routing_decision="small"
+        routing_reason="$DIFF_LINE_COUNT <= $ROUTING_SMALL_MAX_DIFF_LINES diff lines"
+        [ -n "$ROUTING_SMALL_WITH" ]   && CONDUCTOR_WITH="${TOUCHSTONE_CONDUCTOR_WITH:-$ROUTING_SMALL_WITH}"
+        [ -n "$ROUTING_SMALL_PREFER" ] && CONDUCTOR_PREFER="${TOUCHSTONE_CONDUCTOR_PREFER:-$ROUTING_SMALL_PREFER}"
+        [ -n "$ROUTING_SMALL_EFFORT" ] && CONDUCTOR_EFFORT="${TOUCHSTONE_CONDUCTOR_EFFORT:-$ROUTING_SMALL_EFFORT}"
+        [ -n "$ROUTING_SMALL_TAGS" ]   && CONDUCTOR_TAGS="${TOUCHSTONE_CONDUCTOR_TAGS:-$ROUTING_SMALL_TAGS}"
+      elif [ "$diff_line_count_available" = true ]; then
+        routing_decision="large"
+        routing_reason="$DIFF_LINE_COUNT > $ROUTING_SMALL_MAX_DIFF_LINES diff lines"
+        [ -n "$ROUTING_LARGE_WITH" ]   && CONDUCTOR_WITH="${TOUCHSTONE_CONDUCTOR_WITH:-$ROUTING_LARGE_WITH}"
+        [ -n "$ROUTING_LARGE_PREFER" ] && CONDUCTOR_PREFER="${TOUCHSTONE_CONDUCTOR_PREFER:-$ROUTING_LARGE_PREFER}"
+        [ -n "$ROUTING_LARGE_EFFORT" ] && CONDUCTOR_EFFORT="${TOUCHSTONE_CONDUCTOR_EFFORT:-$ROUTING_LARGE_EFFORT}"
+        [ -n "$ROUTING_LARGE_TAGS" ]   && CONDUCTOR_TAGS="${TOUCHSTONE_CONDUCTOR_TAGS:-$ROUTING_LARGE_TAGS}"
+      fi
+      ;;
+  esac
 fi
 
 # Mode → tools (mirror the adapter in hooks/codex-review.sh).
@@ -241,9 +266,10 @@ if [ -n "$CONDUCTOR_WITH" ]; then
   echo "    Effective config:"
   echo "      with     = $CONDUCTOR_WITH"
   echo "      effort   = $CONDUCTOR_EFFORT"
+  echo "      prefer   = $CONDUCTOR_PREFER"
   echo "      mode     = $REVIEW_MODE → tools=${tools:-<none>}"
   echo "      base     = $BASE  ($DIFF_LINE_COUNT diff lines)"
-  echo "      routing  = $routing_decision"
+  echo "      routing  = $routing_decision ($routing_reason)"
   echo ""
   echo "    To preview which provider auto-routing would pick, unset"
   echo "    TOUCHSTONE_CONDUCTOR_WITH and remove [review.conductor].with"
@@ -263,7 +289,7 @@ if [ -z "$json_flag" ]; then
   echo "    base ref:    $BASE"
   echo "    diff lines:  $DIFF_LINE_COUNT"
   echo "    review mode: $REVIEW_MODE → tools=${tools:-<none>}"
-  echo "    routing:     $routing_decision (small/large bucket detection)"
+  echo "    routing:     $routing_decision ($routing_reason)"
   echo ""
 fi
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -78,19 +78,19 @@ Conductor logs its route decision (provider, cost estimate, token count, wall-cl
 | `unsafe_paths` | [] | Paths where auto-fix is never allowed |
 | `[review].enabled` | true | Set false to skip AI review without removing the hook |
 | `[review].reviewer` | `"conductor"` | The only supported value in 2.0 |
-| `[review.conductor].prefer` | `"best"` | `best` \| `cheapest` \| `fastest` \| `balanced` |
-| `[review.conductor].effort` | `"max"` | `minimal` \| `low` \| `medium` \| `high` \| `max` \| integer thinking-token budget |
+| `[review.conductor].prefer` | size-aware | `best` \| `cheapest` \| `fastest` \| `balanced`; used as a global fallback, but default size routing applies per bucket |
+| `[review.conductor].effort` | size-aware | `minimal` \| `low` \| `medium` \| `high` \| `max` \| integer thinking-token budget; used as a global fallback, but default size routing applies per bucket |
 | `[review.conductor].tags` | `"code-review"` | Capability tags passed to the router |
 | `[review.conductor].with` | unset | Pin a specific provider (bypasses auto-routing) |
 | `[review.conductor].exclude` | unset | Exclude providers from auto-routing |
-| `[review.routing].enabled` | false | Route by diff size |
+| `[review.routing].enabled` | true | Route by diff size |
 | `[review.routing].small_max_diff_lines` | 400 | Diffs ≤ this use the `small_*` knobs; diffs above use the `large_*` knobs |
-| `[review.routing].small_prefer` | unset | e.g. `"cheapest"` for small diffs |
-| `[review.routing].small_effort` | unset | e.g. `"minimal"` for small diffs |
+| `[review.routing].small_prefer` | `"cheapest"` | Routing preference for small diffs |
+| `[review.routing].small_effort` | `"minimal"` | Thinking effort for small diffs |
 | `[review.routing].small_with` | unset | Pin provider for small diffs |
 | `[review.routing].small_tags` | unset | e.g. `"code-review"` for small diffs |
-| `[review.routing].large_prefer` | unset | e.g. `"best"` for larger diffs |
-| `[review.routing].large_effort` | unset | e.g. `"max"` for larger diffs |
+| `[review.routing].large_prefer` | `"best"` | Routing preference for larger diffs |
+| `[review.routing].large_effort` | `"max"` | Thinking effort for larger diffs |
 | `[review.routing].large_with` | unset | Pin provider for larger diffs |
 | `[review.routing].large_tags` | unset | e.g. `"code-review,long-context"` |
 | `[review.context].mode` | `"auto"` | `auto` prunes small/simple diffs; `full` always loads full project context |
@@ -98,7 +98,7 @@ Conductor logs its route decision (provider, cost estimate, token count, wall-cl
 | `[review.context].small_max_files` | 4 | Max changed files for bounded prompt context |
 | `[review.context].full_context_paths` | [] | Extra path patterns that always require full `AGENTS.md`/`CLAUDE.md` context |
 
-Routing uses a single cutoff (`small_max_diff_lines`): diffs at or below it go through the `small_*` bucket, everything else through the `large_*` bucket. There is no separate `large_max_diff_lines`.
+Routing uses a single cutoff (`small_max_diff_lines`): diffs at or below it go through the `small_*` bucket, everything else through the `large_*` bucket. There is no separate `large_max_diff_lines`. The default route is `cheapest`/`minimal` for diffs up to 400 lines and `best`/`max` above that. Explicit `TOUCHSTONE_CONDUCTOR_*` environment variables still win over bucket defaults.
 
 Prompt-context pruning is separate from provider routing. In `auto` mode, the hook uses bounded context only when the diff stays within both small limits and avoids `unsafe_paths`, built-in architectural files, and configured `full_context_paths`. The prompt states when full context was intentionally omitted and why.
 

--- a/hooks/codex-review.config.example.toml
+++ b/hooks/codex-review.config.example.toml
@@ -70,8 +70,9 @@ unsafe_paths = [
 # --------------------------------------------------------------------------
 # Conductor routing (optional)
 # --------------------------------------------------------------------------
-# Fine-tune what Conductor picks and how hard it thinks. All four knobs have
-# sensible defaults for code review; only override when you need to.
+# Fine-tune what Conductor picks and how hard it thinks. By default,
+# Touchstone applies size-aware routing below; set these only when you want a
+# global fallback or a pinned provider.
 
 # [review.conductor]
 # # Which provider wins auto-routing. One of:
@@ -96,11 +97,11 @@ unsafe_paths = [
 # # exclude = "gemini"
 
 # --------------------------------------------------------------------------
-# Routing by diff size (optional)
+# Routing by diff size (default)
 # --------------------------------------------------------------------------
-# Use this when you want cheap + shallow review for tiny diffs and max-effort
-# on large or risky changes. Touchstone-side override of Conductor's knobs
-# per size bucket.
+# Touchstone defaults to cheap + shallow review for small diffs and max-effort
+# review for larger changes. Explicit TOUCHSTONE_CONDUCTOR_* env vars still
+# win at invocation time, and enabled = false opts out.
 #
 # Routing uses a single cutoff (small_max_diff_lines): diffs at or below it
 # go through the small_* bucket, everything above through the large_* bucket.
@@ -108,14 +109,15 @@ unsafe_paths = [
 # ignored by the parser.
 #
 # [review.routing]
-# enabled = false
+# enabled = true
 # small_max_diff_lines = 400
 # small_prefer = "cheapest"
 # small_effort = "minimal"
-# small_with = "ollama"
 # large_prefer = "best"
 # large_effort = "max"
-# large_tags = "code-review,long-context"
+# # Optional: pin or retag either bucket.
+# # small_with = "ollama"
+# # large_tags = "code-review,long-context"
 
 # --------------------------------------------------------------------------
 # Prompt context pruning (optional)

--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -52,8 +52,8 @@
 # Env overrides:
 #   TOUCHSTONE_REVIEWER               — DEPRECATED in 2.0.0; auto-translates to TOUCHSTONE_CONDUCTOR_WITH=<provider>
 #   TOUCHSTONE_CONDUCTOR_WITH         — pin a specific provider for auto-routing
-#   TOUCHSTONE_CONDUCTOR_PREFER       — best|cheapest|fastest|balanced (default: best)
-#   TOUCHSTONE_CONDUCTOR_EFFORT       — minimal|low|medium|high|max (default: max)
+#   TOUCHSTONE_CONDUCTOR_PREFER       — best|cheapest|fastest|balanced (default: size-aware)
+#   TOUCHSTONE_CONDUCTOR_EFFORT       — minimal|low|medium|high|max (default: size-aware)
 #   TOUCHSTONE_CONDUCTOR_TAGS         — comma-separated tag hints (default: code-review)
 #   TOUCHSTONE_CONDUCTOR_EXCLUDE      — comma-separated providers to skip
 #   CODEX_REVIEW_SUPPRESS_LEGACY_WARNINGS — silence one-time migration hints
@@ -375,18 +375,18 @@ CONDUCTOR_PREFER=""
 CONDUCTOR_EFFORT=""
 CONDUCTOR_TAGS=""
 CONDUCTOR_EXCLUDE=""
-ROUTING_ENABLED=false
+ROUTING_ENABLED=true
 ROUTING_SMALL_MAX_DIFF_LINES=400
 ROUTING_SMALL_REVIEWERS=()   # legacy 1.x shape; retained for back-compat parsing
 ROUTING_LARGE_REVIEWERS=()   # legacy 1.x shape; retained for back-compat parsing
 # 2.0 routing knobs — override CONDUCTOR_* for small vs large diffs.
 ROUTING_SMALL_WITH=""
-ROUTING_SMALL_PREFER=""
-ROUTING_SMALL_EFFORT=""
+ROUTING_SMALL_PREFER="cheapest"
+ROUTING_SMALL_EFFORT="minimal"
 ROUTING_SMALL_TAGS=""
 ROUTING_LARGE_WITH=""
-ROUTING_LARGE_PREFER=""
-ROUTING_LARGE_EFFORT=""
+ROUTING_LARGE_PREFER="best"
+ROUTING_LARGE_EFFORT="max"
 ROUTING_LARGE_TAGS=""
 ROUTING_DECISION="default"
 PROMPT_CONTEXT_MODE="${CODEX_REVIEW_CONTEXT_MODE:-auto}"

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -52,8 +52,8 @@
 # Env overrides:
 #   TOUCHSTONE_REVIEWER               — DEPRECATED in 2.0.0; auto-translates to TOUCHSTONE_CONDUCTOR_WITH=<provider>
 #   TOUCHSTONE_CONDUCTOR_WITH         — pin a specific provider for auto-routing
-#   TOUCHSTONE_CONDUCTOR_PREFER       — best|cheapest|fastest|balanced (default: best)
-#   TOUCHSTONE_CONDUCTOR_EFFORT       — minimal|low|medium|high|max (default: max)
+#   TOUCHSTONE_CONDUCTOR_PREFER       — best|cheapest|fastest|balanced (default: size-aware)
+#   TOUCHSTONE_CONDUCTOR_EFFORT       — minimal|low|medium|high|max (default: size-aware)
 #   TOUCHSTONE_CONDUCTOR_TAGS         — comma-separated tag hints (default: code-review)
 #   TOUCHSTONE_CONDUCTOR_EXCLUDE      — comma-separated providers to skip
 #   CODEX_REVIEW_SUPPRESS_LEGACY_WARNINGS — silence one-time migration hints
@@ -375,18 +375,18 @@ CONDUCTOR_PREFER=""
 CONDUCTOR_EFFORT=""
 CONDUCTOR_TAGS=""
 CONDUCTOR_EXCLUDE=""
-ROUTING_ENABLED=false
+ROUTING_ENABLED=true
 ROUTING_SMALL_MAX_DIFF_LINES=400
 ROUTING_SMALL_REVIEWERS=()   # legacy 1.x shape; retained for back-compat parsing
 ROUTING_LARGE_REVIEWERS=()   # legacy 1.x shape; retained for back-compat parsing
 # 2.0 routing knobs — override CONDUCTOR_* for small vs large diffs.
 ROUTING_SMALL_WITH=""
-ROUTING_SMALL_PREFER=""
-ROUTING_SMALL_EFFORT=""
+ROUTING_SMALL_PREFER="cheapest"
+ROUTING_SMALL_EFFORT="minimal"
 ROUTING_SMALL_TAGS=""
 ROUTING_LARGE_WITH=""
-ROUTING_LARGE_PREFER=""
-ROUTING_LARGE_EFFORT=""
+ROUTING_LARGE_PREFER="best"
+ROUTING_LARGE_EFFORT="max"
 ROUTING_LARGE_TAGS=""
 ROUTING_DECISION="default"
 PROMPT_CONTEXT_MODE="${CODEX_REVIEW_CONTEXT_MODE:-auto}"

--- a/tests/test-review-dry-run.sh
+++ b/tests/test-review-dry-run.sh
@@ -60,8 +60,35 @@ new_repo() {
   git -C "$dir" add . && git -C "$dir" commit -qm init
 }
 
+commit_new_file_with_diff_lines() {
+  local repo="$1"
+  local target_lines="$2"
+  local path="$3"
+  local content_lines=$((target_lines - 6))
+  local i=1
+
+  if [ "$content_lines" -lt 1 ]; then
+    echo "test setup error: target diff line count must be at least 7" >&2
+    exit 1
+  fi
+
+  : > "$repo/$path"
+  while [ "$i" -le "$content_lines" ]; do
+    printf 'line %03d\n' "$i" >> "$repo/$path"
+    i=$((i + 1))
+  done
+  git -C "$repo" add "$path" && git -C "$repo" commit -qm "change $target_lines lines"
+
+  local actual_lines
+  actual_lines="$(git -C "$repo" diff HEAD~1..HEAD | wc -l | tr -d ' ')"
+  if [ "$actual_lines" != "$target_lines" ]; then
+    echo "test setup error: expected $target_lines diff lines, got $actual_lines" >&2
+    exit 1
+  fi
+}
+
 # ----------------------------------------------------------------------------
-echo "==> Test: --dry-run with auto-routed config calls conductor route"
+echo "==> Test: small default route beats global conductor prefer/effort"
 REPO_AUTO="$TEST_DIR/repo-auto"
 new_repo "$REPO_AUTO"
 cat > "$REPO_AUTO/.codex-review.toml" <<'EOF'
@@ -80,14 +107,83 @@ echo c >> "$REPO_AUTO/README.md" && git -C "$REPO_AUTO" add . && git -C "$REPO_A
 out="$(run_review "$REPO_AUTO" --dry-run --base HEAD~1 2>&1)"
 
 if grep -q '^route' "$ARGS_FILE" \
-  && grep -q '\-\-prefer best' "$ARGS_FILE" \
-  && grep -q '\-\-effort max' "$ARGS_FILE" \
+  && grep -q '\-\-prefer cheapest' "$ARGS_FILE" \
+  && grep -q '\-\-effort minimal' "$ARGS_FILE" \
   && grep -q '\-\-tags code-review' "$ARGS_FILE" \
+  && echo "$out" | grep -q 'routing:     small (.* <= 400 diff lines)' \
   && echo "$out" | grep -q 'would pick: claude'; then
-  echo "==> PASS: auto-routed --dry-run invoked conductor route with config flags"
+  echo "==> PASS: small default route used cheapest/minimal despite global best/max"
 else
-  echo "FAIL: dry-run did not invoke conductor route as expected" >&2
+  echo "FAIL: small default route did not invoke conductor route as expected" >&2
   echo "args file: $(cat "$ARGS_FILE")" >&2
+  echo "out: $out" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ----------------------------------------------------------------------------
+echo "==> Test: exact threshold stays in the small routing bucket"
+REPO_THRESHOLD="$TEST_DIR/repo-threshold"
+new_repo "$REPO_THRESHOLD"
+commit_new_file_with_diff_lines "$REPO_THRESHOLD" 400 threshold.txt
+
+: > "$ARGS_FILE"
+out="$(run_review "$REPO_THRESHOLD" --dry-run --base HEAD~1 2>&1)"
+
+if grep -q '\-\-prefer cheapest' "$ARGS_FILE" \
+  && grep -q '\-\-effort minimal' "$ARGS_FILE" \
+  && echo "$out" | grep -q 'routing:     small (400 <= 400 diff lines)'; then
+  echo "==> PASS: 400-line diff used small cheapest/minimal bucket"
+else
+  echo "FAIL: exact threshold diff should use small routing bucket" >&2
+  echo "args: $(cat "$ARGS_FILE")" >&2
+  echo "out: $out" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ----------------------------------------------------------------------------
+echo "==> Test: large default route uses best/max"
+REPO_LARGE="$TEST_DIR/repo-large"
+new_repo "$REPO_LARGE"
+commit_new_file_with_diff_lines "$REPO_LARGE" 401 large.txt
+
+: > "$ARGS_FILE"
+out="$(run_review "$REPO_LARGE" --dry-run --base HEAD~1 2>&1)"
+
+if grep -q '\-\-prefer best' "$ARGS_FILE" \
+  && grep -q '\-\-effort max' "$ARGS_FILE" \
+  && echo "$out" | grep -q 'routing:     large (401 > 400 diff lines)'; then
+  echo "==> PASS: 401-line diff used large best/max bucket"
+else
+  echo "FAIL: large diff should use large routing bucket" >&2
+  echo "args: $(cat "$ARGS_FILE")" >&2
+  echo "out: $out" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ----------------------------------------------------------------------------
+echo "==> Test: explicit routing opt-out preserves global conductor config"
+REPO_DISABLED="$TEST_DIR/repo-routing-disabled"
+new_repo "$REPO_DISABLED"
+cat > "$REPO_DISABLED/.codex-review.toml" <<'EOF'
+[review.conductor]
+prefer = "balanced"
+effort = "low"
+[review.routing]
+enabled = false
+EOF
+git -C "$REPO_DISABLED" add . && git -C "$REPO_DISABLED" commit -qm cfg
+echo c >> "$REPO_DISABLED/README.md" && git -C "$REPO_DISABLED" add . && git -C "$REPO_DISABLED" commit -qm change
+
+: > "$ARGS_FILE"
+out="$(run_review "$REPO_DISABLED" --dry-run --base HEAD~1 2>&1)"
+
+if grep -q '\-\-prefer balanced' "$ARGS_FILE" \
+  && grep -q '\-\-effort low' "$ARGS_FILE" \
+  && echo "$out" | grep -q 'routing:     default (review.routing.enabled=false)'; then
+  echo "==> PASS: review.routing.enabled=false kept global conductor config"
+else
+  echo "FAIL: explicit routing opt-out should preserve global conductor config" >&2
+  echo "args: $(cat "$ARGS_FILE")" >&2
   echo "out: $out" >&2
   ERRORS=$((ERRORS + 1))
 fi
@@ -109,7 +205,9 @@ git -C "$REPO_PIN" add . && git -C "$REPO_PIN" commit -qm cfg
 : > "$ARGS_FILE"
 out="$(run_review "$REPO_PIN" --dry-run --base HEAD 2>&1)"
 
-if echo "$out" | grep -q 'pinned via --with=claude' && ! grep -q '^route' "$ARGS_FILE"; then
+if echo "$out" | grep -q 'pinned via --with=claude' \
+  && echo "$out" | grep -q 'routing  = small (0 <= 400 diff lines)' \
+  && ! grep -q '^route' "$ARGS_FILE"; then
   echo "==> PASS: pinned config explained, no route preview attempted"
 else
   echo "FAIL: pinned config should have explained, not called conductor route" >&2
@@ -119,21 +217,23 @@ else
 fi
 
 # ----------------------------------------------------------------------------
-echo "==> Test: env override beats config (TOUCHSTONE_CONDUCTOR_PREFER=cheapest)"
+echo "==> Test: env override beats size bucket defaults"
 : > "$ARGS_FILE"
 out="$(
   cd "$REPO_AUTO"
   PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
     ARGS_FILE="$ARGS_FILE" \
-    TOUCHSTONE_CONDUCTOR_PREFER=cheapest \
+    TOUCHSTONE_CONDUCTOR_PREFER=fastest \
+    TOUCHSTONE_CONDUCTOR_EFFORT=high \
     TOUCHSTONE_NO_AUTO_UPDATE=1 \
     bash "$TOUCHSTONE_BIN" review --dry-run --base HEAD~1 2>&1
 )"
 
-if grep -q '\-\-prefer cheapest' "$ARGS_FILE"; then
-  echo "==> PASS: env override TOUCHSTONE_CONDUCTOR_PREFER took precedence"
+if grep -q '\-\-prefer fastest' "$ARGS_FILE" \
+  && grep -q '\-\-effort high' "$ARGS_FILE"; then
+  echo "==> PASS: TOUCHSTONE_CONDUCTOR_* env overrides took precedence"
 else
-  echo "FAIL: env override did not reach conductor route flags" >&2
+  echo "FAIL: env overrides did not reach conductor route flags" >&2
   echo "args: $(cat "$ARGS_FILE")" >&2
   ERRORS=$((ERRORS + 1))
 fi


### PR DESCRIPTION
## Linked Issues

Closes #133

Default review routing now uses cheapest/minimal for diffs at or below 400 lines and best/max above that, with dry-run output showing the bucket threshold decision. Explicit env overrides and routing opt-out remain supported.

Closes #133

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
