### PR TITLE
test: stub Conductor doctor to cut fast-suite wall clock 6×

### DIFF
--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,10 +1,12 @@
 # tests/fixtures — stand-ins for Touchstone's fast test tier
 
-The files in this directory are **not** real Cortex or Sentinel binaries.
-They are deterministic stand-ins that mimic the externally observable
-contract of `cortex init` and `sentinel init` (file scaffold, gitignore
-edits, exit code, sibling-version output) without paying the real
-binaries' startup, banner, or model-detection costs.
+The files in this directory are **not** real Cortex, Sentinel, or
+Conductor binaries. They are deterministic stand-ins that mimic the
+externally observable contract of `cortex init`, `sentinel init`, and
+`conductor doctor --json` (file scaffold, gitignore edits, exit code,
+sibling-version output, configured-provider payload) without paying the
+real binaries' startup, banner, model-detection, or provider-probe
+costs.
 
 `tests/test-bootstrap.sh` prepends this directory to `PATH` so that
 every `command -v cortex` / `command -v sentinel` check inside
@@ -17,7 +19,7 @@ The slow tier (`tests/slow-bootstrap.sh`) sets
 `TOUCHSTONE_REAL_BOOTSTRAP=1`, which skips the `PATH` override and
 exercises the real installed binaries. That is the integration smoke
 path; it must be run before a release-confidence check whenever the
-contract between Touchstone and Cortex/Sentinel changes.
+contract between Touchstone and Cortex / Sentinel / Conductor changes.
 
 The narrower per-test inline stubs in `test-bootstrap.sh` (R5.1/R5.2,
 sibling-detection) override these fixtures by prepending an even-tighter

--- a/tests/fixtures/conductor
+++ b/tests/fixtures/conductor
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# tests/fixtures/conductor — deterministic Conductor stand-in for the
+# fast test tier. Real `conductor doctor --json` probes every configured
+# provider for readiness and takes ~5 s on this machine. The bootstrap
+# wizard runs that probe once per scaffold, so the test harness paid
+# 70 × 5 s = ~6 min wall-clock waiting on a probe whose result the test
+# does not actually exercise.
+#
+# This stub returns a configured-true payload that satisfies the
+# wizard's grep for `"configured": true`. The slow tier
+# (tests/slow-bootstrap.sh) sets TOUCHSTONE_REAL_BOOTSTRAP=1, which
+# skips this stub via the PATH override and exercises the real
+# conductor binary.
+#
+set -euo pipefail
+
+case "${1:-}" in
+  doctor)
+    if [ "${2:-}" = "--json" ]; then
+      cat <<'JSON'
+{
+  "version": "0.0.0-stub",
+  "providers": [
+    {"name": "stub", "configured": true, "ready": true}
+  ]
+}
+JSON
+    fi
+    exit 0
+    ;;
+  list|version|--version|-V|init|ask|call|exec|review|providers)
+    exit 0
+    ;;
+  "")
+    echo "stub-conductor: missing subcommand" >&2
+    exit 2
+    ;;
+  *)
+    exit 0
+    ;;
+esac

--- a/tests/slow-bootstrap.sh
+++ b/tests/slow-bootstrap.sh
@@ -25,6 +25,10 @@ if ! command -v sentinel >/dev/null 2>&1; then
   echo "ERROR: 'sentinel' is not on PATH; install it (brew install autumngarage/sentinel/sentinel) before running this slow probe." >&2
   exit 1
 fi
+if ! command -v conductor >/dev/null 2>&1; then
+  echo "ERROR: 'conductor' is not on PATH; install it (brew install autumngarage/conductor/conductor) before running this slow probe." >&2
+  exit 1
+fi
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 exec env TOUCHSTONE_REAL_BOOTSTRAP=1 bash "$DIR/test-bootstrap.sh" "$@"


### PR DESCRIPTION
## Linked Issues

Closes #167

Profiling a single bootstrap with bash -x and gap analysis pointed at
`conductor doctor --json` (bootstrap/new-project.sh:1264) as a 5.0s
blocking probe. The wizard runs it once per scaffold to decide whether
to print the "Conductor installed but no provider configured yet"
hint. tests/test-bootstrap.sh issues 70 default scaffolds, so the
test paid 70 × 5 s ≈ 5:50 of the 6:24 wall clock waiting on a probe
whose result it never asserts.

Add tests/fixtures/conductor as a deterministic stand-in matching the
cortex/sentinel pattern from #166. It returns a configured-true JSON
payload that satisfies the wizard's grep without spinning up
Conductor's provider router. The slow tier wrapper now also requires
the real conductor binary so integration coverage stays intact.

Measured impact:
  single bootstrap: 6.4s -> 1.0s (6.4×)
  test-bootstrap:   6:24 -> 1:04 (6×)
  full fast suite:  7:17 -> 2:00 (3.6×)

The original #167 body hypothesized pre-commit install (across 154
calls per run) as the culprit; a direct probe showed pre-commit
install at 0.09s, ruling it out. The actual bottleneck was a single
slow probe per bootstrap, not many small ones.

Closes #167

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
