### PR TITLE
fix: persist squash-merge metadata so cleanup-branches handles main moving on

### DIFF
--- a/scripts/cleanup-branches.sh
+++ b/scripts/cleanup-branches.sh
@@ -91,6 +91,53 @@ is_worktree_branch() {
   return 1
 }
 
+# Locate scripts/merge-pr.sh's squash-map. The map records each squash-merge
+# at the moment it happens, capturing branch tip + squash commit. Reading is
+# best-effort and offline: any I/O error or unparseable line is treated as
+# "no record" so a corrupt map never causes a false-positive deletion. The
+# tree-equivalence path (is_fully_applied) is the safety net beneath this.
+SQUASH_MAP_PATH="$(git rev-parse --git-path touchstone/squash-map.jsonl 2>/dev/null || echo "")"
+
+# Returns 0 if a record in the squash-map names $branch AND its recorded
+# branch_oid matches the branch's current tip. The OID equality is the
+# load-bearing invariant: it ensures we only treat a branch as "the same
+# code that merged" — if commits landed on the local branch after the
+# squash, the OIDs differ and we fall through to is_fully_applied (which
+# will correctly tell us those new commits are not yet on $upstream).
+#
+# Any failure to read the map returns 1 (no record); errors are surfaced
+# to stderr but never fatal — same fail-soft contract as the rest of the
+# cleanup classifier.
+is_recorded_squash() {
+  local branch="$1"
+  local branch_oid="$2"
+
+  [ -n "$SQUASH_MAP_PATH" ] || return 1
+  [ -f "$SQUASH_MAP_PATH" ] || return 1
+  [ -r "$SQUASH_MAP_PATH" ] || {
+    echo "WARNING: squash-map exists but is not readable: $SQUASH_MAP_PATH" >&2
+    return 1
+  }
+
+  # Grep for "branch":"<exact name>" — the JSONL writer in merge-pr.sh
+  # refuses to write fields containing quote/backslash, so a literal-string
+  # match is sufficient and avoids pulling in a JSON parser. Filter to
+  # records that also carry the matching branch_oid; if any match, classify
+  # as recorded squash.
+  local line
+  while IFS= read -r line; do
+    case "$line" in
+      *"\"branch\":\"$branch\""*"\"branch_oid\":\"$branch_oid\""*)
+        return 0
+        ;;
+      *"\"branch_oid\":\"$branch_oid\""*"\"branch\":\"$branch\""*)
+        return 0
+        ;;
+    esac
+  done < "$SQUASH_MAP_PATH" 2>/dev/null
+  return 1
+}
+
 # Returns 0 if every file the branch changed relative to the merge-base has
 # the branch's content on $upstream right now. This uniformly detects
 # squash-merges, rebase-merges, and cherry-picks (without caring how the
@@ -130,8 +177,11 @@ UNMERGED_LOCAL=()
 while IFS= read -r branch; do
   [ -z "$branch" ] && continue
   is_protected "$branch" || [ "$branch" = "$CURRENT_BRANCH" ] || is_worktree_branch "$branch" && continue
+  branch_oid="$(git rev-parse --verify --quiet "refs/heads/$branch" 2>/dev/null || echo "")"
   if git merge-base --is-ancestor "$branch" "$DEFAULT_REF" 2>/dev/null; then
     MERGED_LOCAL+=("$branch")
+  elif [ -n "$branch_oid" ] && is_recorded_squash "$branch" "$branch_oid"; then
+    SQUASH_MERGED_LOCAL+=("$branch")
   elif is_fully_applied "$DEFAULT_REF" "$branch"; then
     SQUASH_MERGED_LOCAL+=("$branch")
   else
@@ -217,7 +267,10 @@ if [ "$REMOTE_TOO" -eq 1 ] && [ "$REMOTE_SKIPPED" -eq 0 ]; then
       REMOTE_HAS_PR+=("$remote_branch")
       continue
     fi
