### PR TITLE
fix: open-pr.sh rewrites mismatched upstream on first push

### DIFF
--- a/scripts/open-pr.sh
+++ b/scripts/open-pr.sh
@@ -276,12 +276,24 @@ if [ -n "$BASE_OVERRIDE" ] && [ "$AUTO_MERGE" = true ]; then
   echo "         or drop --base (bundle into one PR on $DEFAULT_BRANCH)." >&2
 fi
 
-# Push (set upstream on first push, plain push afterwards).
-if git rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1; then
+# Push. The "do I already have an upstream?" check is name-aware: a fresh
+# `git checkout -b <branch> origin/main` sets upstream to `origin/main`,
+# which makes `git push` (without `-u`) fail with "upstream does not match
+# the name of your current branch." Treat any upstream that doesn't point
+# at `origin/<current-branch>` the same as "no upstream yet" and rewrite
+# it on first push, so the workflow works regardless of how the branch
+# was created.
+EXISTING_UPSTREAM="$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)"
+EXPECTED_UPSTREAM="origin/$CURRENT_BRANCH"
+if [ -n "$EXISTING_UPSTREAM" ] && [ "$EXISTING_UPSTREAM" = "$EXPECTED_UPSTREAM" ]; then
   echo "==> Pushing $CURRENT_BRANCH ..."
   git push
 else
-  echo "==> Pushing $CURRENT_BRANCH (setting upstream) ..."
+  if [ -n "$EXISTING_UPSTREAM" ] && [ "$EXISTING_UPSTREAM" != "$EXPECTED_UPSTREAM" ]; then
+    echo "==> Existing upstream '$EXISTING_UPSTREAM' does not match '$EXPECTED_UPSTREAM'; resetting on first push." >&2
+  else
+    echo "==> Pushing $CURRENT_BRANCH (setting upstream) ..."
+  fi
   git push -u origin "$CURRENT_BRANCH"
 fi
 

