### PR TITLE
fix: merge-pr auto-promotes to bypass on review failure with clean marker

### DIFF
--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -490,11 +490,40 @@ run_merge_review() {
   fi
 
   echo "==> Running merge review ..."
+  local review_rc=0
   CODEX_REVIEW_BASE="$default_base_ref" \
     CODEX_REVIEW_BRANCH_NAME="$pr_head_branch" \
     CODEX_REVIEW_FORCE=1 \
     CODEX_REVIEW_MODE=review-only \
-    bash "$REVIEW_SCRIPT"
+    bash "$REVIEW_SCRIPT" || review_rc=$?
+
+  if [ "$review_rc" -eq 0 ]; then
+    return 0
+  fi
+
+  # Issue #182: when the merge-pr review fails (typically a routing-induced
+  # timeout — Ollama wedging on review-only on small diffs, etc.) AND the
+  # exact same HEAD already has a recorded clean review marker from a
+  # prior run, auto-promote to bypass-with-disclosure rather than refusing
+  # the merge. The marker proves the diff was reviewed cleanly; a failed
+  # second iteration is a stalled reviewer gate, exactly the case that
+  # principles/git-workflow.md documents `--bypass-with-disclosure` for.
+  # Without this auto-promotion, every operator hit by the routing bug
+  # has to invoke the bypass manually with a synthesized reason.
+  local current_merge_base
+  if current_merge_base="$(git merge-base "$default_base_ref" "$pr_head_oid" 2>/dev/null)" \
+    && branch_has_clean_review_marker "$pr_head_branch" "$pr_head_oid" "$current_merge_base"; then
+    echo "" >&2
+    echo "==> Merge review exited $review_rc, but a prior clean review marker is recorded for HEAD $pr_head_oid." >&2
+    echo "==> Auto-promoting to reviewer bypass with disclosure." >&2
+    BYPASS_REVIEW=true
+    BYPASS_REASON="merge-pr.sh final review iteration exited ${review_rc} (typically a routing-induced timeout); a prior clean review marker is recorded for HEAD ${pr_head_oid}, so this auto-bypass preserves the safety guarantee that the diff was reviewed cleanly at least once."
+    print_bypass_banner
+    record_bypass_comment
+    return 0
+  fi
+
+  return "$review_rc"
 }
 
 # 1. Sanity check the PR exists and is open.

--- a/tests/test-merge-pr.sh
+++ b/tests/test-merge-pr.sh
@@ -275,6 +275,52 @@ else
   exit 1
 fi
 
+echo "==> Test: review failure with prior clean marker auto-promotes to bypass (#182)"
+reset_case_files
+# Synthesize a clean review marker for the same head/base the harness's fake
+# git resolves to (pr-head-oid + base-oid). The merge-pr.sh path treats this
+# as proof the diff was reviewed cleanly at least once; when the second
+# review iteration fails (typically a routing-induced timeout), it should
+# auto-promote to bypass-with-disclosure rather than refusing the merge.
+mkdir -p "$GIT_PATH_ROOT/touchstone/reviewer-clean"
+printf 'result=CODEX_REVIEW_CLEAN\nbranch=feature/test\nbase=origin/main\nmerge_base=base-oid\nhead=pr-head-oid\n' \
+  > "$GIT_PATH_ROOT/touchstone/reviewer-clean/feature_test.clean"
+if ! CODEX_REVIEW_EXIT=124 run_merge_pr "$TEST_DIR/output-auto-bypass.txt" 123; then
+  echo "FAIL: merge-pr.sh did not auto-promote to bypass when review failed and a clean marker exists" >&2
+  cat "$TEST_DIR/output-auto-bypass.txt" >&2
+  exit 1
+fi
+if grep -q 'Auto-promoting to reviewer bypass with disclosure' "$TEST_DIR/output-auto-bypass.txt" \
+  && grep -q 'BYPASSING REVIEWER GATE' "$TEST_DIR/output-auto-bypass.txt" \
+  && [ -f "$TEST_DIR/gh-comment" ] \
+  && grep -q 'Reviewer bypassed via' "$TEST_DIR/gh-comment" \
+  && [ -f "$TEST_DIR/gh-merge-head" ]; then
+  echo "==> PASS: review failure with prior clean marker auto-promoted to bypass and merged"
+else
+  echo "FAIL: auto-bypass path did not produce expected log/comment/merge artifacts" >&2
+  cat "$TEST_DIR/output-auto-bypass.txt" >&2
+  exit 1
+fi
+
+echo "==> Test: review failure with NO prior clean marker still fails closed (#182 safety)"
+reset_case_files
+# No marker is created. The auto-promotion must NOT fire — without a marker
+# there is no proof the diff was ever reviewed cleanly, so failing the
+# review must still refuse the merge (preserves the safety guarantee).
+if CODEX_REVIEW_EXIT=124 run_merge_pr "$TEST_DIR/output-no-marker.txt" 123; then
+  echo "FAIL: merge-pr.sh auto-bypassed even without a clean marker" >&2
+  cat "$TEST_DIR/output-no-marker.txt" >&2
+  exit 1
+fi
+if [ ! -f "$TEST_DIR/gh-merge-head" ] \
+  && ! grep -q 'Auto-promoting to reviewer bypass' "$TEST_DIR/output-no-marker.txt"; then
+  echo "==> PASS: review failure without marker fails closed (no auto-bypass)"
+else
+  echo "FAIL: failure-without-marker case should not merge or auto-bypass" >&2
+  cat "$TEST_DIR/output-no-marker.txt" >&2
+  exit 1
+fi
+
 echo "==> Test: sibling worktree owning main is fast-forwarded without false merge failure"
 reset_case_files
 MAIN_WORKTREE="$TEST_DIR/main-worktree"


### PR DESCRIPTION
## Linked Issues

Closes #182

Every PR shipped today (#173, #178, #180, #181) hit the same friction:
the merge-pr.sh final review iteration timed out at 300s on Ollama in
review-only mode (Touchstone routes small/cheap diffs there by default).
The local pre-merge review had already produced a CODEX_REVIEW_CLEAN
marker for the same HEAD — the timeout was a routing problem, not a
substantive finding. Each ship needed `--bypass-with-disclosure`
invoked manually with a synthesized reason.

This commit teaches `run_merge_review` to detect that exact pattern:
when the second review exits non-zero AND a clean marker exists for
the current PR head + merge-base + branch, auto-promote to the
bypass-with-disclosure path with a synthesized reason naming the
review's exit code and the marker. The marker is the safety guarantee
— if no marker exists, the failure still propagates as fail-closed,
preserving the existing contract.

This converts what was a manual recovery for a routing-induced
timeout into automatic behavior, and saves the bypass audit trail
for cases where it actually means something (a stalled reviewer on
a genuinely already-reviewed branch, the documented use case in
principles/git-workflow.md).

Two tests added in tests/test-merge-pr.sh:
- CODEX_REVIEW_EXIT=124 + clean marker present → auto-bypass fires,
  merge proceeds, PR comment + bypass banner emitted.
- CODEX_REVIEW_EXIT=124 + no marker → still fails closed, no merge.

Closes #182

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
