### PR TITLE
test: stub Cortex/Sentinel + phase markers in fast bootstrap suite

### DIFF
--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,0 +1,25 @@
+# tests/fixtures — stand-ins for Touchstone's fast test tier
+
+The files in this directory are **not** real Cortex or Sentinel binaries.
+They are deterministic stand-ins that mimic the externally observable
+contract of `cortex init` and `sentinel init` (file scaffold, gitignore
+edits, exit code, sibling-version output) without paying the real
+binaries' startup, banner, or model-detection costs.
+
+`tests/test-bootstrap.sh` prepends this directory to `PATH` so that
+every `command -v cortex` / `command -v sentinel` check inside
+`bootstrap/new-project.sh` resolves to the stub. The fast tier therefore
+exercises Touchstone's bootstrap contract — file ordering, gitignore
+scope, atomic-commit semantics, the `--no-with-cortex` / `--no-with-sentinel`
+opt-outs — without spawning a real Cortex or Sentinel process.
+
+The slow tier (`tests/slow-bootstrap.sh`) sets
+`TOUCHSTONE_REAL_BOOTSTRAP=1`, which skips the `PATH` override and
+exercises the real installed binaries. That is the integration smoke
+path; it must be run before a release-confidence check whenever the
+contract between Touchstone and Cortex/Sentinel changes.
+
+The narrower per-test inline stubs in `test-bootstrap.sh` (R5.1/R5.2,
+sibling-detection) override these fixtures by prepending an even-tighter
+stub dir to `PATH` for their own scope. They stay tightly scoped because
+those tests assert on stub-specific output (e.g. `cortex 9.9.9 (installed)`).

--- a/tests/fixtures/cortex
+++ b/tests/fixtures/cortex
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# tests/fixtures/stub-cortex — deterministic Cortex stand-in for the fast
+# test tier. Mirrors the externally observable contract of `cortex init`
+# (creates .cortex/ with the files Touchstone scaffold tests rely on)
+# without paying the real binary's startup, banner, or model-detection
+# costs. The slow tier (tests/slow-bootstrap.sh) opts out of this stub
+# and exercises the real cortex binary instead.
+#
+set -euo pipefail
+
+case "${1:-}" in
+  version|--version|-V)
+    echo "cortex 0.0.0-stub"
+    exit 0
+    ;;
+  init)
+    mkdir -p .cortex/doctrine .cortex/plans .cortex/journal
+    : > .cortex/state.md
+    : > .cortex/README.md
+    : > .cortex/protocol.md
+    echo "0.5.0" > .cortex/SPEC_VERSION
+    echo "==> stub-cortex init: scaffolded .cortex/"
+    exit 0
+    ;;
+  doctor|refresh-state|state|journal|grep|retrieve|manifest)
+    exit 0
+    ;;
+  "")
+    echo "stub-cortex: missing subcommand" >&2
+    exit 2
+    ;;
+  *)
+    exit 0
+    ;;
+esac

--- a/tests/fixtures/sentinel
+++ b/tests/fixtures/sentinel
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# tests/fixtures/stub-sentinel — deterministic Sentinel stand-in for the
+# fast test tier. Mirrors the externally observable contract of
+# `sentinel init` (creates .sentinel/, appends a `.claude/` block to the
+# project's root .gitignore, commits the gitignore change when in a git
+# repo) without paying the real binary's provider-table render cost.
+# The slow tier (tests/slow-bootstrap.sh) opts out of this stub and
+# exercises the real sentinel binary instead.
+#
+set -euo pipefail
+
+case "${1:-}" in
+  version|--version|-V)
+    echo "sentinel, version 0.0.0-stub"
+    exit 0
+    ;;
+  init)
+    mkdir -p .sentinel
+    : > .sentinel/config.toml
+    printf 'state/\n' > .sentinel/.gitignore
+
+    # Note: the root .gitignore gets a `.claude/` block, NOT `.sentinel/`.
+    # Real sentinel keeps `.sentinel/` source-tracked and only ignores the
+    # ephemeral `state/` subdir via .sentinel/.gitignore. The R5.2
+    # regression check enforces that distinction.
+    if [ ! -f .gitignore ] || ! grep -qF '.claude/' .gitignore; then
+      printf '\n# sentinel artifacts — generated per-run, not source\n.claude/\n' >> .gitignore
+      # Mirror real sentinel's _commit_gitignore_if_in_repo: when running
+      # inside a git repo with HEAD, commit the gitignore so a later
+      # `sentinel work --reset` does not throw away the ignore rules.
+      if git rev-parse --git-dir >/dev/null 2>&1 \
+        && git rev-parse --verify HEAD >/dev/null 2>&1; then
+        git add .gitignore >/dev/null 2>&1 || true
+        git -c user.email=sentinel-stub@touchstone.test \
+            -c user.name=sentinel-stub \
+            commit -m "chore: gitignore sentinel artifacts (.claude/)" \
+            --quiet -- .gitignore >/dev/null 2>&1 || true
+      fi
+    fi
+
+    echo "==> stub-sentinel init: scaffolded .sentinel/"
+    exit 0
+    ;;
+  work|run|doctor|status)
+    exit 0
+    ;;
+  "")
+    echo "stub-sentinel: missing subcommand" >&2
+    exit 2
+    ;;
+  *)
+    exit 0
+    ;;
+esac