+    remote_oid="$(git rev-parse --verify --quiet "refs/remotes/origin/$remote_branch" 2>/dev/null || echo "")"
     if git merge-base --is-ancestor "origin/$remote_branch" "$DEFAULT_REF" 2>/dev/null; then
+      REMOTE_DELETABLE+=("$remote_branch")
+    elif [ -n "$remote_oid" ] && is_recorded_squash "$remote_branch" "$remote_oid"; then
       REMOTE_DELETABLE+=("$remote_branch")
     elif is_fully_applied "$DEFAULT_REF" "origin/$remote_branch"; then
       REMOTE_DELETABLE+=("$remote_branch")

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -287,6 +287,73 @@ print_bypass_banner() {
 EOF
 }
 
+# Append a squash-merge record to .git/touchstone/squash-map.jsonl so
+# scripts/cleanup-branches.sh can recognize a branch as squash-merged even
+# after $DEFAULT_BRANCH evolves past it (later commits on the same files
+# break the tree-equivalence heuristic).
+#
+# The record carries:
+#   - branch       : the head ref name of the merged PR
+#   - pr           : PR number
+#   - branch_oid   : tip of the branch at merge time (so cleanup can detect
+#                    "branch picked up new commits after the squash" and
+#                    fall through to the existing tree check)
+#   - squash_commit: the squash commit on the default branch (best effort —
+#                    empty string if gh cannot resolve it yet)
+#   - ts           : UTC ISO timestamp
+#
+# I/O is best-effort. A failure to write must not fail the merge: the merge
+# already succeeded server-side, and the squash-map is an optimization for
+# later cleanup, not a correctness boundary. Any failure is logged to stderr.
+record_squash_merge() {
+  local branch="$1"
+  local pr="$2"
+  local branch_oid="$3"
+  local squash_commit="${4:-}"
+  local map_path map_dir ts
+
+  if [ -z "$branch" ] || [ -z "$pr" ] || [ -z "$branch_oid" ]; then
+    echo "WARNING: record_squash_merge: missing branch/pr/oid, skipping squash-map write." >&2
+    return 0
+  fi
+
+  if ! map_path="$(git rev-parse --git-path touchstone/squash-map.jsonl 2>/dev/null)" \
+      || [ -z "$map_path" ]; then
+    echo "WARNING: record_squash_merge: could not resolve squash-map path; skipping." >&2
+    return 0
+  fi
+  map_dir="$(dirname "$map_path")"
+  if ! mkdir -p "$map_dir" 2>/dev/null; then
+    echo "WARNING: record_squash_merge: could not create $map_dir; skipping squash-map write." >&2
+    return 0
+  fi
+
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")"
+
+  # JSON-encode each string field. Bash can produce safe JSON for these
+  # tightly constrained values (branch names exclude " and \, OIDs are hex,
+  # ts is ISO-8601) by simply quoting — no escaping needed in practice.
+  # Defense in depth: refuse to record if any field contains a quote or
+  # backslash, rather than emit malformed JSON.
+  local field
+  for field in "$branch" "$pr" "$branch_oid" "$squash_commit" "$ts"; do
+    case "$field" in
+      *\"*|*\\*)
+        echo "WARNING: record_squash_merge: field contains quote/backslash, skipping squash-map write." >&2
+        return 0
+        ;;
+    esac
+  done
+
+  local line
+  line="{\"branch\":\"$branch\",\"pr\":\"$pr\",\"branch_oid\":\"$branch_oid\",\"squash_commit\":\"$squash_commit\",\"ts\":\"$ts\"}"
+  if ! printf '%s\n' "$line" >> "$map_path" 2>/dev/null; then
+    echo "WARNING: record_squash_merge: could not append to $map_path; skipping squash-map write." >&2
+    return 0
+  fi
+  echo "==> Recorded squash-merge metadata for '$branch' -> $map_path"
+}
+
 record_bypass_comment() {
   gh pr comment "$PR_NUMBER" --body "Reviewer bypassed via \`--bypass-with-disclosure\`. Reason: $BYPASS_REASON"
 }
