### PR TITLE
feat: add touchstone worker lifecycle commands

### DIFF
--- a/bin/touchstone
+++ b/bin/touchstone
@@ -8,6 +8,7 @@
 #                                      Add touchstone to the current project
 #   touchstone run <task>                  Run profile task: lint, test, build, typecheck, validate
 #   touchstone run-script <name>           Prototype runner for pinned project-local script shims
+#   touchstone worker <command>            Manage worker worktree lifecycle
 #   touchstone update                     Update current project to latest touchstone
 #   touchstone update --in-place          Update on the current branch
 #   touchstone update --dry-run           Show what would change without applying
@@ -285,6 +286,10 @@ cmd_sync() {
 
 cmd_run() {
   exec bash "$TOUCHSTONE_ROOT/scripts/touchstone-run.sh" "$@"
+}
+
+cmd_worker() {
+  exec bash "$TOUCHSTONE_ROOT/scripts/worker.sh" "$@"
 }
 
 run_script_usage() {
@@ -1556,6 +1561,11 @@ cmd_help() {
   printf "    ${BOLD}touchstone detect${RESET}                 Show detected project profile\n"
   printf "    ${BOLD}touchstone run${RESET} <task>             Run lint, typecheck, build, test, or validate\n"
   printf "    ${BOLD}touchstone run-script${RESET} <name>      Prototype runner for pinned script shims\n"
+  printf "    ${BOLD}touchstone worker${RESET} spawn --task ... --type fix|feat|chore|refactor|docs\n"
+  printf "    ${BOLD}touchstone worker${RESET} status --worktree <path> [--json]\n"
+  printf "    ${BOLD}touchstone worker${RESET} ship --worktree <path> [--cleanup]\n"
+  printf "    ${BOLD}touchstone worker${RESET} abandon --worktree <path> [--dry-run|--force]\n"
+  printf "    ${BOLD}touchstone worker${RESET} list [--repo <path>] [--json]\n"
   printf "    ${BOLD}touchstone update${RESET}                 Create a branch + commit for touchstone updates\n"
   printf "    ${BOLD}touchstone update${RESET} --in-place      Commit touchstone updates on the current branch\n"
   printf "    ${BOLD}touchstone update${RESET} --dry-run       Preview what would change\n"
@@ -1603,6 +1613,7 @@ case "$COMMAND" in
   init)         cmd_init "$@" ;;
   run)          cmd_run "$@" ;;
   run-script)   cmd_run_script "$@" ;;
+  worker)      cmd_worker "$@" ;;
   detect)       cmd_detect ;;
   update)       cmd_update "$@" ;;
   migrate-from-toolkit) cmd_migrate_from_toolkit "$@" ;;