--- a/tests/slow-bootstrap.sh
+++ b/tests/slow-bootstrap.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# tests/slow-bootstrap.sh — opt-in integration smoke for the bootstrap
+# flow against the real `cortex` and `sentinel` binaries.
+#
+# The fast tier (tests/test-bootstrap.sh) prepends tests/fixtures/ to
+# PATH so the wizard's default Cortex/Sentinel init paths exercise the
+# Touchstone scaffold contract without paying the real binaries'
+# startup cost. That is the right trade-off ~30 times per run, but it
+# leaves a gap: if Cortex or Sentinel changes its CLI contract, the
+# fast tier will not catch it. This wrapper re-runs the same test
+# script with TOUCHSTONE_REAL_BOOTSTRAP=1 so the real binaries are
+# invoked instead.
+#
+# Run this before a release-confidence check whenever the contract
+# between Touchstone and Cortex/Sentinel changes.
+#
+set -euo pipefail
+
+if ! command -v cortex >/dev/null 2>&1; then
+  echo "ERROR: 'cortex' is not on PATH; install it (brew install autumngarage/cortex/cortex) before running this slow probe." >&2
+  exit 1
+fi
+if ! command -v sentinel >/dev/null 2>&1; then
+  echo "ERROR: 'sentinel' is not on PATH; install it (brew install autumngarage/sentinel/sentinel) before running this slow probe." >&2
+  exit 1
+fi
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+exec env TOUCHSTONE_REAL_BOOTSTRAP=1 bash "$DIR/test-bootstrap.sh" "$@"

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -12,6 +12,18 @@ export YES_MODE=true
 exec </dev/null
 
 TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Issue #162: prepend deterministic stand-ins for `cortex` and `sentinel`
+# so the wizard's default-true Cortex/Sentinel init paths exercise the
+# Touchstone contract without spawning the real binaries (each real
+# `cortex init` / `sentinel init` adds banner output and seconds of
+# startup; the test issues 30+ default bootstraps). The slow tier
+# (tests/slow-bootstrap.sh) sets TOUCHSTONE_REAL_BOOTSTRAP=1 to skip
+# this override and exercise the real binaries against the same
+# assertions. See tests/fixtures/README.md.
+if [ -z "${TOUCHSTONE_REAL_BOOTSTRAP:-}" ]; then
+  export PATH="$TOUCHSTONE_ROOT/tests/fixtures:$PATH"
+fi
 TEST_DIR="$(mktemp -d -t touchstone-test-bootstrap.XXXXXX)"
 
 REAL_HOME="${HOME:-}"
@@ -40,7 +52,19 @@ cleanup() {
 }
 trap cleanup EXIT
 
-echo "==> Test: bootstrap a new project"
+# Issue #162: bounded progress markers. Each `phase` line tells a watching
+# operator (or agent) what section is in flight and a wall-clock timestamp,
+# so a long pre-commit install or git operation is visibly progressing
+# instead of looking stuck.
+PHASE_START_EPOCH="$(date +%s)"
+phase() {
+  local now elapsed
+  now="$(date +%s)"
+  elapsed=$((now - PHASE_START_EPOCH))
+  printf '==> [+%3ds] %s\n' "$elapsed" "$*"
+}
+
+phase "bootstrap a new project"
 echo "    Test dir: $TEST_DIR/test-project"
 
 # Run bootstrap.
@@ -235,6 +259,8 @@ assert_contains "$PROJECT/AGENTS.md" "No band-aids"
 assert_contains "$PROJECT/AGENTS.md" "Authoring Guide"
 assert_contains "$PROJECT/AGENTS.md" "Codex and other AGENTS.md-native coding agents"
 assert_contains "$PROJECT/AGENTS.md" "Review Guide"
