### PR TITLE
fix cleanup worktree self-pid locks

### DIFF
--- a/scripts/cleanup-worktrees.sh
+++ b/scripts/cleanup-worktrees.sh
@@ -144,13 +144,23 @@ pid_is_alive() {
   ps -p "$pid" >/dev/null 2>&1
 }
 
+pid_is_current_shell_parent() {
+  local pid="$1"
+
+  [ -n "$pid" ] || return 1
+  [ -n "${PPID:-}" ] || return 1
+  [ "$pid" = "$PPID" ]
+}
+
 classify_lock() {
   local reason="$1"
   local pid
 
   if [[ "$reason" =~ [Pp][Ii][Dd][[:space:]]+([0-9]+) ]]; then
     pid="${BASH_REMATCH[1]}"
-    if pid_is_alive "$pid"; then
+    if pid_is_current_shell_parent "$pid"; then
+      printf 'stale|%s|stale (pid %s is current shell parent)' "$pid" "$pid"
+    elif pid_is_alive "$pid"; then
       printf 'alive|%s|alive (pid %s)' "$pid" "$pid"
     else
       printf 'stale|%s|stale (pid %s dead)' "$pid" "$pid"

--- a/templates/gitignore
+++ b/templates/gitignore
@@ -39,5 +39,8 @@ out/
 # default — a team may opt to commit it by removing this line).
 .claude/settings.local.json
 
+# Claude Code agent worktrees are transient local workspaces.
+.claude/worktrees/
+
 # Touchstone
 *.bak

--- a/tests/test-cleanup-worktrees-self-pid.sh
+++ b/tests/test-cleanup-worktrees-self-pid.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# tests/test-cleanup-worktrees-self-pid.sh — verify cleanup-worktrees treats
+# a lock held by the invoking shell's parent PID as stale.
+#
+set -euo pipefail
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_DIR="$(mktemp -d -t touchstone-test-cleanup-self-pid.XXXXXX)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+echo "==> Test: cleanup-worktrees.sh unlocks self-parent PID locks only with --unlock-stale"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+assert_exists() {
+  [ -e "$1" ] || fail "expected $1 to exist"
+}
+
+assert_not_exists() {
+  [ ! -e "$1" ] || fail "expected $1 to NOT exist"
+}
+
+assert_contains() {
+  grep -q "$2" "$1" 2>/dev/null || fail "expected $1 to contain '$2'"
+}
+
+REMOTE="$TEST_DIR/remote.git"
+REPO="$TEST_DIR/demo"
+SELF_PID_WT="$TEST_DIR/demo-self-pid"
+
+git init -q --bare -b main "$REMOTE"
+git init -q -b main "$REPO"
+git -C "$REPO" config user.email "test@example.com"
+git -C "$REPO" config user.name "Test"
+git -C "$REPO" remote add origin "$REMOTE"
+
+echo "base" > "$REPO/base.txt"
+git -C "$REPO" add base.txt
+git -C "$REPO" commit -qm "initial"
+git -C "$REPO" push -q -u origin main
+git -C "$REPO" remote set-head origin main
+
+git -C "$REPO" worktree add -q "$SELF_PID_WT" -b feat/self-pid main
+echo "self pid" > "$SELF_PID_WT/self-pid.txt"
+git -C "$SELF_PID_WT" add self-pid.txt
+git -C "$SELF_PID_WT" commit -qm "feat: self pid"
+git -C "$REPO" checkout -q main
+git -C "$REPO" merge --no-ff -q feat/self-pid -m "merge feat/self-pid"
+git -C "$REPO" push -q origin main
+
+git -C "$REPO" worktree lock --reason "agent pid $$" "$SELF_PID_WT"
+
+DRY_RUN_OUTPUT="$TEST_DIR/dry-run-output.txt"
+pushd "$REPO" >/dev/null
+bash "$TOUCHSTONE_ROOT/scripts/cleanup-worktrees.sh" >"$DRY_RUN_OUTPUT" 2>&1
+popd >/dev/null
+
+assert_exists "$SELF_PID_WT"
+assert_contains "$DRY_RUN_OUTPUT" "lock: stale (pid $$ is current shell parent)"
+assert_contains "$DRY_RUN_OUTPUT" 'pass --unlock-stale --execute to remove'
+
+UNLOCK_OUTPUT="$TEST_DIR/unlock-output.txt"
+pushd "$REPO" >/dev/null
+bash "$TOUCHSTONE_ROOT/scripts/cleanup-worktrees.sh" --unlock-stale --execute >"$UNLOCK_OUTPUT" 2>&1
+popd >/dev/null
+
+assert_not_exists "$SELF_PID_WT"
+assert_contains "$UNLOCK_OUTPUT" 'unlocked stale lock:'
+assert_contains "$UNLOCK_OUTPUT" 'removed:'
+
+echo "==> PASS: cleanup-worktrees removes self-parent PID locks only after explicit stale unlock"