--- a/tests/test-open-pr-upstream-mismatch.sh
+++ b/tests/test-open-pr-upstream-mismatch.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# tests/test-open-pr-upstream-mismatch.sh — Issue #169.
+#
+# `git checkout -b <branch> origin/main` traces the new branch's upstream
+# to `origin/main` (correct for catching up), but it means a later plain
+# `git push` fails with "upstream branch does not match the name of your
+# current branch." `scripts/open-pr.sh` used to detect "upstream exists"
+# and call `git push` (no -u), which hit that exact error.
+#
+# This test covers the fix: open-pr.sh detects that the upstream points
+# at the wrong remote ref and rewrites it via `git push -u origin
+# <branch>` on first push, so the workflow succeeds regardless of how
+# the branch was created.
+#
+set -euo pipefail
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_DIR="$(mktemp -d -t touchstone-test-open-pr-upstream.XXXXXX)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+REPO_DIR="$TEST_DIR/repo"
+REMOTE_DIR="$TEST_DIR/remote.git"
+SCRIPT_DIR="$TEST_DIR/scripts"
+FAKE_BIN="$TEST_DIR/bin"
+mkdir -p "$SCRIPT_DIR" "$FAKE_BIN"
+
+cp "$TOUCHSTONE_ROOT/scripts/open-pr.sh" "$SCRIPT_DIR/open-pr.sh"
+chmod +x "$SCRIPT_DIR/open-pr.sh"
+
+# Mock gh — open-pr.sh queries the default branch and creates the PR.
+cat > "$FAKE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$1 $2" in
+  "repo view") echo "main" ;;
+  "pr list") echo "" ;;
+  "pr create") echo "https://example.test/touchstone/pull/9999" ;;
+  "pr view") echo "2026-05-06T18:00:00Z" ;;
+  *) echo "unexpected gh args: $*" >&2; exit 1 ;;
+esac
+EOF
+chmod +x "$FAKE_BIN/gh"
+
+# Real bare remote + clone, so `git push -u` actually creates a branch.
+git init --bare "$REMOTE_DIR" >/dev/null 2>&1
+git clone "$REMOTE_DIR" "$REPO_DIR" >/dev/null 2>&1
+git -C "$REPO_DIR" switch -c main >/dev/null 2>&1
+git -C "$REPO_DIR" config user.name "Touchstone Test"
+git -C "$REPO_DIR" config user.email "touchstone@example.com"
+printf 'base\n' > "$REPO_DIR/file.txt"
+git -C "$REPO_DIR" add file.txt
+git -C "$REPO_DIR" commit -m "base" >/dev/null 2>&1
+git -C "$REPO_DIR" push -u origin main >/dev/null 2>&1
+
+# Reproduce the failure scenario: branch off origin/main with the
+# canonical "branch from remote ref" form. Git points the new branch's
+# upstream at origin/main, which is what triggers issue #169 on push.
+git -C "$REPO_DIR" checkout -b chore/upstream-mismatch-test origin/main >/dev/null 2>&1
+printf 'change\n' >> "$REPO_DIR/file.txt"
+git -C "$REPO_DIR" add file.txt
+git -C "$REPO_DIR" commit -m "test change" >/dev/null 2>&1
+
+# Sanity check: confirm the precondition. Without the fix, a plain
+# `git push` from this state fails with the "upstream does not match"
+# message. We don't need to assert that — the open-pr.sh run below
+# would surface it as a fatal error if we hadn't fixed it.
+UPSTREAM="$(git -C "$REPO_DIR" rev-parse --abbrev-ref --symbolic-full-name '@{u}')"
+if [ "$UPSTREAM" != "origin/main" ]; then
+  echo "FAIL: precondition: expected upstream 'origin/main', got '$UPSTREAM'" >&2
+  exit 1
+fi
+
+echo "==> Running open-pr.sh against a branch whose upstream points at origin/main"
+OUT="$TEST_DIR/run.out"
+RC=0
+(
+  cd "$REPO_DIR"
+  PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    bash "$SCRIPT_DIR/open-pr.sh" "test PR" 2>&1
+) > "$OUT" || RC=$?
+
+if [ "$RC" -ne 0 ]; then
+  echo "FAIL: open-pr.sh exited $RC; expected 0" >&2
+  cat "$OUT" >&2
+  exit 1
+fi
+
+if ! grep -q "Existing upstream 'origin/main' does not match 'origin/chore/upstream-mismatch-test'" "$OUT"; then
+  echo "FAIL: open-pr.sh did not emit the upstream-rewrite warning" >&2
+  cat "$OUT" >&2
+  exit 1
+fi
+
+# After the run, the branch must track its own remote ref, not main.
+NEW_UPSTREAM="$(git -C "$REPO_DIR" rev-parse --abbrev-ref --symbolic-full-name '@{u}')"
+if [ "$NEW_UPSTREAM" != "origin/chore/upstream-mismatch-test" ]; then
+  echo "FAIL: upstream after push should be 'origin/chore/upstream-mismatch-test', got '$NEW_UPSTREAM'" >&2
+  exit 1
+fi
+
+# And the remote should actually have the branch.
+if ! git -C "$REPO_DIR" ls-remote --heads origin chore/upstream-mismatch-test \
+    | grep -q chore/upstream-mismatch-test; then
+  echo "FAIL: remote does not have the expected branch" >&2
+  exit 1
+fi
+
+echo "==> PASS: open-pr.sh rewrites mismatched upstream on first push (#169)"


### PR DESCRIPTION
## Linked Issues

Closes #169

`git checkout -b <branch> origin/main` traces the new branch's upstream
to `origin/main` (correct for catching up from the remote default),
which makes a later plain `git push` fail with "upstream branch does
not match the name of your current branch." open-pr.sh's first-push
detection only checked whether *any* upstream existed, so it picked
the plain-push path and the operator had to manually unset/reset
upstream before retrying.

This commit makes the check name-aware: if the recorded upstream does
not equal `origin/<current-branch>`, treat it the same as "no upstream
yet" and call `git push -u origin <branch>` so the upstream pointer is
rewritten on first push. A visible warning prints when a rewrite
happens, so the operator can see what changed.

Test added: tests/test-open-pr-upstream-mismatch.sh runs the full
push flow against a real bare remote with a branch checked out via
the canonical `git checkout -b <name> origin/main` form, asserts
the rewrite warning fires and the resulting upstream points at
`origin/<name>`.

Closes #169

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