+
+phase "help flags + ecosystem profiles"
 
 # Help flags should print usage instead of bootstrapping a project named --help.
 if (cd "$TEST_DIR" && bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" --help) >"$TEST_DIR/new-project-help.txt" 2>&1; then
@@ -454,6 +480,8 @@ assert_contains "$PROJECT_NODE/setup.sh" 'install_go_devtools'
 assert_contains "$PROJECT_NODE/setup.sh" 'install_rust_devtools'
 assert_contains "$PROJECT_PYTHON/setup.sh" 'install_swift_devtools'
 
+phase "existing-dir + reviewer/CI/scaffold-tests opt-outs"
+
 # Bootstrap into an existing directory should back up touchstone-owned files before replacing them.
 mkdir -p "$PROJECT_EXISTING/principles" "$PROJECT_EXISTING/scripts"
 printf 'custom principle\n' > "$PROJECT_EXISTING/principles/engineering-principles.md"
@@ -667,6 +695,8 @@ bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_PROMOTE" --n
 printf '[project]\nname = "demo"\nversion = "0.0.0"\n' > "$PROJECT_SCAFFOLD_PROMOTE/pyproject.toml"
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_PROMOTE" --no-register --scaffold-tests >/dev/null
 assert_exists "$PROJECT_SCAFFOLD_PROMOTE/tests/test_smoke.py"
+
+phase "touchstone-init reconcile + setup.sh runtime probes"
 
 # touchstone init must not run a pre-existing project setup.sh after preserving it.
 mkdir -p "$PROJECT_INIT_EXISTING_SETUP"
@@ -1031,6 +1061,8 @@ cp "$TOUCHSTONE_ROOT/templates/setup.sh" "$RUST_PROJECT/setup.sh"
 (cd "$RUST_PROJECT" && PATH="$RUNNER_FAKE_BIN:$PATH" RUNNER_LOG="$RUNNER_LOG" TOUCHSTONE_SKIP_DEVTOOLS=1 bash setup.sh --deps-only) >/dev/null
 assert_contains "$RUNNER_LOG" 'cargo|.*/rust-runner|fetch'
 
+phase "hook installation propagation"
+
 # Bootstrap should install git hooks via pre-commit when pre-commit is available,
 # so a fresh repo is actually gated — not just configured.
 HOOKS_FAKE_BIN="$TEST_DIR/hooks-fake-bin"
@@ -1152,6 +1184,8 @@ if grep -q 'Setting up' "$TEST_DIR/reinit-setup-output.txt" 2>/dev/null; then
   echo "FAIL: init reconcile must not run setup.sh even if the file was backfilled" >&2
   ERRORS=$((ERRORS + 1))
 fi
+
+phase "touchstone doctor + sibling detection"
 
 # touchstone doctor --project must exit clean on a fully-armed repo.
 # Use the fake pre-commit so hooks install regardless of what's on the tester's real PATH.
@@ -1632,6 +1666,8 @@ if (cd "$PROJECT_PYTEST_EMPTY" && PATH="$PYTEST_FAKE_BIN:$PATH" bash scripts/tou
   ERRORS=$((ERRORS + 1))
 fi
 
+phase "wizard / non-interactive defaults / --yes"
+
 # ---------------------------------------------------------------------------
 # Doctrine 0002 — interactive wizard for `touchstone new`.
 # The wizard is additive: non-TTY invocations behave exactly as pre-R2 (modulo
@@ -1784,7 +1820,7 @@ rm -rf "$REGISTRY_SKIP_TMP"
 # --------------------------------------------------------------------------
 
 echo ""
-echo "==> R5.1/R5.2: --with-cortex --with-sentinel ordering + gitignore scope"
+phase "R5.1/R5.2 — --with-cortex --with-sentinel ordering + gitignore scope"
 
 PROJECT_R5="$TEST_DIR/test-project-r5"
 R5_STUBDIR="$(mktemp -d -t touchstone-r5-stubs.XXXXXX)"


### PR DESCRIPTION
## Linked Issues

Closes #162

Real cortex/sentinel run on every bootstrap call when YES_MODE=true
sets the wizard's defaults (Initialize Cortex? -> yes). With those
binaries on PATH, test-bootstrap.sh emitted 51 banner blocks, 81
sentinel mentions, and ~2055 lines of output across 77 default
bootstraps -- enough that the test looked stuck even when progressing.

Add tests/fixtures/{cortex,sentinel} as deterministic stand-ins that
mimic the externally observable contract (file scaffold, gitignore
edits, exit codes, sibling --version output) without paying the real
binaries' startup or model-detection cost. tests/test-bootstrap.sh
prepends tests/fixtures/ to PATH unless TOUCHSTONE_REAL_BOOTSTRAP=1,
so the fast tier exercises the contract without real-binary noise.

tests/slow-bootstrap.sh sets that env var and re-execs the same test
script -- the integration smoke path against the real binaries lives
under the existing slow tier, run before release-confidence checks.

Add a phase() helper that prints a wall-clock timestamp at each major
test phase (help/profiles, existing-dir/opt-outs, setup.sh, hooks,
doctor, wizard, R5). A long-running phase is now visibly progressing
instead of looking stuck.

Banner counts after this change: cortex 0, sentinel 0, lines ~950.
Wall clock barely moved (~13s saved); the bulk of remaining time is
pre-commit install across 77 bootstraps -- a separate, larger problem.

Closes #162

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