--- a/tests/test-cleanup-worktrees.sh
+++ b/tests/test-cleanup-worktrees.sh
@@ -7,7 +7,17 @@ set -euo pipefail
 
 TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TEST_DIR="$(mktemp -d -t touchstone-test-cleanup-worktrees.XXXXXX)"
-trap 'rm -rf "$TEST_DIR"' EXIT
+LOCKED_ALIVE_PID=""
+
+cleanup() {
+  if [ -n "$LOCKED_ALIVE_PID" ]; then
+    kill "$LOCKED_ALIVE_PID" >/dev/null 2>&1 || true
+    wait "$LOCKED_ALIVE_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TEST_DIR"
+}
+
+trap cleanup EXIT
 
 echo "==> Test: cleanup-worktrees.sh removes only safe worktree candidates"
 
@@ -103,7 +113,9 @@ git -C "$LOCKED_ALIVE_WT" add locked-alive.txt
 git -C "$LOCKED_ALIVE_WT" commit -qm "feat: locked alive"
 git -C "$REPO" checkout -q main
 git -C "$REPO" merge --no-ff -q feat/locked-alive -m "merge feat/locked-alive"
-git -C "$REPO" worktree lock --reason "agent pid $$" "$LOCKED_ALIVE_WT"
+sleep 120 &
+LOCKED_ALIVE_PID="$!"
+git -C "$REPO" worktree lock --reason "agent pid $LOCKED_ALIVE_PID" "$LOCKED_ALIVE_WT"
 
 git -C "$REPO" worktree add -q "$LOCKED_NOPID_WT" -b feat/locked-nopid main
 echo "locked no pid" > "$LOCKED_NOPID_WT/locked-nopid.txt"
@@ -133,7 +145,7 @@ assert_contains "$DRY_RUN_OUTPUT" "$SQUASH_WT"
 assert_contains "$DRY_RUN_OUTPUT" 'dirty; use --force to remove'
 assert_contains "$DRY_RUN_OUTPUT" 'detached HEAD has unique work'
 assert_contains "$DRY_RUN_OUTPUT" "lock: stale (pid $DEAD_PID dead)"
-assert_contains "$DRY_RUN_OUTPUT" "lock: alive (pid $$)"
+assert_contains "$DRY_RUN_OUTPUT" "lock: alive (pid $LOCKED_ALIVE_PID)"
 assert_contains "$DRY_RUN_OUTPUT" 'lock: present, no PID'
 assert_contains "$DRY_RUN_OUTPUT" 'pass --unlock-stale --execute to remove'
 assert_contains "$DRY_RUN_OUTPUT" 'locked by live process'


### PR DESCRIPTION
## Linked Issues

Closes #183

Ignore Claude Code agent worktrees in the bootstrapped gitignore template and treat only the current cleanup shell's parent PID as a stale lock owner. Keep unrelated live PID locks blocking cleanup.

Closes #183

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