@@ -505,6 +572,11 @@ if [ "$gh_merge_exit" -ne 0 ]; then
     exit "$gh_merge_exit"
   fi
 fi
+
+# Record squash-merge metadata for cleanup-branches.sh. The merge has
+# succeeded on GitHub; this is best-effort persistence for later cleanup.
+SQUASH_COMMIT_OID="$(gh pr view "$PR_NUMBER" --json mergeCommit --jq '.mergeCommit.oid' 2>/dev/null || echo "")"
+record_squash_merge "$PR_HEAD_BRANCH" "$PR_NUMBER" "$REVIEWED_HEAD_OID" "$SQUASH_COMMIT_OID"
 
 # 5. Sync local default branch.
 sync_default_branch_after_merge

--- a/tests/test-cleanup-branches-squash-map.sh
+++ b/tests/test-cleanup-branches-squash-map.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+#
+# tests/test-cleanup-branches-squash-map.sh — regression test for issue #165.
+#
+# Scenario: a branch's PR was squash-merged some time ago. Since then, main
+# picked up another commit that touched the same file. The branch's content
+# is no longer byte-identical to main on every file it changed, so the
+# tree-equivalence heuristic (is_fully_applied) flips to "unique commits"
+# and the branch is stuck in the "needs human decision" bucket forever.
+#
+# The fix: scripts/merge-pr.sh records a squash-map entry at merge time
+# capturing the branch tip. scripts/cleanup-branches.sh consults the map
+# first, classifying as squash-merged when (branch, oid) match — letting
+# the existing `is_fully_applied` path remain the safety net for branches
+# whose tip moved past the recorded oid (no false positives).
+#
+# Two cases:
+#   (1) Branch with a squash-map record AND main moved on — must be
+#       force-deleted (the regression).
+#   (2) Branch with a squash-map record but the local tip has moved past
+#       the recorded oid — must NOT be force-deleted via the map; falls
+#       through to is_fully_applied, which correctly preserves it.
+#
+set -euo pipefail
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_DIR="$(mktemp -d -t touchstone-test-cleanup-squash-map.XXXXXX)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+echo "==> Test: cleanup-branches.sh consults squash-map for squash-merged-then-moved-past branches"
+
+FAKE_BIN="$TEST_DIR/bin"
+mkdir -p "$FAKE_BIN"
+
+cat > "$FAKE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  "repo view --json defaultBranchRef --jq .defaultBranchRef.name")
+    echo "main"
+    ;;
+  *)
+    echo "unexpected gh args: $*" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "$FAKE_BIN/gh"
+
+REMOTE="$TEST_DIR/remote.git"
+REPO="$TEST_DIR/repo"
+
+git init -q --bare -b main "$REMOTE"
+git init -q -b main "$REPO"
+cd "$REPO"
+git config user.email "test@example.com"
+git config user.name "Test"
+git remote add origin "$REMOTE"
+
+echo "A" > shared.txt
+git add shared.txt
+git commit -qm "initial"
+git push -q -u origin main
+
+# (1) Squash-merged branch whose changes were applied to main, then main
+# evolved past it: another commit on main edits the SAME file. The branch's
+# content is no longer byte-identical to main, so is_fully_applied returns
+# false. Without the squash-map record, this branch would land in the
+# "needs human decision" bucket and stay there forever — the issue.
+git checkout -q -b feat/squash-then-moved-past
+echo "BRANCH_CONTENT" > shared.txt
+git add shared.txt
+git commit -qm "feat: change shared.txt"
+RECORDED_OID="$(git rev-parse HEAD)"
+
+git checkout -q main
+git merge --squash feat/squash-then-moved-past >/dev/null
+git commit -qm "feat: change shared.txt (#100)"
+
+# Main moves on — another commit edits the same file. This is what breaks
+# the tree-equivalence check on feat/squash-then-moved-past.
+echo "EVOLVED_PAST_BRANCH" > shared.txt
+git add shared.txt
+git commit -qm "chore: further edits"
+
+# (2) Branch where the squash-map record exists but the local branch picked
+# up new commits AFTER the squash. The recorded oid is stale; the OID
+# equality check must reject the map record and let is_fully_applied take
+# over (which will correctly classify this branch as not-yet-applied).
+git checkout -q -b feat/squash-then-new-commits-locally
+echo "INITIAL_WORK" > new_file.txt
+git add new_file.txt
+git commit -qm "feat: initial work"
+STALE_RECORDED_OID="$(git rev-parse HEAD)"
+
+git checkout -q main
+git merge --squash feat/squash-then-new-commits-locally >/dev/null
+git commit -qm "feat: initial work (#101)"
+
+# Main moves on, breaking tree equivalence for this branch too.
+echo "DRIFT" > new_file.txt
+git add new_file.txt
+git commit -qm "chore: drift"
+
+git checkout -q feat/squash-then-new-commits-locally
+echo "POST_MERGE_LOCAL_WORK" > local_only.txt
+git add local_only.txt
+git commit -qm "feat: post-merge local work (not yet on main)"
+
+git push -q origin main
+
+# (3) Control: branch with no squash-map record and genuinely unique work
+# — must survive both classifiers and land in "Has unique commits".
+git checkout -q main
+git checkout -q -b feat/keep-me-unrelated
+echo "UNIQUE" > unique.txt
+git add unique.txt
+git commit -qm "feat: unique work no record"
+
+git checkout -q main
+
+# Build the synthetic squash-map at the right git-path. Use git rev-parse
+# from the repo so worktree-aware path resolution matches what the script
+# does at runtime.
+MAP_PATH="$(git rev-parse --git-path touchstone/squash-map.jsonl)"
+mkdir -p "$(dirname "$MAP_PATH")"
+cat > "$MAP_PATH" <<EOF
+{"branch":"feat/squash-then-moved-past","pr":"100","branch_oid":"$RECORDED_OID","squash_commit":"deadbeef","ts":"2026-05-06T00:00:00Z"}
+{"branch":"feat/squash-then-new-commits-locally","pr":"101","branch_oid":"$STALE_RECORDED_OID","squash_commit":"deadbee2","ts":"2026-05-06T00:01:00Z"}
+EOF
+
+OUTPUT="$TEST_DIR/output.txt"
+PATH="$FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/scripts/cleanup-branches.sh" --execute >"$OUTPUT" 2>&1
+
+fail() {
+  echo "FAIL: $1" >&2
+  echo "---- script output ----" >&2
+  cat "$OUTPUT" >&2
+  echo "---- squash-map ----" >&2
+  cat "$MAP_PATH" >&2 || true
+  exit 1
+}
+
+# (1) Must be deleted via the squash-map path — this is the regression.
+if git rev-parse --verify --quiet refs/heads/feat/squash-then-moved-past >/dev/null; then
+  fail "feat/squash-then-moved-past should have been force-deleted via squash-map"
+fi
+if ! grep -q "force-deleted local (squash-merged): feat/squash-then-moved-past" "$OUTPUT"; then
+  fail "execute log should report force-deletion of feat/squash-then-moved-past"
+fi
+
+# (2) Must be preserved — the local branch tip moved past the recorded oid,
+# so the squash-map record does not apply, and is_fully_applied correctly
+# refuses (the post-merge local commit is not on main).
+if ! git rev-parse --verify --quiet refs/heads/feat/squash-then-new-commits-locally >/dev/null; then
+  fail "feat/squash-then-new-commits-locally should NOT have been deleted (tip moved past recorded oid)"
+fi
+if grep -q "force-deleted local (squash-merged): feat/squash-then-new-commits-locally" "$OUTPUT"; then
+  fail "feat/squash-then-new-commits-locally was incorrectly classified as squash-merged"
+fi
+
+# (3) Must be preserved as "Has unique commits".
+if ! git rev-parse --verify --quiet refs/heads/feat/keep-me-unrelated >/dev/null; then
+  fail "feat/keep-me-unrelated should have been preserved"
+fi
+if ! grep -q "Has unique commits" "$OUTPUT"; then
+  fail "output should still classify unique-work branches under 'Has unique commits'"
+fi
+
+# Negative tests against the map reader: a missing map and a corrupt map
+# must both be treated as "no record" without breaking the run.
+echo "==> Sub-test: missing squash-map is fail-soft"
+rm -f "$MAP_PATH"
+git checkout -q -b feat/no-map-still-classified
+echo "X" > x.txt
+git add x.txt
+git commit -qm "feat: x"
+git checkout -q main
+git merge --squash feat/no-map-still-classified >/dev/null
+git commit -qm "feat: x (#102)"
+git push -q origin main
+
+OUT2="$TEST_DIR/output-no-map.txt"
+PATH="$FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/scripts/cleanup-branches.sh" --execute >"$OUT2" 2>&1 \
+  || { echo "FAIL: cleanup must not fail when squash-map is missing"; cat "$OUT2" >&2; exit 1; }
+# This branch should still be classified by the existing tree-equivalence
+# fallback (tree on main matches branch's changed files since main hasn't
+# moved past it on this file).
+if git rev-parse --verify --quiet refs/heads/feat/no-map-still-classified >/dev/null; then
+  fail "feat/no-map-still-classified should be force-deleted by the tree-equivalence fallback"
+fi
+
+echo "==> Sub-test: corrupt squash-map is fail-soft (no records)"
+mkdir -p "$(dirname "$MAP_PATH")"
+printf '{not valid json at all\nsecond garbage line\n' > "$MAP_PATH"
+git checkout -q main
+git checkout -q -b feat/corrupt-map-leaves-unique
+echo "Y" > y_unique.txt
+git add y_unique.txt
+git commit -qm "feat: y (still has unique work)"
+OUT3="$TEST_DIR/output-corrupt-map.txt"
+git checkout -q main
+PATH="$FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/scripts/cleanup-branches.sh" --execute >"$OUT3" 2>&1 \
+  || { echo "FAIL: cleanup must not fail on corrupt squash-map"; cat "$OUT3" >&2; exit 1; }
+if ! git rev-parse --verify --quiet refs/heads/feat/corrupt-map-leaves-unique >/dev/null; then
+  fail "feat/corrupt-map-leaves-unique should NOT be deleted; corrupt map must yield no records"
+fi
+
+echo "==> PASS: squash-map record force-deletes squash-merged-then-moved-past;"
+echo "         stale-oid records fall through to tree check (no false positive);"
+echo "         missing map and corrupt map are fail-soft"


