### PR TITLE
fix: find_python_bin walks worktree to parent venv, no system fallback

### DIFF
--- a/scripts/run-pytest-in-venv.sh
+++ b/scripts/run-pytest-in-venv.sh
@@ -7,11 +7,25 @@
 #
 set -euo pipefail
 
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-cd "$REPO_ROOT"
+# tests/test-find-python-bin.sh sources this helper for in-process testing.
+# In source-only mode, REPO_ROOT is fixed by the test fixture rather than
+# resolved via git.
+if [ "${RUN_PYTEST_IN_VENV_SOURCE_ONLY:-0}" = "1" ]; then
+  REPO_ROOT="${RUN_PYTEST_IN_VENV_TEST_REPO_ROOT:-$(pwd)}"
+else
+  REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  cd "$REPO_ROOT"
+fi
+
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
 
 find_python() {
-  local candidate
+  local candidate cwd parent_root parent_python
 
   if [ -n "${PYTEST_PYTHON:-}" ]; then
     if command -v "$PYTEST_PYTHON" >/dev/null 2>&1; then
@@ -30,11 +44,80 @@ find_python() {
     fi
   done
 
-  echo "ERROR: no project virtualenv found for pytest." >&2
-  echo "       Expected .venv/bin/python or agent/.venv/bin/python." >&2
-  echo "       Run: bash setup.sh" >&2
+  cwd="$(pwd)"
+  if parent_root="$(find_worktree_parent_root "$cwd")"; then
+    parent_python="$parent_root/.venv/bin/python"
+    if [ -x "$parent_python" ]; then
+      printf '%s\n' "$parent_python"
+      return 0
+    fi
+  fi
+
+  echo "ERROR: no project virtualenv found." >&2
+  echo "       Tried: $cwd/.venv/bin/python (this checkout)" >&2
+  if [ -n "${parent_root:-}" ]; then
+    echo "       Tried: $parent_root/.venv/bin/python (worktree parent)" >&2
+  fi
+  echo "       Run \`bash setup.sh\` in this checkout, OR push from the" >&2
+  echo "       parent checkout that has the venv set up." >&2
   return 1
 }
+
+# Returns the absolute path of the parent repo's worktree root when $1 is
+# a worktree checkout (i.e. $1/.git is a regular file containing a
+# `gitdir:` pointer). Returns 1 when $1 is a normal checkout or when the
+# worktree metadata is malformed.
+find_worktree_parent_root() {
+  local checkout_root="$1" git_file gitdir gitdir_path search_dir
+
+  git_file="$checkout_root/.git"
+  if [ ! -f "$git_file" ]; then
+    return 1
+  fi
+  if [ ! -r "$git_file" ]; then
+    echo "       Worktree check failed: cannot read $git_file" >&2
+    return 1
+  fi
+
+  IFS= read -r gitdir < "$git_file" || {
+    echo "       Worktree check failed: cannot read gitdir from $git_file" >&2
+    return 1
+  }
+  case "$gitdir" in
+    gitdir:*) gitdir="${gitdir#gitdir:}" ;;
+    *) return 1 ;;
+  esac
+  gitdir="$(trim "$gitdir")"
+  if [ -z "$gitdir" ]; then
+    echo "       Worktree check failed: empty gitdir in $git_file" >&2
+    return 1
+  fi
+
+  case "$gitdir" in
+    /*) gitdir_path="$gitdir" ;;
+    *) gitdir_path="$checkout_root/$gitdir" ;;
+  esac
+  if [ ! -d "$gitdir_path" ]; then
+    echo "       Worktree check failed: gitdir does not exist: $gitdir_path" >&2
+    return 1
+  fi
+
+  search_dir="$(cd "$(dirname "$gitdir_path")" && pwd)"
+  while [ "$search_dir" != "/" ]; do
+    if [ "$(basename "$search_dir")" = ".git" ]; then
+      dirname "$search_dir"
+      return 0
+    fi
+    search_dir="$(dirname "$search_dir")"
+  done
+
+  echo "       Worktree check failed: no parent .git directory above $gitdir_path" >&2
+  return 1
+}
+
+if [ "${RUN_PYTEST_IN_VENV_SOURCE_ONLY:-0}" = "1" ]; then
+  return 0
+fi
 
 PYTHON_BIN="$(find_python)"
 exec "$PYTHON_BIN" -m pytest "$@"

--- a/scripts/touchstone-run.sh
+++ b/scripts/touchstone-run.sh
@@ -14,8 +14,17 @@ set -euo pipefail
 
 ACTION="${1:-validate}"
 
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-cd "$REPO_ROOT"
+# tests/test-find-python-bin.sh sources this script with
+# TOUCHSTONE_RUN_SOURCE_ONLY=1 to call helpers directly without running the
+# action dispatcher at the bottom. Tests pass TOUCHSTONE_RUN_TEST_REPO_ROOT
+# to fix REPO_ROOT explicitly so they can construct fixture filesystems
+# without needing a real git repo.
+if [ "${TOUCHSTONE_RUN_SOURCE_ONLY:-0}" = "1" ]; then
+  REPO_ROOT="${TOUCHSTONE_RUN_TEST_REPO_ROOT:-$(pwd)}"
+else
+  REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  cd "$REPO_ROOT"
+fi
 
 CONFIG_FILE="${TOUCHSTONE_CONFIG_FILE:-.touchstone-config}"
 
@@ -194,7 +203,17 @@ run_node_script() {
 }
 
 find_python_bin() {
-  local candidate
+  local candidate cwd parent_root parent_python
+
+  # Operator override wins over everything else.
+  if [ -n "${PYTEST_PYTHON:-}" ]; then
+    if command -v "$PYTEST_PYTHON" >/dev/null 2>&1; then
+      command -v "$PYTEST_PYTHON"
+      return 0
+    fi
+    echo "ERROR: PYTEST_PYTHON is set but not executable: $PYTEST_PYTHON" >&2
+    return 1
+  fi
 
   for candidate in ".venv/bin/python" "agent/.venv/bin/python"; do
     if [ -x "$candidate" ]; then
@@ -203,17 +222,90 @@ find_python_bin() {
     fi
   done
 
-  if command -v python3 >/dev/null 2>&1; then
-    command -v python3
-    return 0
-  fi
-  if command -v python >/dev/null 2>&1; then
-    command -v python
-    return 0
+  # Worktree fallback: when the current checkout is a worktree (.git is a
+  # file, not a directory), the venv lives in the parent repo. Resolve to
+  # the parent's .venv/bin/python — pinned deps are identical across
+  # worktrees, so the parent's interpreter is the right answer.
+  cwd="$(pwd)"
+  if parent_root="$(find_worktree_parent_root "$cwd")"; then
+    parent_python="$parent_root/.venv/bin/python"
+    if [ -x "$parent_python" ]; then
+      printf '%s\n' "$parent_python"
+      return 0
+    fi
   fi
 
+  # No silent fallback to system python3: the project's pinned deps live
+  # in a venv. Running the test suite against a system interpreter would
+  # produce confusing ModuleNotFoundError noise that the operator can't
+  # diagnose from the failure alone (#171).
+  echo "ERROR: no project virtualenv found." >&2
+  echo "       Tried: $cwd/.venv/bin/python (this checkout)" >&2
+  if [ -n "${parent_root:-}" ]; then
+    echo "       Tried: $parent_root/.venv/bin/python (worktree parent)" >&2
+  fi
+  echo "       Run \`bash setup.sh\` in this checkout, OR push from the" >&2
+  echo "       parent checkout that has the venv set up." >&2
   return 1
 }
+
+# Returns the absolute path of the parent repo's worktree root when $1 is
+# a worktree checkout (i.e. $1/.git is a regular file containing a
+# `gitdir:` pointer). Returns 1 when $1 is a normal checkout or when the
+# worktree metadata is malformed.
+find_worktree_parent_root() {
+  local checkout_root="$1" git_file gitdir gitdir_path search_dir
+
+  git_file="$checkout_root/.git"
+  if [ ! -f "$git_file" ]; then
+    return 1
+  fi
+  if [ ! -r "$git_file" ]; then
+    echo "       Worktree check failed: cannot read $git_file" >&2
+    return 1
+  fi
+
+  IFS= read -r gitdir < "$git_file" || {
+    echo "       Worktree check failed: cannot read gitdir from $git_file" >&2
+    return 1
+  }
+  case "$gitdir" in
+    gitdir:*) gitdir="${gitdir#gitdir:}" ;;
+    *) return 1 ;;
+  esac
+  gitdir="$(trim "$gitdir")"
+  if [ -z "$gitdir" ]; then
+    echo "       Worktree check failed: empty gitdir in $git_file" >&2
+    return 1
+  fi
+
+  case "$gitdir" in
+    /*) gitdir_path="$gitdir" ;;
+    *) gitdir_path="$checkout_root/$gitdir" ;;
+  esac
+  if [ ! -d "$gitdir_path" ]; then
+    echo "       Worktree check failed: gitdir does not exist: $gitdir_path" >&2
+    return 1
+  fi
+
+  search_dir="$(cd "$(dirname "$gitdir_path")" && pwd)"
+  while [ "$search_dir" != "/" ]; do
+    if [ "$(basename "$search_dir")" = ".git" ]; then
+      dirname "$search_dir"
+      return 0
+    fi
+    search_dir="$(dirname "$search_dir")"
+  done
+
+  echo "       Worktree check failed: no parent .git directory above $gitdir_path" >&2
+  return 1
+}
+
+# Allow tests to source the script just for its helpers without invoking
+# the action dispatcher below.
+if [ "${TOUCHSTONE_RUN_SOURCE_ONLY:-0}" = "1" ]; then
+  return 0
+fi
 
 run_node_action() {
   local action="$1"

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -725,7 +725,8 @@ if (cd "$PYTEST_WRAPPER_PROJECT" && "$TOUCHSTONE_ROOT/scripts/run-pytest-in-venv
   echo "FAIL: expected run-pytest-in-venv.sh to fail without a venv" >&2
   ERRORS=$((ERRORS + 1))
 else
-  assert_contains "$TEST_DIR/pytest-missing-venv.txt" 'Run: bash setup.sh'
+  assert_contains "$TEST_DIR/pytest-missing-venv.txt" 'no project virtualenv found'
+  assert_contains "$TEST_DIR/pytest-missing-venv.txt" 'bash setup.sh'
 fi
 
 mkdir -p "$PYTEST_WRAPPER_PROJECT/.venv/bin"
@@ -1138,7 +1139,7 @@ chmod +x "$PYTEST_FAKE_BIN/python3"
 mkdir -p "$PROJECT_PYTEST_EMPTY/scripts"
 cp "$TOUCHSTONE_ROOT/scripts/touchstone-run.sh" "$PROJECT_PYTEST_EMPTY/scripts/touchstone-run.sh"
 printf 'project_type=python\n' > "$PROJECT_PYTEST_EMPTY/.touchstone-config"
-if (cd "$PROJECT_PYTEST_EMPTY" && PATH="$PYTEST_FAKE_BIN:$PATH" bash scripts/touchstone-run.sh test) >"$TEST_DIR/pytest-empty-output.txt" 2>&1; then
+if (cd "$PROJECT_PYTEST_EMPTY" && PATH="$PYTEST_FAKE_BIN:$PATH" PYTEST_PYTHON=python3 bash scripts/touchstone-run.sh test) >"$TEST_DIR/pytest-empty-output.txt" 2>&1; then
   assert_contains "$TEST_DIR/pytest-empty-output.txt" 'pytest found no tests; skipped'
 else
   echo "FAIL: pytest exit 5 must be a graceful skip, not a failure" >&2
@@ -1652,6 +1653,10 @@ else
 fi
 
 # Any non-5 pytest failure must still propagate — we haven't accidentally swallowed real errors.
+# After #171, find_python_bin() no longer silently falls back to system
+# python3, so the fixture has to use PYTEST_PYTHON to point at the fake
+# interpreter explicitly. The intent of the assertion is unchanged: a
+# real (exit 1) test failure must propagate, not be swallowed.
 cat > "$PYTEST_FAKE_BIN/python3" <<'FAKEPY'
 #!/usr/bin/env bash
 if [ "$1" = "-m" ] && [ "$2" = "pytest" ]; then
@@ -1661,7 +1666,7 @@ fi
 exit 0
 FAKEPY
 chmod +x "$PYTEST_FAKE_BIN/python3"
-if (cd "$PROJECT_PYTEST_EMPTY" && PATH="$PYTEST_FAKE_BIN:$PATH" bash scripts/touchstone-run.sh test) >"$TEST_DIR/pytest-fail-output.txt" 2>&1; then
+if (cd "$PROJECT_PYTEST_EMPTY" && PATH="$PYTEST_FAKE_BIN:$PATH" PYTEST_PYTHON=python3 bash scripts/touchstone-run.sh test) >"$TEST_DIR/pytest-fail-output.txt" 2>&1; then
   echo "FAIL: pytest exit 1 (real failure) must still propagate as nonzero" >&2
   ERRORS=$((ERRORS + 1))
 fi

--- a/tests/test-find-python-bin.sh
+++ b/tests/test-find-python-bin.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# tests/test-find-python-bin.sh — Issue #171: scripts/touchstone-run.sh
+# and scripts/run-pytest-in-venv.sh must resolve the parent repo's
+# .venv/bin/python when run from a git worktree, and must error
+# clearly (instead of silently falling back to system python) when no
+# venv can be found.
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TOUCHSTONE_SCRIPT="$REPO_ROOT/scripts/touchstone-run.sh"
+PYTEST_SCRIPT="$REPO_ROOT/scripts/run-pytest-in-venv.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$actual" != "$expected" ]; then
+    printf 'FAIL: %s\nexpected: [%s]\nactual:   [%s]\n' "$name" "$expected" "$actual" >&2
+    exit 1
+  fi
+}
+
+assert_contains() {
+  local name="$1" haystack="$2" needle="$3"
+  case "$haystack" in
+    *"$needle"*) ;;
+    *) fail "$name missing [$needle] in [$haystack]" ;;
+  esac
+}
+
+setup_worktree_fixture() {
+  local root="$1" parent worktree
+  parent="$root/parent"
+  worktree="$root/foo"
+
+  mkdir -p "$parent/.git/worktrees/foo" "$parent/.venv/bin" "$worktree"
+  printf '#!/usr/bin/env bash\n' > "$parent/.venv/bin/python"
+  chmod +x "$parent/.venv/bin/python"
+  printf 'gitdir: %s\n' "$parent/.git/worktrees/foo" > "$worktree/.git"
+}
+
+run_touchstone_lookup() {
+  local worktree="$1"
+  (
+    cd "$worktree"
+    # shellcheck source=/dev/null
+    TOUCHSTONE_RUN_SOURCE_ONLY=1 source "$TOUCHSTONE_SCRIPT"
+    find_python_bin
+  )
+}
+
+run_pytest_lookup() {
+  local worktree="$1"
+  (
+    cd "$worktree"
+    # shellcheck source=/dev/null
+    RUN_PYTEST_IN_VENV_SOURCE_ONLY=1 source "$PYTEST_SCRIPT"
+    find_python
+  )
+}
+
+run_local_lookup() {
+  local checkout="$1"
+  (
+    cd "$checkout"
+    # shellcheck source=/dev/null
+    TOUCHSTONE_RUN_SOURCE_ONLY=1 source "$TOUCHSTONE_SCRIPT"
+    find_python_bin
+  )
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# ---------------------------------------------------------------------------
+# Case 1: worktree → parent .venv resolved.
+# ---------------------------------------------------------------------------
+echo "==> Case 1: worktree resolves parent's .venv"
+setup_worktree_fixture "$tmp/with-venv"
+expected="$tmp/with-venv/parent/.venv/bin/python"
+
+actual="$(run_touchstone_lookup "$tmp/with-venv/foo")"
+assert_eq "touchstone worktree parent venv" "$expected" "$actual"
+
+actual="$(run_pytest_lookup "$tmp/with-venv/foo")"
+assert_eq "pytest helper worktree parent venv" "$expected" "$actual"
+
+# ---------------------------------------------------------------------------
+# Case 2: worktree without parent venv → clear error, no system fallback.
+# ---------------------------------------------------------------------------
+echo "==> Case 2: worktree without parent venv errors clearly"
+mkdir -p "$tmp/no-venv/parent/.git/worktrees/foo" "$tmp/no-venv/foo"
+printf 'gitdir: %s\n' "$tmp/no-venv/parent/.git/worktrees/foo" > "$tmp/no-venv/foo/.git"
+
+err_file="$tmp/touchstone.err"
+if run_touchstone_lookup "$tmp/no-venv/foo" > "$tmp/touchstone.out" 2> "$err_file"; then
+  fail "touchstone lookup should fail without any project venv"
+fi
+err="$(cat "$err_file")"
+assert_contains "touchstone error" "$err" "ERROR: no project virtualenv found."
+assert_contains "touchstone checkout tried" "$err" "Tried: $tmp/no-venv/foo/.venv/bin/python (this checkout)"
+assert_contains "touchstone parent tried" "$err" "Tried: $tmp/no-venv/parent/.venv/bin/python (worktree parent)"
+
+err_file="$tmp/pytest.err"
+if run_pytest_lookup "$tmp/no-venv/foo" > "$tmp/pytest.out" 2> "$err_file"; then
+  fail "pytest helper lookup should fail without any project venv"
+fi
+err="$(cat "$err_file")"
+assert_contains "pytest error" "$err" "ERROR: no project virtualenv found."
+assert_contains "pytest checkout tried" "$err" "Tried: $tmp/no-venv/foo/.venv/bin/python (this checkout)"
+assert_contains "pytest parent tried" "$err" "Tried: $tmp/no-venv/parent/.venv/bin/python (worktree parent)"
+
+# ---------------------------------------------------------------------------
+# Case 3: regular checkout with local .venv → returns local venv.
+# ---------------------------------------------------------------------------
+echo "==> Case 3: regular checkout with local .venv"
+mkdir -p "$tmp/local/.venv/bin"
+printf '#!/usr/bin/env bash\n' > "$tmp/local/.venv/bin/python"
+chmod +x "$tmp/local/.venv/bin/python"
+# Real .git directory marks this as a non-worktree checkout.
+mkdir -p "$tmp/local/.git"
+
+actual="$(run_local_lookup "$tmp/local")"
+assert_eq "local checkout local venv" ".venv/bin/python" "$actual"
+
+echo "==> PASS: find_python_bin worktree-aware lookup (#171)"


### PR DESCRIPTION
## Linked Issues

Closes #171
Closes #195

Pushing from a git worktree triggered the touchstone-validate pre-push
hook to run pytest against /opt/homebrew/bin/python3 instead of the
project's pinned .venv interpreter, producing 31 ModuleNotFoundError
collection errors. The bug: find_python_bin in scripts/touchstone-run.sh
checked .venv/bin/python in the current checkout (where it doesn't
exist for a worktree), then silently fell back to system python3 on
PATH. Same shape in scripts/run-pytest-in-venv.sh.

This commit ports the fix from autumngarage/conductor#195:

1. PYTEST_PYTHON env var is honored first as an explicit operator
   override (used by tests and any caller pinning a specific
   interpreter).
2. Local .venv/bin/python and agent/.venv/bin/python come next —
   parent-checkout behavior is unchanged.
3. find_worktree_parent_root reads .git when it is a regular file
   (worktree marker), parses the gitdir: pointer, walks up to the
   parent repo's worktree root, and returns it. find_python_bin then
   tries <parent>/.venv/bin/python.
4. No silent fallback to system python3. When no venv is found the
   script errors with the paths it tried and a recovery hint
   (run setup.sh, or push from the parent checkout).

The TOUCHSTONE_RUN_SOURCE_ONLY / RUN_PYTEST_IN_VENV_SOURCE_ONLY
escape hatches let tests source the scripts to call helpers
directly without invoking the action dispatcher.

Test added: tests/test-find-python-bin.sh covers (a) worktree resolves
to parent's venv, (b) worktree without parent venv produces the right
error, (c) regular checkout returns its local venv. Two existing
test-bootstrap.sh fixtures updated to use PYTEST_PYTHON=python3 and to
match the new error wording.

Closes #171
Refs: autumngarage/conductor#195

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