--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -991,7 +991,10 @@ write_touchstone_manifest() {
     printf 'scripts/cleanup-branches.sh\n'
     printf 'scripts/spawn-worktree.sh\n'
     printf 'scripts/cleanup-worktrees.sh\n'
+    printf 'scripts/worker.sh\n'
     printf 'lib/toml.sh\n'
+    printf 'lib/events.sh\n'
+    printf 'lib/worker-state.sh\n'
     if [ "$INPUT_TYPE" = "python" ]; then
       printf 'scripts/run-pytest-in-venv.sh\n'
     fi
@@ -1241,12 +1244,15 @@ copy_file_force "$TOUCHSTONE_ROOT/scripts/merge-pr.sh" "$PROJECT_DIR/scripts/mer
 copy_file_force "$TOUCHSTONE_ROOT/scripts/cleanup-branches.sh" "$PROJECT_DIR/scripts/cleanup-branches.sh"
 copy_file_force "$TOUCHSTONE_ROOT/scripts/spawn-worktree.sh" "$PROJECT_DIR/scripts/spawn-worktree.sh"
 copy_file_force "$TOUCHSTONE_ROOT/scripts/cleanup-worktrees.sh" "$PROJECT_DIR/scripts/cleanup-worktrees.sh"
+copy_file_force "$TOUCHSTONE_ROOT/scripts/worker.sh" "$PROJECT_DIR/scripts/worker.sh"
 chmod +x "$PROJECT_DIR/scripts/"*.sh
 
 echo ""
 echo "==> Copying libraries (touchstone-owned, will be auto-updated):"
 mkdir -p "$PROJECT_DIR/lib"
 copy_file_force "$TOUCHSTONE_ROOT/lib/toml.sh" "$PROJECT_DIR/lib/toml.sh"
+copy_file_force "$TOUCHSTONE_ROOT/lib/events.sh" "$PROJECT_DIR/lib/events.sh"
+copy_file_force "$TOUCHSTONE_ROOT/lib/worker-state.sh" "$PROJECT_DIR/lib/worker-state.sh"
 
 # Claude Code settings — wires the branch-guard and emergency-disclosure
 # PreToolUse hooks shipped above. Touchstone-owned (overwritten on update);

--- a/bootstrap/update-project.sh
+++ b/bootstrap/update-project.sh
@@ -388,10 +388,12 @@ update_file "$TOUCHSTONE_ROOT/scripts/merge-pr.sh" "$PROJECT_DIR/scripts/merge-p
 update_file "$TOUCHSTONE_ROOT/scripts/cleanup-branches.sh" "$PROJECT_DIR/scripts/cleanup-branches.sh"
 update_file "$TOUCHSTONE_ROOT/scripts/spawn-worktree.sh" "$PROJECT_DIR/scripts/spawn-worktree.sh"
 update_file "$TOUCHSTONE_ROOT/scripts/cleanup-worktrees.sh" "$PROJECT_DIR/scripts/cleanup-worktrees.sh"
+update_file "$TOUCHSTONE_ROOT/scripts/worker.sh" "$PROJECT_DIR/scripts/worker.sh"
 
 # Libraries used by touchstone-owned scripts.
 update_file "$TOUCHSTONE_ROOT/lib/toml.sh" "$PROJECT_DIR/lib/toml.sh"
 update_file "$TOUCHSTONE_ROOT/lib/events.sh" "$PROJECT_DIR/lib/events.sh"
+update_file "$TOUCHSTONE_ROOT/lib/worker-state.sh" "$PROJECT_DIR/lib/worker-state.sh"
 
 if [ "$PROJECT_TYPE" = "python" ] || [ -f "$PROJECT_DIR/scripts/run-pytest-in-venv.sh" ]; then
   update_file "$TOUCHSTONE_ROOT/scripts/run-pytest-in-venv.sh" "$PROJECT_DIR/scripts/run-pytest-in-venv.sh"
@@ -539,8 +541,10 @@ write_touchstone_manifest() {
     printf 'scripts/cleanup-branches.sh\n'
     printf 'scripts/spawn-worktree.sh\n'
     printf 'scripts/cleanup-worktrees.sh\n'
+    printf 'scripts/worker.sh\n'
     printf 'lib/toml.sh\n'
     printf 'lib/events.sh\n'
+    printf 'lib/worker-state.sh\n'
     if [ "$PROJECT_TYPE" = "python" ] || [ -f "$PROJECT_DIR/scripts/run-pytest-in-venv.sh" ]; then
       printf 'scripts/run-pytest-in-venv.sh\n'
     fi

--- a/lib/events.sh
+++ b/lib/events.sh
@@ -1,6 +1,21 @@
 #!/usr/bin/env bash
 #
 # lib/events.sh — optional NDJSON lifecycle events for UI clients.
+#
+# Event schema:
+#   worktree_created: branch, worktree_path, base_branch, repo_root
+#   pr_opened: pr_url, pr_number, branch, base_branch, head_sha
+#   review_started: pr_number, mode
+#   review_clean: pr_number, head_sha
+#   review_blocked: pr_number, head_sha
+#   review_bypass: pr_number, reason
+#   merged: pr_number, merged_at, head_sha
+#   cleanup_started: worktree_path
+#   cleanup_done: worktree_path, result
+#   failed: phase, reason, pr_number
+#   worker_spawned: branch, worktree_path, task
+#   worker_state_changed: worktree_path, from, to
+#   worker_abandoned: worktree_path, branch
 
 touchstone_json_string() {
   local value="${1-}"

--- a/lib/worker-state.sh
+++ b/lib/worker-state.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# lib/worker-state.sh — derive Touchstone worker lifecycle state.
+#
+# Source this file and call:
+#   derive_worker_state <worktree_path>
+#
+# The helper is intentionally read-only: it derives state from filesystem,
+# git, gh, and existing review markers without writing cache files.
+
+touchstone_worker_default_ref() {
+  local origin_head ref branch default_branch
+
+  origin_head="$(git symbolic-ref -q refs/remotes/origin/HEAD 2>/dev/null || true)"
+  if [ -n "$origin_head" ]; then
+    ref="${origin_head#refs/remotes/}"
+    if git rev-parse --verify --quiet "$ref^{commit}" >/dev/null 2>&1; then
+      printf '%s\n' "$ref"
+      return 0
+    fi
+  fi
+
+  default_branch="$(git config --get init.defaultBranch 2>/dev/null || true)"
+  for branch in "$default_branch" main master; do
+    [ -n "$branch" ] || continue
+    if git rev-parse --verify --quiet "origin/$branch^{commit}" >/dev/null 2>&1; then
+      printf '%s\n' "origin/$branch"
+      return 0
+    fi
+    if git rev-parse --verify --quiet "$branch^{commit}" >/dev/null 2>&1; then
+      printf '%s\n' "$branch"
+      return 0
+    fi
+  done
+
+  printf 'origin/main\n'
+}
+
+touchstone_worker_review_marker_key() {
+  printf '%s' "$1" | sed 's/[^A-Za-z0-9._-]/_/g'
+}
+
+touchstone_worker_has_clean_marker() {
+  local branch="$1" common_dir marker
+  common_dir="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+  [ -n "$common_dir" ] || return 1
+  marker="$common_dir/touchstone/reviewer-clean/$(touchstone_worker_review_marker_key "$branch").clean"
+  [ -f "$marker" ]
+}
+
+touchstone_worker_has_blocked_signal() {
+  local branch="$1" common_dir key marker log_file
+  common_dir="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+  key="$(touchstone_worker_review_marker_key "$branch")"
+  if [ -n "$common_dir" ]; then
+    for marker in \
+      "$common_dir/touchstone/reviewer-blocked/$key.blocked" \
+      "$common_dir/touchstone/worker-blocked/$key.blocked"; do
+      [ -f "$marker" ] && return 0
+    done
+  fi
+
+  log_file="${TOUCHSTONE_REVIEW_LOG-$HOME/.touchstone-review-log}"
+  [ -n "$log_file" ] && [ -f "$log_file" ] || return 1
+  awk -F '\t' -v branch="$branch" '
+    $3 == branch && ($5 == "ran" || $5 == "review-blocked") && $6 ~ /blocked/ { found = 1 }
+    END { exit found ? 0 : 1 }
+  ' "$log_file" 2>/dev/null
+}
+
+touchstone_worker_pr_field() {
+  local branch="$1" field="$2"
+  command -v gh >/dev/null 2>&1 || return 0
+  gh pr list --head "$branch" --state all --json number,url,state,mergedAt \
+    --jq ".[0].$field // empty" 2>/dev/null || true
+}
+
+derive_worker_state() {
+  local worktree_path="${1:-}"
+  local base branch has_commits has_uncommitted pr_state merged_at
+
+  if [ -z "$worktree_path" ] || [ ! -d "$worktree_path" ]; then
+    echo "abandoned"
+    return 0
+  fi
+
+  (
+    cd "$worktree_path" || exit 0
+
+    base="$(touchstone_worker_default_ref)"
+    branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+    [ -n "$branch" ] && [ "$branch" != "HEAD" ] || { echo "abandoned"; exit 0; }
+
+    has_commits="$(git log "$base..HEAD" --oneline 2>/dev/null | head -1 || true)"
+    has_uncommitted="$(git status --porcelain 2>/dev/null || true)"
+
+    if [ -z "$has_commits" ]; then
+      echo "spawned"
+      exit 0
+    fi
+
+    pr_state="$(touchstone_worker_pr_field "$branch" state)"
+    merged_at="$(touchstone_worker_pr_field "$branch" mergedAt)"
+
+    if [ "$pr_state" = "MERGED" ] || { [ "$pr_state" = "CLOSED" ] && [ -n "$merged_at" ]; }; then
+      echo "cleanup_failed"
+      exit 0
+    fi
+
+    if [ "$pr_state" = "CLOSED" ]; then
+      if touchstone_worker_has_blocked_signal "$branch"; then
+        echo "review_blocked"
+      else
+        echo "abandoned"
+      fi
+      exit 0
+    fi
+
+    if [ "$pr_state" = "OPEN" ]; then
+      if touchstone_worker_has_clean_marker "$branch"; then
+        echo "reviewing"
+      else
+        echo "pr_opened"
+      fi
+      exit 0
+    fi
+
+    if [ -n "$has_uncommitted" ]; then
+      echo "dirty"
+    else
+      echo "working"
+    fi
+  )
+}

--- a/scripts/worker.sh
+++ b/scripts/worker.sh
@@ -1,0 +1,421 @@
+#!/usr/bin/env bash
+#
+# scripts/worker.sh — first-class Touchstone worker lifecycle commands.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TOUCHSTONE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=../lib/worker-state.sh
+source "$TOUCHSTONE_ROOT/lib/worker-state.sh"
+if [ -f "$TOUCHSTONE_ROOT/lib/events.sh" ]; then
+  # shellcheck source=../lib/events.sh
+  source "$TOUCHSTONE_ROOT/lib/events.sh"
+else
+  touchstone_emit_event() { :; }
+  touchstone_json_string() {
+    local value="${1-}"
+    value="${value//\\/\\\\}"
+    value="${value//\"/\\\"}"
+    value="${value//$'\n'/\\n}"
+    value="${value//$'\t'/\\t}"
+    value="${value//$'\r'/\\r}"
+    printf '"%s"' "$value"
+  }
+fi
+
+usage() {
+  cat <<'EOF'
+Usage:
+  touchstone worker spawn --task "<description>" --type fix|feat|chore|refactor|docs [--json]
+  touchstone worker status --worktree <path> [--json]
+  touchstone worker ship --worktree <path> [--auto-merge] [--cleanup] [--events-json <path>]
+  touchstone worker abandon --worktree <path> [--dry-run] [--force]
+  touchstone worker list [--repo <path>] [--json]
+EOF
+}
+
+json_bool() {
+  if [ -n "${1:-}" ]; then
+    printf 'true'
+  else
+    printf 'false'
+  fi
+}
+
+json_field() {
+  local key="$1" value="$2"
+  printf '"%s":%s' "$key" "$(touchstone_json_string "$value")"
+}
+
+json_number_or_null_field() {
+  local key="$1" value="$2"
+  if [ -n "$value" ]; then
+    printf '"%s":%s' "$key" "$value"
+  else
+    printf '"%s":null' "$key"
+  fi
+}
+
+sanitize_task_slug() {
+  local raw="$1" slug
+  slug="$(printf '%s' "$raw" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed 's/[^a-z0-9]/-/g; s/--*/-/g; s/^-//; s/-$//')"
+  printf '%s' "${slug:-worker-task}"
+}
+
+require_worker_type() {
+  case "$1" in
+    fix|feat|chore|refactor|docs) return 0 ;;
+    *)
+      echo "ERROR: --type must be one of fix, feat, chore, refactor, docs." >&2
+      return 1
+      ;;
+  esac
+}
+
+repo_root_or_die() {
+  if ! git rev-parse --show-toplevel 2>/dev/null; then
+    echo "ERROR: must run inside a git repository." >&2
+    return 1
+  fi
+}
+
+worker_branch() {
+  git -C "$1" rev-parse --abbrev-ref HEAD 2>/dev/null || true
+}
+
+worker_head_sha() {
+  git -C "$1" rev-parse HEAD 2>/dev/null || true
+}
+
+worker_has_uncommitted() {
+  git -C "$1" status --porcelain 2>/dev/null || true
+}
+
+worker_pr_field() {
+  local branch="$1" field="$2"
+  command -v gh >/dev/null 2>&1 || return 0
+  gh pr list --head "$branch" --state all --json number,url,state,mergedAt \
+    --jq ".[0].$field // empty" 2>/dev/null || true
+}
+
+worker_status_json() {
+  local worktree_path="$1"
+  local state branch head_sha has_uncommitted pr_number pr_url merged_at
+
+  state="$(derive_worker_state "$worktree_path")"
+  branch=""
+  head_sha=""
+  has_uncommitted=""
+  pr_number=""
+  pr_url=""
+  merged_at=""
+
+  if [ -d "$worktree_path" ]; then
+    branch="$(worker_branch "$worktree_path")"
+    head_sha="$(worker_head_sha "$worktree_path")"
+    has_uncommitted="$(worker_has_uncommitted "$worktree_path")"
+    if [ -n "$branch" ] && [ "$branch" != "HEAD" ]; then
+      pr_number="$(worker_pr_field "$branch" number)"
+      pr_url="$(worker_pr_field "$branch" url)"
+      merged_at="$(worker_pr_field "$branch" mergedAt)"
+    fi
+  fi
+
+  printf '{'
+  json_field state "$state"
+  printf ','
+  json_field branch "$branch"
+  printf ','
+  json_field head_sha "$head_sha"
+  printf ',"has_uncommitted":'
+  json_bool "$has_uncommitted"
+  printf ','
+  json_number_or_null_field pr_number "$pr_number"
+  if [ -n "$pr_url" ]; then
+    printf ','
+    json_field pr_url "$pr_url"
+  fi
+  if [ -n "$merged_at" ]; then
+    printf ','
+    json_field merged_at "$merged_at"
+  fi
+  printf '}\n'
+}
+
+cmd_spawn() {
+  local task="" type="" json=false slug branch repo_root worktree_path base_ref base_branch output
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --task)
+        [ "$#" -ge 2 ] || { echo "ERROR: --task requires a value." >&2; return 2; }
+        task="$2"; shift 2 ;;
+      --type)
+        [ "$#" -ge 2 ] || { echo "ERROR: --type requires a value." >&2; return 2; }
+        type="$2"; shift 2 ;;
+      --json) json=true; shift ;;
+      -h|--help) usage; return 0 ;;
+      *) echo "ERROR: unknown worker spawn argument '$1'." >&2; return 2 ;;
+    esac
+  done
+
+  [ -n "$task" ] || { echo "ERROR: worker spawn requires --task." >&2; return 2; }
+  [ -n "$type" ] || { echo "ERROR: worker spawn requires --type." >&2; return 2; }
+  require_worker_type "$type"
+
+  repo_root="$(repo_root_or_die)"
+  slug="$(sanitize_task_slug "$task")"
+  branch="$type/$slug"
+  base_ref="$(cd "$repo_root" && touchstone_worker_default_ref)"
+  base_branch="${base_ref#origin/}"
+
+  output="$(cd "$repo_root" && bash "$TOUCHSTONE_ROOT/scripts/spawn-worktree.sh" "$branch")"
+  worktree_path="$(printf '%s\n' "$output" | awk '/^[[:space:]]*path:[[:space:]]*/ { sub(/^[[:space:]]*path:[[:space:]]*/, ""); value=$0 } END { print value }')"
+  if [ -n "$worktree_path" ]; then
+    worktree_path="$(cd "$repo_root" && cd "$worktree_path" && pwd)"
+  fi
+
+  touchstone_emit_event worker_spawned branch="$branch" worktree_path="$worktree_path" task="$task"
+
+  if [ "$json" = true ]; then
+    printf '{'
+    json_field branch "$branch"
+    printf ','
+    json_field worktree_path "$worktree_path"
+    printf ','
+    json_field base_branch "$base_branch"
+    printf '}\n'
+  else
+    printf '%s\n' "$output"
+  fi
+}
+
+cmd_status() {
+  local worktree_path="" json=false state branch head_sha has_uncommitted
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --worktree)
+        [ "$#" -ge 2 ] || { echo "ERROR: --worktree requires a path." >&2; return 2; }
+        worktree_path="$2"; shift 2 ;;
+      --json) json=true; shift ;;
+      -h|--help) usage; return 0 ;;
+      *) echo "ERROR: unknown worker status argument '$1'." >&2; return 2 ;;
+    esac
+  done
+
+  [ -n "$worktree_path" ] || { echo "ERROR: worker status requires --worktree." >&2; return 2; }
+
+  if [ "$json" = true ]; then
+    worker_status_json "$worktree_path"
+    return 0
+  fi
+
+  state="$(derive_worker_state "$worktree_path")"
+  branch=""
+  head_sha=""
+  has_uncommitted=""
+  if [ -d "$worktree_path" ]; then
+    branch="$(worker_branch "$worktree_path")"
+    head_sha="$(worker_head_sha "$worktree_path")"
+    has_uncommitted="$(worker_has_uncommitted "$worktree_path")"
+  fi
+  echo "Worker state: $state"
+  [ -n "$branch" ] && echo "Branch: $branch"
+  [ -n "$head_sha" ] && echo "Head: $head_sha"
+  if [ -n "$has_uncommitted" ]; then
+    echo "Uncommitted changes: yes"
+  else
+    echo "Uncommitted changes: no"
+  fi
+}
+
+cmd_ship() {
+  local worktree_path="" cleanup=false events_json="" args
+  args=(--auto-merge)
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --worktree)
+        [ "$#" -ge 2 ] || { echo "ERROR: --worktree requires a path." >&2; return 2; }
+        worktree_path="$2"; shift 2 ;;
+      --auto-merge) shift ;;
+      --cleanup) cleanup=true; shift ;;
+      --events-json)
+        [ "$#" -ge 2 ] || { echo "ERROR: --events-json requires a path." >&2; return 2; }
+        events_json="$2"; shift 2 ;;
+      -h|--help) usage; return 0 ;;
+      *) echo "ERROR: unknown worker ship argument '$1'." >&2; return 2 ;;
+    esac
+  done
+
+  [ -n "$worktree_path" ] || { echo "ERROR: worker ship requires --worktree." >&2; return 2; }
+  [ -d "$worktree_path" ] || { echo "ERROR: worktree does not exist: $worktree_path" >&2; return 1; }
+  if [ "$cleanup" = true ]; then
+    args+=(--cleanup-worktree)
+  fi
+  if [ -n "$events_json" ]; then
+    TOUCHSTONE_EVENTS_FILE="$events_json" \
+      bash -c 'cd "$1" && shift && bash scripts/open-pr.sh "$@"' _ "$worktree_path" "${args[@]}"
+  else
+    (cd "$worktree_path" && bash scripts/open-pr.sh "${args[@]}")
+  fi
+}
+
+branch_has_open_or_closed_pr() {
+  local branch="$1" number
+  number="$(worker_pr_field "$branch" number)"
+  [ -n "$number" ]
+}
+
+remote_branch_exists() {
+  local repo_path="$1" branch="$2"
+  git -C "$repo_path" ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1
+}
+
+worktree_manager_path() {
+  local worktree_path="$1"
+  git -C "$worktree_path" worktree list --porcelain \
+    | awk '/^worktree / { print substr($0, length("worktree ") + 1); exit }'
+}
+
+cmd_abandon() {
+  local worktree_path="" dry_run=false force=false branch base unique_commits manager_path
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --worktree)
+        [ "$#" -ge 2 ] || { echo "ERROR: --worktree requires a path." >&2; return 2; }
+        worktree_path="$2"; shift 2 ;;
+      --dry-run) dry_run=true; shift ;;
+      --force) force=true; shift ;;
+      -h|--help) usage; return 0 ;;
+      *) echo "ERROR: unknown worker abandon argument '$1'." >&2; return 2 ;;
+    esac
+  done
+
+  [ -n "$worktree_path" ] || { echo "ERROR: worker abandon requires --worktree." >&2; return 2; }
+  [ -d "$worktree_path" ] || { echo "ERROR: worktree does not exist: $worktree_path" >&2; return 1; }
+
+  branch="$(worker_branch "$worktree_path")"
+  [ -n "$branch" ] && [ "$branch" != "HEAD" ] || { echo "ERROR: cannot abandon detached worktree." >&2; return 1; }
+  base="$(cd "$worktree_path" && touchstone_worker_default_ref)"
+  unique_commits="$(git -C "$worktree_path" log "$base..HEAD" --oneline 2>/dev/null || true)"
+
+  if [ -n "$unique_commits" ] && [ "$force" != true ]; then
+    echo "ERROR: refusing to abandon $worktree_path; branch '$branch' has commits not merged into $base." >&2
+    echo "       Use --force only after confirming the work is disposable." >&2
+    return 1
+  fi
+
+  if [ "$dry_run" = true ]; then
+    echo "Would remove worktree: $worktree_path"
+    if branch_has_open_or_closed_pr "$branch"; then
+      echo "Would keep remote branch because a PR exists for: $branch"
+    elif remote_branch_exists "$worktree_path" "$branch"; then
+      echo "Would delete remote branch: origin/$branch"
+    fi
+    return 0
+  fi
+
+  manager_path="$(worktree_manager_path "$worktree_path")"
+  [ -n "$manager_path" ] || { echo "ERROR: could not find a git worktree manager for $worktree_path" >&2; return 1; }
+  git -C "$manager_path" worktree remove --force "$worktree_path"
+  if branch_has_open_or_closed_pr "$branch"; then
+    echo "Kept remote branch because a PR exists for: $branch"
+  elif remote_branch_exists "$manager_path" "$branch"; then
+    git -C "$manager_path" push origin --delete "$branch"
+  fi
+  touchstone_emit_event worker_abandoned worktree_path="$worktree_path" branch="$branch"
+}
+
+cmd_list() {
+  local repo_path="" json=false repo_root list_output first=true path="" branch_ref="" branch=""
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --repo)
+        [ "$#" -ge 2 ] || { echo "ERROR: --repo requires a path." >&2; return 2; }
+        repo_path="$2"; shift 2 ;;
+      --json) json=true; shift ;;
+      -h|--help) usage; return 0 ;;
+      *) echo "ERROR: unknown worker list argument '$1'." >&2; return 2 ;;
+    esac
+  done
+
+  if [ -n "$repo_path" ]; then
+    repo_root="$(cd "$repo_path" && git rev-parse --show-toplevel)"
+  else
+    repo_root="$(repo_root_or_die)"
+  fi
+  list_output="$(git -C "$repo_root" worktree list --porcelain)"
+
+  if [ "$json" = true ]; then
+    printf '['
+  fi
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    if [ -z "$line" ]; then
+      if [ -n "$path" ] && [ -n "$branch_ref" ]; then
+        branch="${branch_ref#refs/heads/}"
+        case "$branch" in
+          feat/*|fix/*|chore/*|refactor/*|docs/*)
+            if [ "$json" = true ]; then
+              [ "$first" = true ] || printf ','
+              worker_status_json "$path" | tr -d '\n'
+              first=false
+            else
+              printf '%s  %s\n' "$(derive_worker_state "$path")" "$path"
+            fi
+            ;;
+        esac
+      fi
+      path=""
+      branch_ref=""
+      continue
+    fi
+    case "$line" in
+      worktree\ *) path="${line#worktree }" ;;
+      branch\ *) branch_ref="${line#branch }" ;;
+    esac
+  done <<< "$list_output"
+
+  if [ -n "$path" ] && [ -n "$branch_ref" ]; then
+    branch="${branch_ref#refs/heads/}"
+    case "$branch" in
+      feat/*|fix/*|chore/*|refactor/*|docs/*)
+        if [ "$json" = true ]; then
+          [ "$first" = true ] || printf ','
+          worker_status_json "$path" | tr -d '\n'
+        else
+          printf '%s  %s\n' "$(derive_worker_state "$path")" "$path"
+        fi
+        ;;
+    esac
+  fi
+
+  if [ "$json" = true ]; then
+    printf ']\n'
+  fi
+}
+
+command="${1:-help}"
+shift 2>/dev/null || true
+
+case "$command" in
+  spawn) cmd_spawn "$@" ;;
+  status) cmd_status "$@" ;;
+  ship) cmd_ship "$@" ;;
+  abandon) cmd_abandon "$@" ;;
+  list) cmd_list "$@" ;;
+  help|-h|--help) usage ;;
+  *)
+    echo "ERROR: unknown worker command '$command'." >&2
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/tests/test-worker.sh
+++ b/tests/test-worker.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+#
+# tests/test-worker.sh — verify touchstone worker lifecycle commands.
+#
+set -euo pipefail
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_DIR="$(mktemp -d -t touchstone-test-worker.XXXXXX)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+ERRORS=0
+
+fail() {
+  echo "FAIL: $*" >&2
+  ERRORS=$((ERRORS + 1))
+}
+
+assert_contains() {
+  local file="$1" pattern="$2"
+  if ! grep -qE "$pattern" "$file"; then
+    fail "expected $file to contain: $pattern"
+    [ -f "$file" ] && cat "$file" >&2
+  fi
+}
+
+assert_json_value() {
+  local file="$1" key="$2" expected="$3"
+  if ! grep -q "\"$key\":\"$expected\"" "$file"; then
+    fail "expected JSON key $key to equal $expected"
+    cat "$file" >&2
+  fi
+}
+
+setup_repo_with_origin() {
+  local repo="$1" origin="$2"
+  mkdir -p "$repo"
+  git -C "$repo" init -b main >/dev/null 2>&1
+  git -C "$repo" config user.name "Touchstone Test"
+  git -C "$repo" config user.email "touchstone@example.com"
+  printf 'base\n' > "$repo/file.txt"
+  git -C "$repo" add file.txt
+  git -C "$repo" commit -m "base commit" >/dev/null 2>&1
+  git init --bare "$origin" >/dev/null 2>&1
+  git -C "$repo" remote add origin "$origin"
+  git -C "$repo" push -u origin main >/dev/null 2>&1
+}
+
+make_fake_gh() {
+  local bin_dir="$1"
+  mkdir -p "$bin_dir"
+  cat > "$bin_dir/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-} ${2:-}" in
+  "pr list")
+    field=""
+    while [ "$#" -gt 0 ]; do
+      if [ "${1:-}" = "--jq" ]; then
+        field="$2"
+        break
+      fi
+      shift
+    done
+    case "$field" in
+      *number*) printf '%s\n' "${GH_PR_NUMBER:-}" ;;
+      *url*) printf '%s\n' "${GH_PR_URL:-}" ;;
+      *state*) printf '%s\n' "${GH_PR_STATE:-}" ;;
+      *mergedAt*) printf '%s\n' "${GH_PR_MERGED_AT:-}" ;;
+      *) printf '\n' ;;
+    esac
+    ;;
+  *)
+    echo "unexpected gh args: $*" >&2
+    exit 1
+    ;;
+esac
+EOF
+  chmod +x "$bin_dir/gh"
+}
+
+echo "==> Case a: worker spawn creates a worktree, JSON, and event"
+REPO="$TEST_DIR/repo"
+ORIGIN="$TEST_DIR/origin.git"
+setup_repo_with_origin "$REPO" "$ORIGIN"
+SPAWN_EVENTS="$TEST_DIR/spawn-events.ndjson"
+SPAWN_JSON="$TEST_DIR/spawn.json"
+(
+  cd "$REPO"
+  TOUCHSTONE_EVENTS_FILE="$SPAWN_EVENTS" \
+    "$TOUCHSTONE_ROOT/bin/touchstone" worker spawn \
+      --task "Fix Worker Lifecycle!" \
+      --type fix \
+      --json >"$SPAWN_JSON"
+)
+WORKTREE_PATH="$(sed -n 's/.*"worktree_path":"\([^"]*\)".*/\1/p' "$SPAWN_JSON")"
+if [ ! -d "$WORKTREE_PATH" ]; then
+  fail "spawn did not create worktree at $WORKTREE_PATH"
+fi
+assert_json_value "$SPAWN_JSON" branch "fix/fix-worker-lifecycle"
+assert_json_value "$SPAWN_JSON" base_branch "main"
+assert_contains "$SPAWN_EVENTS" '"event":"worker_spawned"'
+assert_contains "$SPAWN_EVENTS" '"task":"Fix Worker Lifecycle!"'
+
+echo "==> Case b: worker status derives spawned, working, dirty, PR, reviewing, and merged states"
+STATUS_JSON="$TEST_DIR/status.json"
+(
+  cd "$REPO"
+  "$TOUCHSTONE_ROOT/bin/touchstone" worker status --worktree "$WORKTREE_PATH" --json >"$STATUS_JSON"
+)
+assert_json_value "$STATUS_JSON" state "spawned"
+
+printf 'change\n' >> "$WORKTREE_PATH/file.txt"
+git -C "$WORKTREE_PATH" add file.txt
+git -C "$WORKTREE_PATH" commit -m "worker change" >/dev/null 2>&1
+(
+  cd "$REPO"
+  "$TOUCHSTONE_ROOT/bin/touchstone" worker status --worktree "$WORKTREE_PATH" --json >"$STATUS_JSON"
+)
+assert_json_value "$STATUS_JSON" state "working"
+
+printf 'dirty\n' >> "$WORKTREE_PATH/file.txt"
+(
+  cd "$REPO"
+  "$TOUCHSTONE_ROOT/bin/touchstone" worker status --worktree "$WORKTREE_PATH" --json >"$STATUS_JSON"
+)
+assert_json_value "$STATUS_JSON" state "dirty"
+git -C "$WORKTREE_PATH" checkout -- file.txt
+
+FAKE_GH="$TEST_DIR/fake-gh"
+make_fake_gh "$FAKE_GH"
+PATH="$FAKE_GH:/usr/bin:/bin:/usr/sbin:/sbin" \
+GH_PR_NUMBER=138 \
+GH_PR_URL="https://example.test/autumngarage/touchstone/pull/138" \
+GH_PR_STATE=OPEN \
+  "$TOUCHSTONE_ROOT/bin/touchstone" worker status --worktree "$WORKTREE_PATH" --json >"$STATUS_JSON"
+assert_json_value "$STATUS_JSON" state "pr_opened"
+assert_contains "$STATUS_JSON" '"pr_number":138'
+
+COMMON_DIR="$(git -C "$WORKTREE_PATH" rev-parse --git-common-dir)"
+mkdir -p "$COMMON_DIR/touchstone/reviewer-clean"
+cat > "$COMMON_DIR/touchstone/reviewer-clean/fix_fix-worker-lifecycle.clean" <<'EOF'
+result=CODEX_REVIEW_CLEAN
+branch=fix/fix-worker-lifecycle
+EOF
+PATH="$FAKE_GH:/usr/bin:/bin:/usr/sbin:/sbin" \
+GH_PR_STATE=OPEN \
+  "$TOUCHSTONE_ROOT/bin/touchstone" worker status --worktree "$WORKTREE_PATH" --json >"$STATUS_JSON"
+assert_json_value "$STATUS_JSON" state "reviewing"
+
+PATH="$FAKE_GH:/usr/bin:/bin:/usr/sbin:/sbin" \
+GH_PR_STATE=MERGED \
+GH_PR_MERGED_AT=2026-05-06T12:00:00Z \
+  "$TOUCHSTONE_ROOT/bin/touchstone" worker status --worktree "$WORKTREE_PATH" --json >"$STATUS_JSON"
+assert_json_value "$STATUS_JSON" state "cleanup_failed"
+assert_json_value "$STATUS_JSON" merged_at "2026-05-06T12:00:00Z"
+
+PATH="$FAKE_GH:/usr/bin:/bin:/usr/sbin:/sbin" \
+GH_PR_STATE=CLOSED \
+  "$TOUCHSTONE_ROOT/bin/touchstone" worker status --worktree "$WORKTREE_PATH" --json >"$STATUS_JSON"
+assert_json_value "$STATUS_JSON" state "abandoned"
+
+mkdir -p "$COMMON_DIR/touchstone/reviewer-blocked"
+: > "$COMMON_DIR/touchstone/reviewer-blocked/fix_fix-worker-lifecycle.blocked"
+PATH="$FAKE_GH:/usr/bin:/bin:/usr/sbin:/sbin" \
+GH_PR_STATE=CLOSED \
+  "$TOUCHSTONE_ROOT/bin/touchstone" worker status --worktree "$WORKTREE_PATH" --json >"$STATUS_JSON"
+assert_json_value "$STATUS_JSON" state "review_blocked"
+
+echo "==> Case c: worker list filters lifecycle branches"
+LIST_JSON="$TEST_DIR/list.json"
+PATH="$FAKE_GH:/usr/bin:/bin:/usr/sbin:/sbin" \
+GH_PR_STATE=OPEN \
+  "$TOUCHSTONE_ROOT/bin/touchstone" worker list --repo "$REPO" --json >"$LIST_JSON"
+assert_contains "$LIST_JSON" '"branch":"fix/fix-worker-lifecycle"'
+
+echo "==> Case d: worker ship delegates to project-local open-pr with cleanup and events env"
+SHIP_WT="$TEST_DIR/ship-worktree"
+mkdir -p "$SHIP_WT/scripts"
+cat > "$SHIP_WT/scripts/open-pr.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" > "$SHIP_ARGS_FILE"
+printf '%s\n' "${TOUCHSTONE_EVENTS_FILE:-}" > "$SHIP_EVENTS_FILE"
+EOF
+chmod +x "$SHIP_WT/scripts/open-pr.sh"
+SHIP_ARGS_FILE="$TEST_DIR/ship-args" \
+SHIP_EVENTS_FILE="$TEST_DIR/ship-events-env" \
+  "$TOUCHSTONE_ROOT/bin/touchstone" worker ship \
+    --worktree "$SHIP_WT" \
+    --cleanup \
+    --events-json "$TEST_DIR/ship-events.ndjson"
+if ! grep -q -- '--auto-merge --cleanup-worktree' "$TEST_DIR/ship-args"; then
+  fail "worker ship did not pass expected open-pr args"
+  cat "$TEST_DIR/ship-args" >&2
+fi
+if ! grep -q "$TEST_DIR/ship-events.ndjson" "$TEST_DIR/ship-events-env"; then
+  fail "worker ship did not forward TOUCHSTONE_EVENTS_FILE"
+fi
+
+echo "==> Case e: worker abandon refuses unique work and removes spawned worktrees"
+if "$TOUCHSTONE_ROOT/bin/touchstone" worker abandon --worktree "$WORKTREE_PATH" >"$TEST_DIR/abandon-refuse.out" 2>&1; then
+  fail "worker abandon should refuse unique commits without --force"
+fi
+assert_contains "$TEST_DIR/abandon-refuse.out" 'refusing to abandon'
+
+SAFE_JSON="$TEST_DIR/safe-spawn.json"
+SAFE_EVENTS="$TEST_DIR/safe-events.ndjson"
+(
+  cd "$REPO"
+  TOUCHSTONE_EVENTS_FILE="$SAFE_EVENTS" \
+    "$TOUCHSTONE_ROOT/bin/touchstone" worker spawn \
+      --task "Docs noop" \
+      --type docs \
+      --json >"$SAFE_JSON"
+)
+SAFE_WORKTREE="$(sed -n 's/.*"worktree_path":"\([^"]*\)".*/\1/p' "$SAFE_JSON")"
+ABANDON_EVENTS="$TEST_DIR/abandon-events.ndjson"
+TOUCHSTONE_EVENTS_FILE="$ABANDON_EVENTS" \
+  "$TOUCHSTONE_ROOT/bin/touchstone" worker abandon --worktree "$SAFE_WORKTREE" >"$TEST_DIR/abandon.out" 2>&1
+if [ -d "$SAFE_WORKTREE" ]; then
+  fail "worker abandon did not remove spawned worktree"
+fi
+assert_contains "$ABANDON_EVENTS" '"event":"worker_abandoned"'
+assert_contains "$ABANDON_EVENTS" '"branch":"docs/docs-noop"'
+
+if [ "$ERRORS" -eq 0 ]; then
+  echo "==> PASS: worker lifecycle commands derive state and delegate safely"
+  exit 0
+fi
+
+echo "==> FAIL: $ERRORS worker assertion(s) failed" >&2
+exit 1


### PR DESCRIPTION
## Linked Issues

Closes #138

Wraps spawn-worktree.sh / open-pr.sh / cleanup-worktrees.sh in a single
stable command surface for UI clients and agent supervisors. State is
derived from filesystem + git + gh, not persisted.

New surface:
- touchstone worker spawn --task ... --type ...
- touchstone worker status --worktree ...
- touchstone worker ship --worktree ...
- touchstone worker abandon --worktree ...
- touchstone worker list --repo ...

Closes #138

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