### PR DESCRIPTION
## Linked Issues

Closes #165

scripts/cleanup-branches.sh classifies squash-merged branches by tree
equivalence: every file the branch changed must match the default
branch's current tree. That heuristic flips to "needs human decision"
the moment any later commit on main edits the same file, even though
the branch's content was applied long ago.

merge-pr.sh now records each squash-merge in
.git/touchstone/squash-map.jsonl (branch, pr, branch_oid at merge time,
squash commit, ts). cleanup-branches.sh consults the map first: a
record matches only when both the branch name and the recorded
branch_oid equal the current branch tip. If the local branch has
picked up new commits past the recorded oid, the OID equality fails
and the existing tree-equivalence path runs unchanged — preserving the
add-then-revert and rename-half guarantees from the existing test.

The state lives in .git/, never the working tree. The reader is
fail-soft: a missing, unreadable, or corrupt JSONL file yields no
records (no false-positive deletions). The writer in merge-pr.sh is
also fail-soft: a write failure logs to stderr but never fails the
merge that already succeeded server-side.

The squash_commit field is best-effort (gh pr view --json mergeCommit
may be empty during some race windows); it is recorded for forensic
value but not consumed by cleanup-branches.sh.

tests/test-cleanup-branches-squash-map.sh is the regression test:
fails on the old code (the squash-then-moved-past branch lands in
"unique commits"), passes on the new code (force-deleted via the
map). It also covers the stale-oid case (map record exists but local
tip moved past — must not delete) and fail-soft behavior on missing
and corrupt maps.

Closes #165

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
