### PR TITLE
fix(validate): clear pre-push context for nested review tests

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,19 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD022": false,
+  "MD024": {
+    "siblings_only": true
+  },
+  "MD026": {
+    "punctuation": ".,;:!"
+  },
+  "MD032": false,
+  "MD034": false,
+  "MD033": false,
+  "MD038": false,
+  "MD040": false,
+  "MD041": false,
+  "MD046": false,
+  "MD060": false
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,14 @@ repos:
         args: ['-i', '2', '-ci', '-bn']
         exclude: ^(bin/touchstone$|completions/|prototypes/)
 
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.46.0
+    hooks:
+      - id: markdownlint
+        args: ['--config', '.markdownlint.json']
+        files: ^([^/]+\.md|principles/.*\.md|audits/.*\.md|feedback/.*\.md|templates/.*\.md)$
+        exclude: ^\.cortex/
+
   # Codex review for direct pushes to the default branch
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: trailing-whitespace
         exclude: ^\.cortex/(journal|doctrine)/
       - id: end-of-file-fixer
-        exclude: ^\.cortex/(journal|doctrine)/
+        exclude: ^(\.cortex/(journal|doctrine)/|docs/adr/0001-hybrid-pinned-script-shims\.md$|prototypes/)
       - id: check-yaml
       - id: check-added-large-files
         args: ['--maxkb=500']
@@ -38,6 +38,29 @@ repos:
         args: ['--severity=warning']
         exclude: ^(completions/|prototypes/)
 
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.13.1-1
+    hooks:
+      - id: shfmt
+        # Match the repo's existing 2-space shell style while making case blocks
+        # and binary operators deterministic.
+        args: ['-i', '2', '-ci', '-bn']
+        exclude: ^(bin/touchstone$|completions/|prototypes/)
+
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.46.0
+    hooks:
+      - id: markdownlint
+        args: ['--config', '.markdownlint.json']
+        files: ^([^/]+\.md|principles/.*\.md|audits/.*\.md|feedback/.*\.md|templates/.*\.md)$
+        exclude: ^\.cortex/
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+        files: ^\.github/workflows/.*\.ya?ml$
+
   # Codex review for direct pushes to the default branch
   - repo: local
     hooks:
@@ -58,7 +81,7 @@ repos:
     hooks:
       - id: touchstone-validate
         name: Touchstone project validation
-        entry: /usr/bin/env bash scripts/touchstone-run.sh validate
+        entry: /usr/bin/env env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE bash scripts/touchstone-run.sh validate
         language: system
         stages: [pre-push]
         always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,15 @@ repos:
         args: ['--severity=warning']
         exclude: ^(completions/|prototypes/)
 
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.13.1-1
+    hooks:
+      - id: shfmt
+        # Match the repo's existing 2-space shell style while making case blocks
+        # and binary operators deterministic.
+        args: ['-i', '2', '-ci', '-bn']
+        exclude: ^(bin/touchstone$|completions/|prototypes/)
+
   # Codex review for direct pushes to the default branch
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,7 +81,13 @@ repos:
     hooks:
       - id: touchstone-validate
         name: Touchstone project validation
-        entry: /usr/bin/env env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE bash scripts/touchstone-run.sh validate
+        entry: >-
+          /usr/bin/env env
+          -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE
+          -u PRE_COMMIT -u PRE_COMMIT_FROM_REF -u PRE_COMMIT_TO_REF
+          -u PRE_COMMIT_LOCAL_BRANCH -u PRE_COMMIT_REMOTE_BRANCH
+          -u PRE_COMMIT_REMOTE_NAME -u PRE_COMMIT_REMOTE_URL
+          bash scripts/touchstone-run.sh validate
         language: system
         stages: [pre-push]
         always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: trailing-whitespace
         exclude: ^\.cortex/(journal|doctrine)/
       - id: end-of-file-fixer
-        exclude: ^(\.cortex/(journal|doctrine)/|docs/adr/0001-hybrid-pinned-script-shims\.md$|prototypes/)
+        exclude: ^\.cortex/(journal|doctrine)/
       - id: check-yaml
       - id: check-added-large-files
         args: ['--maxkb=500']
@@ -37,29 +37,6 @@ repos:
       - id: shellcheck
         args: ['--severity=warning']
         exclude: ^(completions/|prototypes/)
-
-  - repo: https://github.com/scop/pre-commit-shfmt
-    rev: v3.13.1-1
-    hooks:
-      - id: shfmt
-        # Match the repo's existing 2-space shell style while making case blocks
-        # and binary operators deterministic.
-        args: ['-i', '2', '-ci', '-bn']
-        exclude: ^(bin/touchstone$|completions/|prototypes/)
-
-  - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.46.0
-    hooks:
-      - id: markdownlint
-        args: ['--config', '.markdownlint.json']
-        files: ^([^/]+\.md|principles/.*\.md|audits/.*\.md|feedback/.*\.md|templates/.*\.md)$
-        exclude: ^\.cortex/
-
-  - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.12
-    hooks:
-      - id: actionlint
-        files: ^\.github/workflows/.*\.ya?ml$
 
   # Codex review for direct pushes to the default branch
   - repo: local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: trailing-whitespace
         exclude: ^\.cortex/(journal|doctrine)/
       - id: end-of-file-fixer
-        exclude: ^\.cortex/(journal|doctrine)/
+        exclude: ^(\.cortex/(journal|doctrine)/|docs/adr/0001-hybrid-pinned-script-shims\.md$|prototypes/)
       - id: check-yaml
       - id: check-added-large-files
         args: ['--maxkb=500']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,12 @@ repos:
         files: ^([^/]+\.md|principles/.*\.md|audits/.*\.md|feedback/.*\.md|templates/.*\.md)$
         exclude: ^\.cortex/
 
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+        files: ^\.github/workflows/.*\.ya?ml$
+
   # Codex review for direct pushes to the default branch
   - repo: local
     hooks:

--- a/bootstrap/migrate-review-config.sh
+++ b/bootstrap/migrate-review-config.sh
@@ -43,13 +43,31 @@ file=".codex-review.toml"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    --dry-run) dry_run=true; shift ;;
-    --no-backup) no_backup=true; shift ;;
+    --dry-run)
+      dry_run=true
+      shift
+      ;;
+    --no-backup)
+      no_backup=true
+      shift
+      ;;
     --file)
-      [ "$#" -ge 2 ] || { echo "ERROR: --file requires a path" >&2; exit 1; }
-      file="$2"; shift 2 ;;
-    -h|--help) usage; exit 0 ;;
-    *) echo "ERROR: unknown argument '$1'" >&2; usage >&2; exit 1 ;;
+      [ "$#" -ge 2 ] || {
+        echo "ERROR: --file requires a path" >&2
+        exit 1
+      }
+      file="$2"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument '$1'" >&2
+      usage >&2
+      exit 1
+      ;;
   esac
 done
 
@@ -76,18 +94,18 @@ grep -qE '^\[review\.assist\]' "$file" && has_legacy_assist=true
 grep -qE '^[[:space:]]*(small|large)_reviewers[[:space:]]*=[[:space:]]*\[' "$file" && has_legacy_routing=true
 
 if [ "$already_migrated" = true ] \
-   && [ "$has_legacy_reviewers" = false ] \
-   && [ "$has_legacy_local" = false ] \
-   && [ "$has_legacy_assist" = false ] \
-   && [ "$has_legacy_routing" = false ]; then
+  && [ "$has_legacy_reviewers" = false ] \
+  && [ "$has_legacy_local" = false ] \
+  && [ "$has_legacy_assist" = false ] \
+  && [ "$has_legacy_routing" = false ]; then
   echo "==> $file is already in 2.0 shape — nothing to migrate."
   exit 0
 fi
 
 if [ "$has_legacy_reviewers" = false ] \
-   && [ "$has_legacy_local" = false ] \
-   && [ "$has_legacy_assist" = false ] \
-   && [ "$has_legacy_routing" = false ]; then
+  && [ "$has_legacy_local" = false ] \
+  && [ "$has_legacy_assist" = false ] \
+  && [ "$has_legacy_routing" = false ]; then
   echo "==> $file has no recognizable 1.x markers — nothing to migrate."
   echo "    (Looked for: reviewers=[...], [review.local], [review.assist], small_/large_reviewers=[...])"
   exit 0
@@ -95,9 +113,9 @@ fi
 
 echo "==> Migrating $file from 1.x → 2.0"
 [ "$has_legacy_reviewers" = true ] && echo "    - reviewers=[...] → reviewer=\"conductor\" + [review.conductor].with"
-[ "$has_legacy_local" = true ]     && echo "    - [review.local] → commented out (retired in 2.0)"
-[ "$has_legacy_assist" = true ]    && echo "    - [review.assist] → commented out (returns in 2.1)"
-[ "$has_legacy_routing" = true ]   && echo "    - small_/large_reviewers=[...] → small_/large_with=\"...\""
+[ "$has_legacy_local" = true ] && echo "    - [review.local] → commented out (retired in 2.0)"
+[ "$has_legacy_assist" = true ] && echo "    - [review.assist] → commented out (returns in 2.1)"
+[ "$has_legacy_routing" = true ] && echo "    - small_/large_reviewers=[...] → small_/large_with=\"...\""
 
 tmp="$(mktemp "${TMPDIR:-/tmp}/codex-review-migrate.XXXXXX")"
 trap 'rm -f "$tmp"' EXIT
@@ -237,7 +255,7 @@ END {
     }
   }
 }
-' "$file" > "$tmp"
+' "$file" >"$tmp"
 
 if [ "$dry_run" = true ]; then
   echo ""

--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -32,11 +32,11 @@ source "$TOUCHSTONE_ROOT/lib/agents-principles-block.sh"
 
 REGISTER=true
 
-REGISTER_REQUESTED=false       # Doctrine 0002: track whether --register / --no-register was passed.
+REGISTER_REQUESTED=false # Doctrine 0002: track whether --register / --no-register was passed.
 INPUT_UNSAFE=""
 INPUT_TYPE=""
 # shellcheck disable=SC2034  # set below, read by future --type-aware branches.
-INPUT_TYPE_REQUESTED=false     # Tracks explicit --type (not the auto-detect fall-through).
+INPUT_TYPE_REQUESTED=false # Tracks explicit --type (not the auto-detect fall-through).
 INPUT_REVIEWER=""
 INPUT_REVIEW_ASSIST=""
 INPUT_REVIEW_AUTOFIX=""
@@ -56,13 +56,13 @@ WORKFLOW_CONFIG_REQUESTED=false
 YES_MODE="${YES_MODE:-false}"
 SKIP_LANGUAGE_SCAFFOLD=false
 SKIP_LANGUAGE_SCAFFOLD_REQUESTED=false
-WITH_CORTEX=""                 # unset | true | false
+WITH_CORTEX="" # unset | true | false
 WITH_CORTEX_REQUESTED=false
 WITH_SENTINEL=""
 WITH_SENTINEL_REQUESTED=false
 INITIAL_COMMIT=true
 INITIAL_COMMIT_REQUESTED=false
-GITHUB_MODE=""                 # unset | private | public | none
+GITHUB_MODE="" # unset | private | public | none
 GITHUB_MODE_REQUESTED=false
 
 usage() {
@@ -129,7 +129,7 @@ write_unsafe_paths_block() {
       printf '  "%s",\n' "$(escape_toml_basic_string "$path")"
     done
     printf ']\n'
-  } > "$block_file"
+  } >"$block_file"
 
   if awk -v block_file="$block_file" '
     BEGIN { replaced = 0; in_block = 0 }
@@ -154,7 +154,7 @@ write_unsafe_paths_block() {
         exit 1
       }
     }
-  ' "$file" > "$tmp_file"; then
+  ' "$file" >"$tmp_file"; then
     mv "$tmp_file" "$file"
   else
     rm -f "$block_file" "$tmp_file"
@@ -182,12 +182,12 @@ normalize_project_type() {
   value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
 
   case "$value" in
-    ""|auto) printf 'auto' ;;
-    node|js|javascript|ts|typescript) printf 'node' ;;
-    python|py) printf 'python' ;;
+    "" | auto) printf 'auto' ;;
+    node | js | javascript | ts | typescript) printf 'node' ;;
+    python | py) printf 'python' ;;
     swift) printf 'swift' ;;
-    rust|rs) printf 'rust' ;;
-    go|golang) printf 'go' ;;
+    rust | rs) printf 'rust' ;;
+    go | golang) printf 'go' ;;
     generic) printf 'generic' ;;
     *)
       echo "ERROR: unknown project type '$1' (expected node, python, swift, rust, go, generic, or auto)" >&2
@@ -204,9 +204,9 @@ normalize_reviewer() {
   value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
 
   case "$value" in
-    ""|auto|conductor) printf 'auto' ;;
-    codex|claude|gemini|local) printf '%s' "$value" ;;
-    none|no|off|disabled|false) printf 'none' ;;
+    "" | auto | conductor) printf 'auto' ;;
+    codex | claude | gemini | local) printf '%s' "$value" ;;
+    none | no | off | disabled | false) printf 'none' ;;
     *)
       echo "ERROR: unknown reviewer '$1' (expected conductor, none, or legacy: codex, claude, gemini, local, auto)" >&2
       return 1
@@ -219,10 +219,10 @@ normalize_review_routing() {
   value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
 
   case "$value" in
-    ""|hosted|all|all-hosted|cloud|remote) printf 'all-hosted' ;;
-    local|all-local) printf 'all-local' ;;
-    hybrid|small-local|local-small|small-local-large-hosted) printf 'small-local' ;;
-    none|off|disabled|false) printf 'none' ;;
+    "" | hosted | all | all-hosted | cloud | remote) printf 'all-hosted' ;;
+    local | all-local) printf 'all-local' ;;
+    hybrid | small-local | local-small | small-local-large-hosted) printf 'small-local' ;;
+    none | off | disabled | false) printf 'none' ;;
     *)
       echo "ERROR: unknown review routing '$1' (expected all-hosted, all-local, or small-local)" >&2
       return 1
@@ -235,8 +235,8 @@ normalize_git_workflow() {
   value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
 
   case "$value" in
-    ""|git|plain|standard|classic) printf 'git' ;;
-    gitbutler|butler|but) printf 'gitbutler' ;;
+    "" | git | plain | standard | classic) printf 'git' ;;
+    gitbutler | butler | but) printf 'gitbutler' ;;
     *)
       echo "ERROR: unknown git workflow '$1' (expected git or gitbutler)" >&2
       return 1
@@ -247,7 +247,7 @@ normalize_git_workflow() {
 normalize_positive_int() {
   local value="$1"
   case "$value" in
-    ''|*[!0-9]*)
+    '' | *[!0-9]*)
       echo "ERROR: expected a positive integer, got '$1'" >&2
       return 1
       ;;
@@ -265,8 +265,8 @@ normalize_yes_no() {
   local value="$1"
   value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
   case "$value" in
-    y|yes|true|1|on) printf 'true' ;;
-    n|no|false|0|off) printf 'false' ;;
+    y | yes | true | 1 | on) printf 'true' ;;
+    n | no | false | 0 | off) printf 'false' ;;
     *) printf '%s' "$value" ;;
   esac
 }
@@ -403,9 +403,9 @@ scaffold_smoke_test_for_profile() {
       fi
       mkdir -p "$project_dir/tests"
       if [ ! -f "$project_dir/tests/__init__.py" ]; then
-        : > "$project_dir/tests/__init__.py"
+        : >"$project_dir/tests/__init__.py"
       fi
-      cat > "$project_dir/tests/test_smoke.py" <<'PYTEST'
+      cat >"$project_dir/tests/test_smoke.py" <<'PYTEST'
 # Placeholder smoke test. Replace with real coverage as soon as there's
 # behavior worth testing — touchstone-run.sh test runs whatever exists here.
 def test_smoke() -> None:
@@ -421,7 +421,7 @@ PYTEST
       mkdir -p "$project_dir/tests"
       # .test.ts works with vitest, jest, and bun test without framework config.
       # describe/it globals are injected by all three.
-      cat > "$project_dir/tests/smoke.test.ts" <<'NODETEST'
+      cat >"$project_dir/tests/smoke.test.ts" <<'NODETEST'
 // Placeholder smoke test. Replace with real coverage as soon as there's
 // behavior worth testing — touchstone-run.sh test runs whatever "test" script
 // package.json declares. Works with vitest/jest/bun test out of the box.
@@ -452,7 +452,7 @@ NODETEST
         package_name="$(sed -n 's/^package \([a-zA-Z_][a-zA-Z0-9_]*\).*/\1/p' "$first_go" | head -1)"
       fi
       package_name="${package_name:-main}"
-      cat > "$project_dir/smoke_test.go" <<GOTEST
+      cat >"$project_dir/smoke_test.go" <<GOTEST
 // Placeholder smoke test. Replace with real coverage as soon as there's
 // behavior worth testing — touchstone-run.sh test runs go test ./... over
 // every package in the module.
@@ -483,7 +483,7 @@ GOTEST
         echo "==> tests: swift tests scaffolded by boilerplate function"
       fi
       ;;
-    generic|"")
+    generic | "")
       echo "==> tests: profile is 'generic' — no default test layout to scaffold"
       echo "          set test_command= in .touchstone-config for your stack"
       ;;
@@ -511,7 +511,7 @@ _profile_has_any_tests_node() {
   # conventions — React/TS projects commonly use Button.spec.tsx.
   matches="$(find "$dir" -maxdepth 4 -type f \
     \( -name '*.test.ts' -o -name '*.test.tsx' -o -name '*.test.js' -o -name '*.test.jsx' \
-       -o -name '*.spec.ts' -o -name '*.spec.tsx' -o -name '*.spec.js' -o -name '*.spec.jsx' \) \
+    -o -name '*.spec.ts' -o -name '*.spec.tsx' -o -name '*.spec.js' -o -name '*.spec.jsx' \) \
     -print -quit 2>/dev/null || true)"
   [ -n "$matches" ]
 }
@@ -550,7 +550,7 @@ scaffold_swift_package_boilerplate() {
 
   mkdir -p "$project_dir/Sources/$pascal_name" "$project_dir/Tests/${pascal_name}Tests"
 
-  cat > "$project_dir/Package.swift" <<SWIFTPKG
+  cat >"$project_dir/Package.swift" <<SWIFTPKG
 // swift-tools-version: 5.10
 import PackageDescription
 
@@ -574,7 +574,7 @@ let package = Package(
 )
 SWIFTPKG
 
-  cat > "$project_dir/Sources/$pascal_name/${pascal_name}App.swift" <<SWIFTAPP
+  cat >"$project_dir/Sources/$pascal_name/${pascal_name}App.swift" <<SWIFTAPP
 import SwiftUI
 
 @main
@@ -598,7 +598,7 @@ struct ContentView: View {
 }
 SWIFTAPP
 
-  cat > "$project_dir/Tests/${pascal_name}Tests/SmokeTests.swift" <<SWIFTTEST
+  cat >"$project_dir/Tests/${pascal_name}Tests/SmokeTests.swift" <<SWIFTTEST
 import XCTest
 @testable import ${pascal_name}
 
@@ -652,7 +652,7 @@ append_profile_gitignore_entries() {
             printf '%s\n' "$entry"
           fi
         done
-      } >> "$gitignore"
+      } >>"$gitignore"
       echo "==> .gitignore: appended Swift / SPM entries"
       ;;
     *)
@@ -673,20 +673,20 @@ resolve_project_type_from_config() {
   if [ -f "$dir/.touchstone-config" ]; then
     while IFS= read -r line || [ -n "$line" ]; do
       line="${line#"${line%%[![:space:]]*}"}"
-      case "$line" in \#*|"") continue ;; esac
+      case "$line" in \#* | "") continue ;; esac
       case "$line" in *=*) ;; *) continue ;; esac
       candidate="${line%%=*}"
       candidate="${candidate#"${candidate%%[![:space:]]*}"}"
       candidate="${candidate%"${candidate##*[![:space:]]}"}"
       case "$candidate" in
-        project_type|profile)
+        project_type | profile)
           value="${line#*=}"
           value="${value#"${value%%[![:space:]]*}"}"
           value="${value%"${value##*[![:space:]]}"}"
           result="$value"
           ;;
       esac
-    done < "$dir/.touchstone-config"
+    done <"$dir/.touchstone-config"
   fi
 
   if [ -z "$result" ] || [ "$result" = "auto" ]; then
@@ -706,7 +706,7 @@ if [ "$#" -lt 1 ]; then
 fi
 
 case "$1" in
-  -h|--help)
+  -h | --help)
     usage
     exit 0
     ;;
@@ -722,51 +722,120 @@ shift
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    -h|--help) usage; exit 0 ;;
-    -y|--yes) YES_MODE=true; shift ;;
-    --no-register) REGISTER=false; REGISTER_REQUESTED=true; shift ;;
-    --register) REGISTER=true; REGISTER_REQUESTED=true; shift ;;
-    --with-cortex) WITH_CORTEX=true; WITH_CORTEX_REQUESTED=true; shift ;;
-    --no-with-cortex) WITH_CORTEX=false; WITH_CORTEX_REQUESTED=true; shift ;;
-    --with-sentinel) WITH_SENTINEL=true; WITH_SENTINEL_REQUESTED=true; shift ;;
-    --no-with-sentinel) WITH_SENTINEL=false; WITH_SENTINEL_REQUESTED=true; shift ;;
-    --initial-commit) INITIAL_COMMIT=true; INITIAL_COMMIT_REQUESTED=true; shift ;;
-    --no-initial-commit) INITIAL_COMMIT=false; INITIAL_COMMIT_REQUESTED=true; shift ;;
-    --github-private) GITHUB_MODE=private; GITHUB_MODE_REQUESTED=true; shift ;;
-    --github-public) GITHUB_MODE=public; GITHUB_MODE_REQUESTED=true; shift ;;
-    --no-github) GITHUB_MODE=none; GITHUB_MODE_REQUESTED=true; shift ;;
-    --skip-language-scaffold) SKIP_LANGUAGE_SCAFFOLD=true; SKIP_LANGUAGE_SCAFFOLD_REQUESTED=true; shift ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    -y | --yes)
+      YES_MODE=true
+      shift
+      ;;
+    --no-register)
+      REGISTER=false
+      REGISTER_REQUESTED=true
+      shift
+      ;;
+    --register)
+      REGISTER=true
+      REGISTER_REQUESTED=true
+      shift
+      ;;
+    --with-cortex)
+      WITH_CORTEX=true
+      WITH_CORTEX_REQUESTED=true
+      shift
+      ;;
+    --no-with-cortex)
+      WITH_CORTEX=false
+      WITH_CORTEX_REQUESTED=true
+      shift
+      ;;
+    --with-sentinel)
+      WITH_SENTINEL=true
+      WITH_SENTINEL_REQUESTED=true
+      shift
+      ;;
+    --no-with-sentinel)
+      WITH_SENTINEL=false
+      WITH_SENTINEL_REQUESTED=true
+      shift
+      ;;
+    --initial-commit)
+      INITIAL_COMMIT=true
+      INITIAL_COMMIT_REQUESTED=true
+      shift
+      ;;
+    --no-initial-commit)
+      INITIAL_COMMIT=false
+      INITIAL_COMMIT_REQUESTED=true
+      shift
+      ;;
+    --github-private)
+      GITHUB_MODE=private
+      GITHUB_MODE_REQUESTED=true
+      shift
+      ;;
+    --github-public)
+      GITHUB_MODE=public
+      GITHUB_MODE_REQUESTED=true
+      shift
+      ;;
+    --no-github)
+      GITHUB_MODE=none
+      GITHUB_MODE_REQUESTED=true
+      shift
+      ;;
+    --skip-language-scaffold)
+      SKIP_LANGUAGE_SCAFFOLD=true
+      SKIP_LANGUAGE_SCAFFOLD_REQUESTED=true
+      shift
+      ;;
     --type)
-      [ "$#" -ge 2 ] || { echo "ERROR: --type requires a value (node, python, swift, rust, go, generic, auto)" >&2; exit 1; }
+      [ "$#" -ge 2 ] || {
+        echo "ERROR: --type requires a value (node, python, swift, rust, go, generic, auto)" >&2
+        exit 1
+      }
       INPUT_TYPE="$(normalize_project_type "$2")"
       # shellcheck disable=SC2034  # reserved for --type-aware branches.
       INPUT_TYPE_REQUESTED=true
       shift 2
       ;;
     --unsafe-paths)
-      [ "$#" -ge 2 ] || { echo "ERROR: --unsafe-paths requires a comma-separated value" >&2; exit 1; }
+      [ "$#" -ge 2 ] || {
+        echo "ERROR: --unsafe-paths requires a comma-separated value" >&2
+        exit 1
+      }
       INPUT_UNSAFE="$2"
       shift 2
       ;;
     --reviewer)
-      [ "$#" -ge 2 ] || { echo "ERROR: --reviewer requires a value (conductor, none, or legacy: codex, claude, gemini, local, auto)" >&2; exit 1; }
+      [ "$#" -ge 2 ] || {
+        echo "ERROR: --reviewer requires a value (conductor, none, or legacy: codex, claude, gemini, local, auto)" >&2
+        exit 1
+      }
       INPUT_REVIEWER="$(normalize_reviewer "$2")"
       REVIEW_CONFIG_REQUESTED=true
       shift 2
       ;;
     --review-routing)
-      [ "$#" -ge 2 ] || { echo "ERROR: --review-routing requires a value (all-hosted, all-local, small-local)" >&2; exit 1; }
+      [ "$#" -ge 2 ] || {
+        echo "ERROR: --review-routing requires a value (all-hosted, all-local, small-local)" >&2
+        exit 1
+      }
       INPUT_REVIEW_ROUTING="$(normalize_review_routing "$2")"
       REVIEW_CONFIG_REQUESTED=true
       shift 2
       ;;
     --small-review-lines)
-      [ "$#" -ge 2 ] || { echo "ERROR: --small-review-lines requires a positive integer" >&2; exit 1; }
+      [ "$#" -ge 2 ] || {
+        echo "ERROR: --small-review-lines requires a positive integer" >&2
+        exit 1
+      }
       INPUT_SMALL_REVIEW_LINES="$(normalize_positive_int "$2")"
       REVIEW_CONFIG_REQUESTED=true
       shift 2
       ;;
-    --no-ai-review|--no-review)
+    --no-ai-review | --no-review)
       INPUT_REVIEWER="none"
       INPUT_REVIEW_ROUTING="none"
       REVIEW_CONFIG_REQUESTED=true
@@ -793,13 +862,19 @@ while [ "$#" -gt 0 ]; do
       shift
       ;;
     --local-review-command)
-      [ "$#" -ge 2 ] || { echo "ERROR: --local-review-command requires a command string" >&2; exit 1; }
+      [ "$#" -ge 2 ] || {
+        echo "ERROR: --local-review-command requires a command string" >&2
+        exit 1
+      }
       INPUT_LOCAL_REVIEW_COMMAND="$2"
       REVIEW_CONFIG_REQUESTED=true
       shift 2
       ;;
     --git-workflow)
-      [ "$#" -ge 2 ] || { echo "ERROR: --git-workflow requires a value (git or gitbutler)" >&2; exit 1; }
+      [ "$#" -ge 2 ] || {
+        echo "ERROR: --git-workflow requires a value (git or gitbutler)" >&2
+        exit 1
+      }
       INPUT_GIT_WORKFLOW="$(normalize_git_workflow "$2")"
       WORKFLOW_CONFIG_REQUESTED=true
       shift 2
@@ -830,8 +905,14 @@ while [ "$#" -gt 0 ]; do
       # for future providers (gitlab, circle). For now only github is shipped.
       if [ "$#" -ge 2 ] && [[ "$2" != --* ]]; then
         case "$2" in
-          github|none) INPUT_CI="$2"; shift 2 ;;
-          *) echo "ERROR: --ci value must be one of: github, none" >&2; exit 1 ;;
+          github | none)
+            INPUT_CI="$2"
+            shift 2
+            ;;
+          *)
+            echo "ERROR: --ci value must be one of: github, none" >&2
+            exit 1
+            ;;
         esac
       else
         INPUT_CI="github"
@@ -846,7 +927,10 @@ while [ "$#" -gt 0 ]; do
       INPUT_SCAFFOLD_TESTS=true
       shift
       ;;
-    *) echo "ERROR: unknown argument '$1'" >&2; exit 1 ;;
+    *)
+      echo "ERROR: unknown argument '$1'" >&2
+      exit 1
+      ;;
   esac
 done
 
@@ -998,7 +1082,7 @@ write_touchstone_manifest() {
     if [ "$INPUT_TYPE" = "python" ]; then
       printf 'scripts/run-pytest-in-venv.sh\n'
     fi
-  } > "$manifest_tmp"
+  } >"$manifest_tmp"
   if copy_file_force "$manifest_tmp" "$PROJECT_DIR/.touchstone-manifest"; then
     rm -f "$manifest_tmp"
   else
@@ -1044,7 +1128,7 @@ set_codex_review_key() {
         print repl
       }
     }
-  ' "$file" > "$tmp_file"
+  ' "$file" >"$tmp_file"
   mv "$tmp_file" "$file"
 }
 
@@ -1054,8 +1138,8 @@ conductor_with_for() {
   # directly. local maps to ollama (closest 2.0 analog; warn below).
   local reviewer="$1"
   case "$reviewer" in
-    auto|conductor|"") printf '' ;;
-    codex|claude|gemini) printf '%s' "$reviewer" ;;
+    auto | conductor | "") printf '' ;;
+    codex | claude | gemini) printf '%s' "$reviewer" ;;
     local) printf 'ollama' ;;
     *) printf '%s' "$reviewer" ;;
   esac
@@ -1150,7 +1234,7 @@ write_review_onboarding_config() {
       printf '# [review.assist]\n'
       printf '# enabled = true\n'
     fi
-  } >> "$file"
+  } >>"$file"
 }
 
 print_review_setup_hint() {
@@ -1301,7 +1385,7 @@ if [ -d "$TOUCHSTONE_ROOT/.git" ]; then
 else
   TOUCHSTONE_SHA="$(cat "$TOUCHSTONE_ROOT/VERSION" 2>/dev/null | tr -d '[:space:]' || echo "unknown")"
 fi
-echo "$TOUCHSTONE_SHA" > "$PROJECT_DIR/.touchstone-version"
+echo "$TOUCHSTONE_SHA" >"$PROJECT_DIR/.touchstone-version"
 echo ""
 echo "==> Wrote .touchstone-version: $TOUCHSTONE_SHA"
 
@@ -1317,7 +1401,7 @@ if [ "$REGISTER" = true ]; then
   touch "$PROJECTS_FILE"
   # Add if not already registered.
   if ! grep -qxF "$PROJECT_DIR" "$PROJECTS_FILE" 2>/dev/null; then
-    echo "$PROJECT_DIR" >> "$PROJECTS_FILE"
+    echo "$PROJECT_DIR" >>"$PROJECTS_FILE"
     echo "==> Registered in $PROJECTS_FILE — opt out next time with --no-register"
   else
     echo "==> Already registered in $PROJECTS_FILE — opt out next time with --no-register"
@@ -1381,54 +1465,54 @@ if [ "$WIZARD_INTERACTIVE" = true ]; then
       INPUT_REVIEW_ASSIST=false
       REVIEW_CONFIG_REQUESTED=true
     else
-    echo ""
-    echo "==> Configure AI review (press Enter for the default):"
-    echo "   Touchstone 2.0 routes every review through Conductor."
-    echo "   Hosted: Conductor auto-picks the best configured provider for each diff."
-    echo "   Local: small diffs go to Ollama (fast/cheap); nothing hosted."
-    echo "   Hybrid: small diffs go to Ollama; larger diffs to Conductor's router."
-    if [ "$(prompt_yes_no "Use AI review before code reaches main?" "true")" = "true" ]; then
-      local_review_style=""
-      read -r -p "   Review style (hosted, local, hybrid) [hosted]: " local_review_style
-      local_review_style="$(normalize_review_routing "${local_review_style:-hosted}")"
+      echo ""
+      echo "==> Configure AI review (press Enter for the default):"
+      echo "   Touchstone 2.0 routes every review through Conductor."
+      echo "   Hosted: Conductor auto-picks the best configured provider for each diff."
+      echo "   Local: small diffs go to Ollama (fast/cheap); nothing hosted."
+      echo "   Hybrid: small diffs go to Ollama; larger diffs to Conductor's router."
+      if [ "$(prompt_yes_no "Use AI review before code reaches main?" "true")" = "true" ]; then
+        local_review_style=""
+        read -r -p "   Review style (hosted, local, hybrid) [hosted]: " local_review_style
+        local_review_style="$(normalize_review_routing "${local_review_style:-hosted}")"
 
-      case "$local_review_style" in
-        all-hosted)
-          INPUT_REVIEW_ROUTING="all-hosted"
-          read -r -p "   Pin a specific provider (e.g. claude, codex, gemini; Enter = Conductor auto-routes): " INPUT_REVIEWER
-          INPUT_REVIEWER="${INPUT_REVIEWER:-conductor}"
-          INPUT_REVIEWER="$(normalize_reviewer "$INPUT_REVIEWER")"
-          ;;
-        all-local)
-          INPUT_REVIEW_ROUTING="all-local"
-          INPUT_REVIEWER="local"
-          ;;
-        small-local)
-          INPUT_REVIEW_ROUTING="small-local"
-          read -r -p "   Pin a provider for larger diffs (e.g. claude, codex, gemini; Enter = Conductor auto-routes): " INPUT_REVIEWER
-          INPUT_REVIEWER="${INPUT_REVIEWER:-conductor}"
-          INPUT_REVIEWER="$(normalize_reviewer "$INPUT_REVIEWER")"
-          read -r -p "   Small-diff cutoff in changed diff lines [400]: " INPUT_SMALL_REVIEW_LINES
-          INPUT_SMALL_REVIEW_LINES="${INPUT_SMALL_REVIEW_LINES:-400}"
-          INPUT_SMALL_REVIEW_LINES="$(normalize_positive_int "$INPUT_SMALL_REVIEW_LINES")"
-          ;;
-      esac
+        case "$local_review_style" in
+          all-hosted)
+            INPUT_REVIEW_ROUTING="all-hosted"
+            read -r -p "   Pin a specific provider (e.g. claude, codex, gemini; Enter = Conductor auto-routes): " INPUT_REVIEWER
+            INPUT_REVIEWER="${INPUT_REVIEWER:-conductor}"
+            INPUT_REVIEWER="$(normalize_reviewer "$INPUT_REVIEWER")"
+            ;;
+          all-local)
+            INPUT_REVIEW_ROUTING="all-local"
+            INPUT_REVIEWER="local"
+            ;;
+          small-local)
+            INPUT_REVIEW_ROUTING="small-local"
+            read -r -p "   Pin a provider for larger diffs (e.g. claude, codex, gemini; Enter = Conductor auto-routes): " INPUT_REVIEWER
+            INPUT_REVIEWER="${INPUT_REVIEWER:-conductor}"
+            INPUT_REVIEWER="$(normalize_reviewer "$INPUT_REVIEWER")"
+            read -r -p "   Small-diff cutoff in changed diff lines [400]: " INPUT_SMALL_REVIEW_LINES
+            INPUT_SMALL_REVIEW_LINES="${INPUT_SMALL_REVIEW_LINES:-400}"
+            INPUT_SMALL_REVIEW_LINES="$(normalize_positive_int "$INPUT_SMALL_REVIEW_LINES")"
+            ;;
+        esac
 
-      INPUT_REVIEW_AUTOFIX="$(prompt_yes_no "Let the AI auto-fix low-risk issues?" "false")"
-      # Peer review is retired in 2.0.0 — returns in 2.1 via `conductor call --exclude`.
-      INPUT_REVIEW_ASSIST=false
+        INPUT_REVIEW_AUTOFIX="$(prompt_yes_no "Let the AI auto-fix low-risk issues?" "false")"
+        # Peer review is retired in 2.0.0 — returns in 2.1 via `conductor call --exclude`.
+        INPUT_REVIEW_ASSIST=false
 
-      if [ "$INPUT_REVIEW_AUTOFIX" = "true" ] && [ -z "$INPUT_UNSAFE" ]; then
-        read -r -p "   High-scrutiny paths the AI must never auto-fix (comma-separated, e.g., src/auth/,migrations/): " INPUT_UNSAFE
+        if [ "$INPUT_REVIEW_AUTOFIX" = "true" ] && [ -z "$INPUT_UNSAFE" ]; then
+          read -r -p "   High-scrutiny paths the AI must never auto-fix (comma-separated, e.g., src/auth/,migrations/): " INPUT_UNSAFE
+        fi
+      else
+        INPUT_REVIEWER="none"
+        INPUT_REVIEW_ROUTING="none"
+        INPUT_REVIEW_AUTOFIX=false
+        INPUT_REVIEW_ASSIST=false
       fi
-    else
-      INPUT_REVIEWER="none"
-      INPUT_REVIEW_ROUTING="none"
-      INPUT_REVIEW_AUTOFIX=false
-      INPUT_REVIEW_ASSIST=false
-    fi
-    REVIEW_CONFIG_REQUESTED=true
-    fi  # YES_MODE else
+      REVIEW_CONFIG_REQUESTED=true
+    fi # YES_MODE else
   fi
 
   if [ "$WORKFLOW_CONFIG_REQUESTED" = false ]; then
@@ -1583,8 +1667,8 @@ if [ -n "$INPUT_NAME" ] || [ -n "$INPUT_DESC" ] || [ -n "$INPUT_TEST" ] || [ -n 
   if [ -n "$INPUT_UNSAFE" ]; then
     unsafe_paths_input=()
     local_unsafe_paths=()
-    IFS=',' read -r -a unsafe_paths_input <<< "$INPUT_UNSAFE"
-    for unsafe_path in "${unsafe_paths_input[@]}"; do  # empty-array-guard: safe — populated by IFS-split of non-empty INPUT_UNSAFE
+    IFS=',' read -r -a unsafe_paths_input <<<"$INPUT_UNSAFE"
+    for unsafe_path in "${unsafe_paths_input[@]}"; do # empty-array-guard: safe — populated by IFS-split of non-empty INPUT_UNSAFE
       unsafe_path="$(trim "$unsafe_path")"
       [ -z "$unsafe_path" ] && continue
       local_unsafe_paths+=("$unsafe_path")
@@ -1631,7 +1715,7 @@ if [ ! -f "$PROJECT_DIR/.touchstone-config" ]; then
     printf 'build_command=\n'
     printf 'test_command=%s\n' "$INPUT_TEST"
     printf 'validate_command=\n'
-  } > "$PROJECT_DIR/.touchstone-config"
+  } >"$PROJECT_DIR/.touchstone-config"
   echo "==> Wrote .touchstone-config: project_type=$INPUT_TYPE"
 else
   echo "==> .touchstone-config already exists; left unchanged."
@@ -1714,7 +1798,7 @@ if [ "$WITH_CORTEX" = true ] && [ "$RE_INIT" = false ]; then
     echo "==> Initializing Cortex ..."
     cortex_args=()
     if [ "$YES_MODE" = true ]; then cortex_args+=("--yes"); fi
-    if ( cd "$PROJECT_DIR" && cortex init ${cortex_args[@]+"${cortex_args[@]}"} ); then
+    if (cd "$PROJECT_DIR" && cortex init ${cortex_args[@]+"${cortex_args[@]}"}); then
       :
     else
       echo "==> Cortex init failed (continuing)." >&2
@@ -1732,7 +1816,7 @@ if [ "$WITH_SENTINEL" = true ] && [ "$RE_INIT" = false ]; then
     echo "==> Initializing Sentinel ..."
     sentinel_args=()
     if [ "$YES_MODE" = true ]; then sentinel_args+=("--yes"); fi
-    if ( cd "$PROJECT_DIR" && sentinel init ${sentinel_args[@]+"${sentinel_args[@]}"} ); then
+    if (cd "$PROJECT_DIR" && sentinel init ${sentinel_args[@]+"${sentinel_args[@]}"}); then
       :
     else
       echo "==> Sentinel init failed (continuing)." >&2
@@ -1864,7 +1948,7 @@ if { [ "$GITHUB_MODE" = "private" ] || [ "$GITHUB_MODE" = "public" ]; } && [ "$R
     echo ""
     echo "==> Creating GitHub repo ($GITHUB_MODE) ..."
     gh_visibility_flag="--${GITHUB_MODE}"
-    if ( cd "$PROJECT_DIR" && gh repo create "$(basename "$PROJECT_DIR")" "$gh_visibility_flag" --source . --push ); then
+    if (cd "$PROJECT_DIR" && gh repo create "$(basename "$PROJECT_DIR")" "$gh_visibility_flag" --source . --push); then
       :
     else
       echo "==> gh repo create failed (continuing)." >&2

--- a/bootstrap/review.sh
+++ b/bootstrap/review.sh
@@ -43,16 +43,39 @@ json_flag=""
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    --dry-run) dry_run=true; shift ;;
+    --dry-run)
+      dry_run=true
+      shift
+      ;;
     --mode)
-      [ "$#" -ge 2 ] || { echo "ERROR: --mode requires a value" >&2; exit 1; }
-      mode_override="$2"; shift 2 ;;
+      [ "$#" -ge 2 ] || {
+        echo "ERROR: --mode requires a value" >&2
+        exit 1
+      }
+      mode_override="$2"
+      shift 2
+      ;;
     --base)
-      [ "$#" -ge 2 ] || { echo "ERROR: --base requires a ref" >&2; exit 1; }
-      base_override="$2"; shift 2 ;;
-    --json) json_flag="--json"; shift ;;
-    -h|--help) usage; exit 0 ;;
-    *) echo "ERROR: unknown argument '$1'" >&2; usage >&2; exit 1 ;;
+      [ "$#" -ge 2 ] || {
+        echo "ERROR: --base requires a ref" >&2
+        exit 1
+      }
+      base_override="$2"
+      shift 2
+      ;;
+    --json)
+      json_flag="--json"
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument '$1'" >&2
+      usage >&2
+      exit 1
+      ;;
   esac
 done
 
@@ -71,7 +94,10 @@ if ! command -v conductor >/dev/null 2>&1; then
 fi
 
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
-[ -n "$REPO_ROOT" ] || { echo "ERROR: not inside a git repository." >&2; exit 1; }
+[ -n "$REPO_ROOT" ] || {
+  echo "ERROR: not inside a git repository." >&2
+  exit 1
+}
 
 CONFIG_FILE="$REPO_ROOT/.codex-review.toml"
 
@@ -95,10 +121,17 @@ CONFIG_MODE=""
 
 strip_quotes() {
   local v="$1"
-  v="${v# }"; v="${v% }"
+  v="${v# }"
+  v="${v% }"
   case "$v" in
-    \"*\") v="${v#\"}"; v="${v%\"}" ;;
-    \'*\') v="${v#\'}"; v="${v%\'}" ;;
+    \"*\")
+      v="${v#\"}"
+      v="${v%\"}"
+      ;;
+    \'*\')
+      v="${v#\'}"
+      v="${v%\'}"
+      ;;
   esac
   printf '%s' "$v"
 }
@@ -109,8 +142,8 @@ normalize_bool() {
   value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
 
   case "$value" in
-    true|1|yes|on) printf 'true' ;;
-    false|0|no|off) printf 'false' ;;
+    true | 1 | yes | on) printf 'true' ;;
+    false | 0 | no | off) printf 'false' ;;
     *) printf '%s' "$value" ;;
   esac
 }
@@ -127,32 +160,32 @@ if [ -f "$CONFIG_FILE" ]; then
     local value="$3"
 
     case "$section" in
-      "codex_review"|"")
+      "codex_review" | "")
         case "$key" in
           mode) CONFIG_MODE="$(toml_unquote "$value")" ;;
         esac
         ;;
       "review.conductor")
         case "$key" in
-          prefer)  CONDUCTOR_PREFER="$(toml_unquote "$value")" ;;
-          effort)  CONDUCTOR_EFFORT="$(toml_unquote "$value")" ;;
-          tags)    CONDUCTOR_TAGS="$(toml_normalize_array "$value")" ;;
-          with)    CONDUCTOR_WITH="$(toml_unquote "$value")" ;;
+          prefer) CONDUCTOR_PREFER="$(toml_unquote "$value")" ;;
+          effort) CONDUCTOR_EFFORT="$(toml_unquote "$value")" ;;
+          tags) CONDUCTOR_TAGS="$(toml_normalize_array "$value")" ;;
+          with) CONDUCTOR_WITH="$(toml_unquote "$value")" ;;
           exclude) CONDUCTOR_EXCLUDE="$(toml_normalize_array "$value")" ;;
         esac
         ;;
       "review.routing")
         case "$key" in
           enabled) ROUTING_ENABLED="$(normalize_bool "$value")" ;;
-          small_max_diff_lines|small_diff_lines) ROUTING_SMALL_MAX_DIFF_LINES="$value" ;;
-          small_with)    ROUTING_SMALL_WITH="$(toml_unquote "$value")" ;;
-          small_prefer)  ROUTING_SMALL_PREFER="$(toml_unquote "$value")" ;;
-          small_effort)  ROUTING_SMALL_EFFORT="$(toml_unquote "$value")" ;;
-          small_tags)    ROUTING_SMALL_TAGS="$(toml_normalize_array "$value")" ;;
-          large_with)    ROUTING_LARGE_WITH="$(toml_unquote "$value")" ;;
-          large_prefer)  ROUTING_LARGE_PREFER="$(toml_unquote "$value")" ;;
-          large_effort)  ROUTING_LARGE_EFFORT="$(toml_unquote "$value")" ;;
-          large_tags)    ROUTING_LARGE_TAGS="$(toml_normalize_array "$value")" ;;
+          small_max_diff_lines | small_diff_lines) ROUTING_SMALL_MAX_DIFF_LINES="$value" ;;
+          small_with) ROUTING_SMALL_WITH="$(toml_unquote "$value")" ;;
+          small_prefer) ROUTING_SMALL_PREFER="$(toml_unquote "$value")" ;;
+          small_effort) ROUTING_SMALL_EFFORT="$(toml_unquote "$value")" ;;
+          small_tags) ROUTING_SMALL_TAGS="$(toml_normalize_array "$value")" ;;
+          large_with) ROUTING_LARGE_WITH="$(toml_unquote "$value")" ;;
+          large_prefer) ROUTING_LARGE_PREFER="$(toml_unquote "$value")" ;;
+          large_effort) ROUTING_LARGE_EFFORT="$(toml_unquote "$value")" ;;
+          large_tags) ROUTING_LARGE_TAGS="$(toml_normalize_array "$value")" ;;
         esac
         ;;
     esac
@@ -168,13 +201,13 @@ fi
 # the translation block in hooks/codex-review.sh (keep in sync).
 if [ -n "${TOUCHSTONE_REVIEWER:-}" ]; then
   case "$TOUCHSTONE_REVIEWER" in
-    auto|conductor) ;;
+    auto | conductor) ;;
     local)
       echo "==> NOTE: TOUCHSTONE_REVIEWER=local is deprecated in 2.0.0." >&2
       echo "    Migrating to: TOUCHSTONE_CONDUCTOR_WITH=ollama (the closest 2.0 analog)." >&2
       [ -z "${TOUCHSTONE_CONDUCTOR_WITH:-}" ] && export TOUCHSTONE_CONDUCTOR_WITH="ollama"
       ;;
-    codex|claude|gemini|ollama)
+    codex | claude | gemini | ollama)
       echo "==> NOTE: TOUCHSTONE_REVIEWER=$TOUCHSTONE_REVIEWER is deprecated in 2.0.0." >&2
       echo "    Pin an underlying provider with: TOUCHSTONE_CONDUCTOR_WITH=$TOUCHSTONE_REVIEWER" >&2
       [ -z "${TOUCHSTONE_CONDUCTOR_WITH:-}" ] && export TOUCHSTONE_CONDUCTOR_WITH="$TOUCHSTONE_REVIEWER"
@@ -218,24 +251,24 @@ routing_reason="review.routing.enabled=false"
 if [ "$ROUTING_ENABLED" = true ]; then
   routing_reason="diff line count unavailable for base $BASE"
   case "$ROUTING_SMALL_MAX_DIFF_LINES" in
-    ''|*[!0-9]*)
+    '' | *[!0-9]*)
       routing_reason="invalid review.routing.small_max_diff_lines='$ROUTING_SMALL_MAX_DIFF_LINES'"
       ;;
     *)
       if [ "$diff_line_count_available" = true ] && [ "$DIFF_LINE_COUNT" -le "$ROUTING_SMALL_MAX_DIFF_LINES" ] 2>/dev/null; then
         routing_decision="small"
         routing_reason="$DIFF_LINE_COUNT <= $ROUTING_SMALL_MAX_DIFF_LINES diff lines"
-        [ -n "$ROUTING_SMALL_WITH" ]   && CONDUCTOR_WITH="${TOUCHSTONE_CONDUCTOR_WITH:-$ROUTING_SMALL_WITH}"
+        [ -n "$ROUTING_SMALL_WITH" ] && CONDUCTOR_WITH="${TOUCHSTONE_CONDUCTOR_WITH:-$ROUTING_SMALL_WITH}"
         [ -n "$ROUTING_SMALL_PREFER" ] && CONDUCTOR_PREFER="${TOUCHSTONE_CONDUCTOR_PREFER:-$ROUTING_SMALL_PREFER}"
         [ -n "$ROUTING_SMALL_EFFORT" ] && CONDUCTOR_EFFORT="${TOUCHSTONE_CONDUCTOR_EFFORT:-$ROUTING_SMALL_EFFORT}"
-        [ -n "$ROUTING_SMALL_TAGS" ]   && CONDUCTOR_TAGS="${TOUCHSTONE_CONDUCTOR_TAGS:-$ROUTING_SMALL_TAGS}"
+        [ -n "$ROUTING_SMALL_TAGS" ] && CONDUCTOR_TAGS="${TOUCHSTONE_CONDUCTOR_TAGS:-$ROUTING_SMALL_TAGS}"
       elif [ "$diff_line_count_available" = true ]; then
         routing_decision="large"
         routing_reason="$DIFF_LINE_COUNT > $ROUTING_SMALL_MAX_DIFF_LINES diff lines"
-        [ -n "$ROUTING_LARGE_WITH" ]   && CONDUCTOR_WITH="${TOUCHSTONE_CONDUCTOR_WITH:-$ROUTING_LARGE_WITH}"
+        [ -n "$ROUTING_LARGE_WITH" ] && CONDUCTOR_WITH="${TOUCHSTONE_CONDUCTOR_WITH:-$ROUTING_LARGE_WITH}"
         [ -n "$ROUTING_LARGE_PREFER" ] && CONDUCTOR_PREFER="${TOUCHSTONE_CONDUCTOR_PREFER:-$ROUTING_LARGE_PREFER}"
         [ -n "$ROUTING_LARGE_EFFORT" ] && CONDUCTOR_EFFORT="${TOUCHSTONE_CONDUCTOR_EFFORT:-$ROUTING_LARGE_EFFORT}"
-        [ -n "$ROUTING_LARGE_TAGS" ]   && CONDUCTOR_TAGS="${TOUCHSTONE_CONDUCTOR_TAGS:-$ROUTING_LARGE_TAGS}"
+        [ -n "$ROUTING_LARGE_TAGS" ] && CONDUCTOR_TAGS="${TOUCHSTONE_CONDUCTOR_TAGS:-$ROUTING_LARGE_TAGS}"
       fi
       ;;
   esac
@@ -244,10 +277,10 @@ fi
 # Mode → tools (mirror the adapter in hooks/codex-review.sh).
 tools=""
 case "$REVIEW_MODE" in
-  diff-only)   tools="" ;;
+  diff-only) tools="" ;;
   review-only) tools="Read,Grep,Glob,Bash" ;;
-  no-tests)    tools="Read,Grep,Glob,Edit,Write" ;;
-  fix)         tools="Read,Grep,Glob,Bash,Edit,Write" ;;
+  no-tests) tools="Read,Grep,Glob,Edit,Write" ;;
+  fix) tools="Read,Grep,Glob,Bash,Edit,Write" ;;
   *)
     echo "WARNING: unknown REVIEW_MODE='$REVIEW_MODE' — defaulting to review-only flags." >&2
     tools="Read,Grep,Glob,Bash"
@@ -277,12 +310,12 @@ if [ -n "$CONDUCTOR_WITH" ]; then
   exit 0
 fi
 
-[ -n "$CONDUCTOR_PREFER" ]  && args+=(--prefer  "$CONDUCTOR_PREFER")
-[ -n "$CONDUCTOR_EFFORT" ]  && args+=(--effort  "$CONDUCTOR_EFFORT")
-[ -n "$CONDUCTOR_TAGS" ]    && args+=(--tags    "$CONDUCTOR_TAGS")
+[ -n "$CONDUCTOR_PREFER" ] && args+=(--prefer "$CONDUCTOR_PREFER")
+[ -n "$CONDUCTOR_EFFORT" ] && args+=(--effort "$CONDUCTOR_EFFORT")
+[ -n "$CONDUCTOR_TAGS" ] && args+=(--tags "$CONDUCTOR_TAGS")
 [ -n "$CONDUCTOR_EXCLUDE" ] && args+=(--exclude "$CONDUCTOR_EXCLUDE")
-[ -n "$tools" ]             && args+=(--tools   "$tools")
-[ -n "$json_flag" ]         && args+=("$json_flag")
+[ -n "$tools" ] && args+=(--tools "$tools")
+[ -n "$json_flag" ] && args+=("$json_flag")
 
 if [ -z "$json_flag" ]; then
   echo "==> touchstone review --dry-run"

--- a/bootstrap/sync-all.sh
+++ b/bootstrap/sync-all.sh
@@ -25,14 +25,26 @@ CHECK_ONLY=false
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    --dry-run|-n) DRY_RUN="--dry-run"; shift ;;
-    --pull-first) PULL_FIRST=true; shift ;;
-    --check) CHECK_ONLY=true; shift ;;
-    -h|--help)
+    --dry-run | -n)
+      DRY_RUN="--dry-run"
+      shift
+      ;;
+    --pull-first)
+      PULL_FIRST=true
+      shift
+      ;;
+    --check)
+      CHECK_ONLY=true
+      shift
+      ;;
+    -h | --help)
       sed -n '3,14p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
-    *) echo "ERROR: unknown argument '$1'" >&2; exit 1 ;;
+    *)
+      echo "ERROR: unknown argument '$1'" >&2
+      exit 1
+      ;;
   esac
 done
 
@@ -75,7 +87,7 @@ if [ "$CHECK_ONLY" = true ]; then
       echo "  ! $(basename "$project_dir") — needs sync"
       BEHIND=$((BEHIND + 1))
     fi
-  done < "$PROJECTS_FILE"
+  done <"$PROJECTS_FILE"
   echo ""
   if [ "$BEHIND" -eq 0 ]; then
     echo "All $TOTAL projects are up to date."
@@ -114,7 +126,7 @@ while IFS= read -r project_dir; do
     echo "==> FAILED: $project_dir"
     FAILED=$((FAILED + 1))
   fi
-done < "$PROJECTS_FILE"
+done <"$PROJECTS_FILE"
 
 echo ""
 echo "================================================================"

--- a/bootstrap/update-project.sh
+++ b/bootstrap/update-project.sh
@@ -37,21 +37,43 @@ usage() {
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    --dry-run|-n) DRY_RUN=true; shift ;;
-    --check) CHECK_ONLY=true; shift ;;
-    --ship) SHIP=true; shift ;;
-    --no-ship) SHIP=false; shift ;;
-    --in-place|--no-branch) IN_PLACE=true; shift ;;
+    --dry-run | -n)
+      DRY_RUN=true
+      shift
+      ;;
+    --check)
+      CHECK_ONLY=true
+      shift
+      ;;
+    --ship)
+      SHIP=true
+      shift
+      ;;
+    --no-ship)
+      SHIP=false
+      shift
+      ;;
+    --in-place | --no-branch)
+      IN_PLACE=true
+      shift
+      ;;
     --branch)
-      [ "$#" -ge 2 ] || { echo "ERROR: --branch requires a value" >&2; exit 1; }
+      [ "$#" -ge 2 ] || {
+        echo "ERROR: --branch requires a value" >&2
+        exit 1
+      }
       REQUESTED_BRANCH="$2"
       shift 2
       ;;
-    -h|--help)
+    -h | --help)
       usage
       exit 0
       ;;
-    *) echo "ERROR: unknown argument '$1'" >&2; usage >&2; exit 1 ;;
+    *)
+      echo "ERROR: unknown argument '$1'" >&2
+      usage >&2
+      exit 1
+      ;;
   esac
 done
 
@@ -104,8 +126,8 @@ CODEX_REVIEW_TOML="$PROJECT_DIR/.codex-review.toml"
 NEEDS_CODEX_REVIEW_MIGRATION=false
 if [ "$DRY_RUN" = false ] && [ "$CHECK_ONLY" = false ] && [ -f "$CODEX_REVIEW_TOML" ]; then
   if grep -qE '^[[:space:]]*reviewers[[:space:]]*=[[:space:]]*\[' "$CODEX_REVIEW_TOML" \
-    || grep -qE '^\[review\.local\]'   "$CODEX_REVIEW_TOML" \
-    || grep -qE '^\[review\.assist\]'  "$CODEX_REVIEW_TOML" \
+    || grep -qE '^\[review\.local\]' "$CODEX_REVIEW_TOML" \
+    || grep -qE '^\[review\.assist\]' "$CODEX_REVIEW_TOML" \
     || grep -qE '^[[:space:]]*(small|large)_reviewers[[:space:]]*=[[:space:]]*\[' "$CODEX_REVIEW_TOML"; then
     NEEDS_CODEX_REVIEW_MIGRATION=true
   fi
@@ -163,9 +185,9 @@ snapshot_touchstone_metadata() {
   if [ -f "$PROJECT_DIR/.touchstone-manifest" ]; then
     cp "$PROJECT_DIR/.touchstone-manifest" "$ROLLBACK_TMP_DIR/.touchstone-manifest"
   elif [ -e "$PROJECT_DIR/.touchstone-manifest" ]; then
-    : > "$ROLLBACK_TMP_DIR/.touchstone-manifest.nonfile"
+    : >"$ROLLBACK_TMP_DIR/.touchstone-manifest.nonfile"
   else
-    : > "$ROLLBACK_TMP_DIR/.touchstone-manifest.missing"
+    : >"$ROLLBACK_TMP_DIR/.touchstone-manifest.missing"
   fi
 }
 
@@ -290,8 +312,8 @@ if [ "$NEEDS_CODEX_REVIEW_MIGRATION" = true ]; then
   echo "==> Migrating .codex-review.toml from v1.x → v2.x shape..."
   if (
     cd "$PROJECT_DIR" \
-    && bash "$TOUCHSTONE_ROOT/bootstrap/migrate-review-config.sh" --no-backup
-  ) > "$PROJECT_DIR/.touchstone-migrate-codex-review.log" 2>&1; then
+      && bash "$TOUCHSTONE_ROOT/bootstrap/migrate-review-config.sh" --no-backup
+  ) >"$PROJECT_DIR/.touchstone-migrate-codex-review.log" 2>&1; then
     rm -f "$PROJECT_DIR/.touchstone-migrate-codex-review.log"
     echo "    .codex-review.toml: rewrote v1.x reviewer cascade to v2.x conductor shape."
     echo "    The migration warning in scripts/codex-review.sh will no longer fire on push."
@@ -559,7 +581,7 @@ write_touchstone_manifest() {
         done
       done
     fi
-  } > "$manifest"
+  } >"$manifest"
 }
 
 # Ensure scripts are executable and write touchstone metadata.
@@ -567,7 +589,7 @@ if [ "$DRY_RUN" = false ]; then
   if [ -d "$PROJECT_DIR/scripts" ]; then
     chmod +x "$PROJECT_DIR/scripts/"*.sh 2>/dev/null || true
   fi
-  echo "$CURRENT_SHA" > "$PROJECT_DIR/.touchstone-version"
+  echo "$CURRENT_SHA" >"$PROJECT_DIR/.touchstone-version"
   write_touchstone_manifest
 fi
 
@@ -579,8 +601,8 @@ echo "    Prototype shim runner available for evaluation: touchstone run-script 
 # Reinstall pre-commit hook shims so a drifted or empty .git/hooks/ gets repaired.
 # The helper is idempotent; it skips silently when there's nothing to do.
 if [ "$DRY_RUN" = false ] \
-   && [ -f "$PROJECT_DIR/.pre-commit-config.yaml" ] \
-   && { [ ! -f "$PROJECT_DIR/.git/hooks/pre-commit" ] || [ ! -f "$PROJECT_DIR/.git/hooks/pre-push" ]; }; then
+  && [ -f "$PROJECT_DIR/.pre-commit-config.yaml" ] \
+  && { [ ! -f "$PROJECT_DIR/.git/hooks/pre-commit" ] || [ ! -f "$PROJECT_DIR/.git/hooks/pre-push" ]; }; then
   echo ""
   touchstone_install_hooks "$PROJECT_DIR" || true
 fi

--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -323,21 +323,24 @@ log_skip_event() {
     # Guard against `set -euo pipefail` propagating a failed pipeline up
     # to the hook's exit code — log_skip_event must never block a push,
     # even on an unreadable log file or a TOCTOU race against rotation.
-    line_count="$(wc -l < "$log_file" 2>/dev/null | tr -d ' ')" || line_count=0
+    line_count="$(wc -l <"$log_file" 2>/dev/null | tr -d ' ')" || line_count=0
     line_count="${line_count:-0}"
     if [ "$line_count" -ge "$TOUCHSTONE_REVIEW_LOG_MAX_LINES" ]; then
       keep_lines=$((TOUCHSTONE_REVIEW_LOG_MAX_LINES - 1))
-      tail -n "$keep_lines" "$log_file" > "$tmp_file" 2>/dev/null || : > "$tmp_file"
+      tail -n "$keep_lines" "$log_file" >"$tmp_file" 2>/dev/null || : >"$tmp_file"
     else
-      cat "$log_file" > "$tmp_file" 2>/dev/null || : > "$tmp_file"
+      cat "$log_file" >"$tmp_file" 2>/dev/null || : >"$tmp_file"
     fi
   else
-    : > "$tmp_file"
+    : >"$tmp_file"
   fi
 
   printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
     "$timestamp" "$REPO_ROOT" "$branch" "$sha" "$reason" "$detail" \
-    >> "$tmp_file" 2>/dev/null || { rm -f "$tmp_file" 2>/dev/null; return 0; }
+    >>"$tmp_file" 2>/dev/null || {
+    rm -f "$tmp_file" 2>/dev/null
+    return 0
+  }
 
   mv "$tmp_file" "$log_file" 2>/dev/null || rm -f "$tmp_file" 2>/dev/null
   return 0
@@ -377,8 +380,8 @@ CONDUCTOR_TAGS=""
 CONDUCTOR_EXCLUDE=""
 ROUTING_ENABLED=true
 ROUTING_SMALL_MAX_DIFF_LINES=400
-ROUTING_SMALL_REVIEWERS=()   # legacy 1.x shape; retained for back-compat parsing
-ROUTING_LARGE_REVIEWERS=()   # legacy 1.x shape; retained for back-compat parsing
+ROUTING_SMALL_REVIEWERS=() # legacy 1.x shape; retained for back-compat parsing
+ROUTING_LARGE_REVIEWERS=() # legacy 1.x shape; retained for back-compat parsing
 # 2.0 routing knobs — override CONDUCTOR_* for small vs large diffs.
 ROUTING_SMALL_WITH=""
 ROUTING_SMALL_PREFER="cheapest"
@@ -428,8 +431,14 @@ strip_toml_string() {
   local value="$1"
   value="$(trim "$value")"
   case "$value" in
-    \"*\") value="${value#\"}"; value="${value%\"}" ;;
-    \'*\') value="${value#\'}"; value="${value%\'}" ;;
+    \"*\")
+      value="${value#\"}"
+      value="${value%\"}"
+      ;;
+    \'*\')
+      value="${value#\'}"
+      value="${value%\'}"
+      ;;
   esac
   printf '%s' "$value"
 }
@@ -487,8 +496,14 @@ append_unsafe_path() {
   value="$(trim "$value")"
 
   case "$value" in
-    \"*\") value="${value#\"}"; value="${value%\"}" ;;
-    \'*\') value="${value#\'}"; value="${value%\'}" ;;
+    \"*\")
+      value="${value#\"}"
+      value="${value%\"}"
+      ;;
+    \'*\')
+      value="${value#\'}"
+      value="${value%\'}"
+      ;;
   esac
 
   [ -z "$value" ] && return
@@ -508,7 +523,7 @@ append_unsafe_paths_csv() {
 
   [ -n "$csv" ] || return 0
 
-  IFS=',' read -r -a items <<< "$csv"
+  IFS=',' read -r -a items <<<"$csv"
   for item in "${items[@]}"; do
     append_unsafe_path "$item"
   done
@@ -521,8 +536,14 @@ append_prompt_context_path() {
   value="$(trim "$value")"
 
   case "$value" in
-    \"*\") value="${value#\"}"; value="${value%\"}" ;;
-    \'*\') value="${value#\'}"; value="${value%\'}" ;;
+    \"*\")
+      value="${value#\"}"
+      value="${value%\"}"
+      ;;
+    \'*\')
+      value="${value#\'}"
+      value="${value%\'}"
+      ;;
   esac
 
   [ -z "$value" ] && return
@@ -542,7 +563,7 @@ append_prompt_context_paths_csv() {
 
   [ -n "$csv" ] || return 0
 
-  IFS=',' read -r -a items <<< "$csv"
+  IFS=',' read -r -a items <<<"$csv"
   for item in "${items[@]}"; do
     append_prompt_context_path "$item"
   done
@@ -554,8 +575,14 @@ append_reviewer() {
   value="${value%,}"
   value="$(trim "$value")"
   case "$value" in
-    \"*\") value="${value#\"}"; value="${value%\"}" ;;
-    \'*\') value="${value#\'}"; value="${value%\'}" ;;
+    \"*\")
+      value="${value#\"}"
+      value="${value%\"}"
+      ;;
+    \'*\')
+      value="${value#\'}"
+      value="${value%\'}"
+      ;;
   esac
   [ -z "$value" ] && return
   REVIEWER_CASCADE+=("$value")
@@ -565,7 +592,7 @@ append_reviewers_csv() {
   local csv="$1" item
   local -a items=()
   [ -n "$csv" ] || return 0
-  IFS=',' read -r -a items <<< "$csv"
+  IFS=',' read -r -a items <<<"$csv"
   for item in "${items[@]}"; do
     append_reviewer "$item"
   done
@@ -577,8 +604,14 @@ append_routing_small_reviewer() {
   value="${value%,}"
   value="$(trim "$value")"
   case "$value" in
-    \"*\") value="${value#\"}"; value="${value%\"}" ;;
-    \'*\') value="${value#\'}"; value="${value%\'}" ;;
+    \"*\")
+      value="${value#\"}"
+      value="${value%\"}"
+      ;;
+    \'*\')
+      value="${value#\'}"
+      value="${value%\'}"
+      ;;
   esac
   [ -z "$value" ] && return
   ROUTING_SMALL_REVIEWERS+=("$value")
@@ -588,7 +621,7 @@ append_routing_small_reviewers_csv() {
   local csv="$1" item
   local -a items=()
   [ -n "$csv" ] || return 0
-  IFS=',' read -r -a items <<< "$csv"
+  IFS=',' read -r -a items <<<"$csv"
   for item in "${items[@]}"; do
     append_routing_small_reviewer "$item"
   done
@@ -600,8 +633,14 @@ append_routing_large_reviewer() {
   value="${value%,}"
   value="$(trim "$value")"
   case "$value" in
-    \"*\") value="${value#\"}"; value="${value%\"}" ;;
-    \'*\') value="${value#\'}"; value="${value%\'}" ;;
+    \"*\")
+      value="${value#\"}"
+      value="${value%\"}"
+      ;;
+    \'*\')
+      value="${value#\'}"
+      value="${value%\'}"
+      ;;
   esac
   [ -z "$value" ] && return
   ROUTING_LARGE_REVIEWERS+=("$value")
@@ -611,7 +650,7 @@ append_routing_large_reviewers_csv() {
   local csv="$1" item
   local -a items=()
   [ -n "$csv" ] || return 0
-  IFS=',' read -r -a items <<< "$csv"
+  IFS=',' read -r -a items <<<"$csv"
   for item in "${items[@]}"; do
     append_routing_large_reviewer "$item"
   done
@@ -623,8 +662,14 @@ append_assist_helper() {
   value="${value%,}"
   value="$(trim "$value")"
   case "$value" in
-    \"*\") value="${value#\"}"; value="${value%\"}" ;;
-    \'*\') value="${value#\'}"; value="${value%\'}" ;;
+    \"*\")
+      value="${value#\"}"
+      value="${value%\"}"
+      ;;
+    \'*\')
+      value="${value#\'}"
+      value="${value%\'}"
+      ;;
   esac
   [ -z "$value" ] && return
   ASSIST_HELPERS+=("$value")
@@ -634,7 +679,7 @@ append_assist_helpers_csv() {
   local csv="$1" item
   local -a items=()
   [ -n "$csv" ] || return 0
-  IFS=',' read -r -a items <<< "$csv"
+  IFS=',' read -r -a items <<<"$csv"
   for item in "${items[@]}"; do
     append_assist_helper "$item"
   done
@@ -650,8 +695,8 @@ normalize_bool() {
   value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
 
   case "$value" in
-    true|1|yes|on) printf 'true' ;;
-    false|0|no|off) printf 'false' ;;
+    true | 1 | yes | on) printf 'true' ;;
+    false | 0 | no | off) printf 'false' ;;
     *) printf '%s' "$value" ;;
   esac
 }
@@ -660,8 +705,14 @@ toml_string_value() {
   local value="$1"
   value="$(trim "$value")"
   case "$value" in
-    \"*\") value="${value#\"}"; value="${value%\"}" ;;
-    \'*\') value="${value#\'}"; value="${value%\'}" ;;
+    \"*\")
+      value="${value#\"}"
+      value="${value%\"}"
+      ;;
+    \'*\')
+      value="${value#\'}"
+      value="${value%\'}"
+      ;;
   esac
   printf '%s' "$value"
 }
@@ -688,25 +739,25 @@ if [ -f "$CONFIG_FILE" ]; then
     case "$section" in
       "review.conductor")
         case "$key" in
-          prefer)  CONDUCTOR_PREFER="${CONDUCTOR_PREFER:-$(toml_unquote "$value")}" ;;
-          effort)  CONDUCTOR_EFFORT="${CONDUCTOR_EFFORT:-$(toml_unquote "$value")}" ;;
-          tags)    CONDUCTOR_TAGS="${CONDUCTOR_TAGS:-$(toml_normalize_array "$value")}" ;;
-          with)    CONDUCTOR_WITH="${CONDUCTOR_WITH:-$(toml_unquote "$value")}" ;;
+          prefer) CONDUCTOR_PREFER="${CONDUCTOR_PREFER:-$(toml_unquote "$value")}" ;;
+          effort) CONDUCTOR_EFFORT="${CONDUCTOR_EFFORT:-$(toml_unquote "$value")}" ;;
+          tags) CONDUCTOR_TAGS="${CONDUCTOR_TAGS:-$(toml_normalize_array "$value")}" ;;
+          with) CONDUCTOR_WITH="${CONDUCTOR_WITH:-$(toml_unquote "$value")}" ;;
           exclude) CONDUCTOR_EXCLUDE="${CONDUCTOR_EXCLUDE:-$(toml_normalize_array "$value")}" ;;
         esac
         ;;
       "review.routing")
         case "$key" in
           enabled) ROUTING_ENABLED="$(normalize_bool "$value")" ;;
-          small_max_diff_lines|small_diff_lines) ROUTING_SMALL_MAX_DIFF_LINES="$value" ;;
-          small_with)   ROUTING_SMALL_WITH="$(toml_unquote "$value")" ;;
+          small_max_diff_lines | small_diff_lines) ROUTING_SMALL_MAX_DIFF_LINES="$value" ;;
+          small_with) ROUTING_SMALL_WITH="$(toml_unquote "$value")" ;;
           small_prefer) ROUTING_SMALL_PREFER="$(toml_unquote "$value")" ;;
           small_effort) ROUTING_SMALL_EFFORT="$(toml_unquote "$value")" ;;
-          small_tags)   ROUTING_SMALL_TAGS="$(toml_unquote "$value")" ;;
-          large_with)   ROUTING_LARGE_WITH="$(toml_unquote "$value")" ;;
+          small_tags) ROUTING_SMALL_TAGS="$(toml_unquote "$value")" ;;
+          large_with) ROUTING_LARGE_WITH="$(toml_unquote "$value")" ;;
           large_prefer) ROUTING_LARGE_PREFER="$(toml_unquote "$value")" ;;
           large_effort) ROUTING_LARGE_EFFORT="$(toml_unquote "$value")" ;;
-          large_tags)   ROUTING_LARGE_TAGS="$(toml_unquote "$value")" ;;
+          large_tags) ROUTING_LARGE_TAGS="$(toml_unquote "$value")" ;;
           small_reviewers)
             if [[ "$value" == "["* ]]; then
               append_routing_small_reviewers_csv "$(toml_normalize_array "$value")"
@@ -741,9 +792,9 @@ if [ -f "$CONFIG_FILE" ]; then
       "review.context")
         case "$key" in
           mode) PROMPT_CONTEXT_MODE="${CODEX_REVIEW_CONTEXT_MODE:-$(toml_unquote "$value")}" ;;
-          small_max_diff_lines|small_diff_lines) PROMPT_CONTEXT_SMALL_MAX_DIFF_LINES="${CODEX_REVIEW_CONTEXT_SMALL_MAX_DIFF_LINES:-$value}" ;;
-          small_max_files|max_files) PROMPT_CONTEXT_SMALL_MAX_FILES="${CODEX_REVIEW_CONTEXT_SMALL_MAX_FILES:-$value}" ;;
-          full_context_paths|full_context_patterns)
+          small_max_diff_lines | small_diff_lines) PROMPT_CONTEXT_SMALL_MAX_DIFF_LINES="${CODEX_REVIEW_CONTEXT_SMALL_MAX_DIFF_LINES:-$value}" ;;
+          small_max_files | max_files) PROMPT_CONTEXT_SMALL_MAX_FILES="${CODEX_REVIEW_CONTEXT_SMALL_MAX_FILES:-$value}" ;;
+          full_context_paths | full_context_patterns)
             if [[ "$value" == "["* ]]; then
               append_prompt_context_paths_csv "$(toml_normalize_array "$value")"
             else
@@ -766,7 +817,7 @@ if [ -f "$CONFIG_FILE" ]; then
         ;;
       "review.local")
         case "$key" in
-          command|auth_command)
+          command | auth_command)
             if [ -z "${CODEX_REVIEW_SUPPRESS_LEGACY_WARNINGS:-}" ]; then
               echo "==> NOTE: [review.local] is ignored in Touchstone 2.0.0." >&2
               echo "    Register your command as a Conductor custom provider" >&2
@@ -776,7 +827,7 @@ if [ -f "$CONFIG_FILE" ]; then
             ;;
         esac
         ;;
-      ""|"codex_review")
+      "" | "codex_review")
         case "$key" in
           max_iterations) MAX_ITERATIONS="${CODEX_REVIEW_MAX_ITERATIONS:-$value}" ;;
           max_diff_lines) MAX_DIFF_LINES="${CODEX_REVIEW_MAX_DIFF_LINES:-$value}" ;;
@@ -845,7 +896,7 @@ REVIEWER_CASCADE=("conductor")
 # v1.x peer-review (ASSIST_HELPERS) is disabled in 2.0.0 and returns in v2.1
 # via `conductor call --exclude <primary_provider>`. Users who had it enabled
 # get a warning; the setting is ignored rather than throwing.
-ASSIST_HELPERS=()  # 1.x helpers field is ignored — Conductor picks the peer.
+ASSIST_HELPERS=() # 1.x helpers field is ignored — Conductor picks the peer.
 
 REVIEW_ENABLED="$(normalize_bool "$REVIEW_ENABLED")"
 ROUTING_ENABLED="$(normalize_bool "$ROUTING_ENABLED")"
@@ -873,7 +924,7 @@ if [ -n "${TOUCHSTONE_REVIEWER:-}" ]; then
       # TOUCHSTONE_REVIEWER is env-scoped, so it trumps the TOML `with=` pin.
       CONDUCTOR_WITH="ollama"
       ;;
-    codex|claude|gemini)
+    codex | claude | gemini)
       echo "==> NOTE: TOUCHSTONE_REVIEWER=$TOUCHSTONE_REVIEWER is deprecated in 2.0.0." >&2
       echo "    Pin an underlying provider with: TOUCHSTONE_CONDUCTOR_WITH=$TOUCHSTONE_REVIEWER" >&2
       CONDUCTOR_WITH="$TOUCHSTONE_REVIEWER"
@@ -915,7 +966,7 @@ resolve_mode() {
   [ -n "$mode" ] || mode="${CONFIG_MODE:-fix}"
 
   case "$mode" in
-    review-only|fix|diff-only|no-tests) ;;
+    review-only | fix | diff-only | no-tests) ;;
     *)
       echo "WARNING: Invalid mode '$mode' — falling back to 'fix'. Valid: review-only, fix, diff-only, no-tests" >&2
       mode="fix"
@@ -926,7 +977,7 @@ resolve_mode() {
 
 REVIEW_MODE="$(resolve_mode)"
 
-mode_allows_fix()  { [ "$REVIEW_MODE" = "fix" ] || [ "$REVIEW_MODE" = "no-tests" ]; }
+mode_allows_fix() { [ "$REVIEW_MODE" = "fix" ] || [ "$REVIEW_MODE" = "no-tests" ]; }
 mode_allows_bash() { [ "$REVIEW_MODE" = "fix" ] || [ "$REVIEW_MODE" = "review-only" ]; }
 
 short_ref_name() {
@@ -982,10 +1033,9 @@ path_matches_context_pattern() {
     */)
       [[ "$path" == "$pattern"* ]] && return 0
       ;;
-    *\**|*\?*|*\[*)
-      case "$path" in
-        $pattern) return 0 ;;
-      esac
+    *\** | *\?* | *\[*)
+      # shellcheck disable=SC2053 # Configured context patterns intentionally use globs.
+      [[ "$path" == $pattern ]] && return 0
       ;;
     *)
       if [ "$path" = "$pattern" ] || [[ "$path" == "$pattern/"* ]]; then
@@ -1013,8 +1063,8 @@ find_path_matching_context_patterns() {
         printf '%s (matched %s)' "$path" "$pattern"
         return 0
       fi
-    done <<< "$patterns"
-  done <<< "$paths"
+    done <<<"$patterns"
+  done <<<"$paths"
 
   return 1
 }
@@ -1028,7 +1078,7 @@ select_prompt_context_mode() {
   requested="$(printf '%s' "${PROMPT_CONTEXT_MODE:-auto}" | tr '[:upper:]' '[:lower:]')"
 
   case "$requested" in
-    auto|bounded|full) ;;
+    auto | bounded | full) ;;
     *)
       echo "WARNING: Invalid review.context.mode='$PROMPT_CONTEXT_MODE' — using auto." >&2
       requested="auto"
@@ -1042,7 +1092,7 @@ select_prompt_context_mode() {
   fi
 
   case "$PROMPT_CONTEXT_SMALL_MAX_DIFF_LINES" in
-    ''|*[!0-9]*)
+    '' | *[!0-9]*)
       PROMPT_CONTEXT_DECISION="full"
       PROMPT_CONTEXT_REASON="invalid review.context.small_max_diff_lines='$PROMPT_CONTEXT_SMALL_MAX_DIFF_LINES'"
       return 0
@@ -1050,7 +1100,7 @@ select_prompt_context_mode() {
   esac
 
   case "$PROMPT_CONTEXT_SMALL_MAX_FILES" in
-    ''|*[!0-9]*)
+    '' | *[!0-9]*)
       PROMPT_CONTEXT_DECISION="full"
       PROMPT_CONTEXT_REASON="invalid review.context.small_max_files='$PROMPT_CONTEXT_SMALL_MAX_FILES'"
       return 0
@@ -1300,7 +1350,7 @@ reviewer_conductor_exec() {
 conductor_subcommand_for_mode() {
   case "$REVIEW_MODE" in
     diff-only) printf 'call' ;;
-    *)         printf 'exec' ;;
+    *) printf 'exec' ;;
   esac
 }
 
@@ -1396,7 +1446,7 @@ apply_review_routing() {
   [ -z "${TOUCHSTONE_REVIEWER:-}" ] || return 0
 
   case "$ROUTING_SMALL_MAX_DIFF_LINES" in
-    ''|*[!0-9]*)
+    '' | *[!0-9]*)
       echo "WARNING: Invalid review.routing.small_max_diff_lines='$ROUTING_SMALL_MAX_DIFF_LINES' — ignoring routing." >&2
       return 0
       ;;
@@ -1419,18 +1469,18 @@ apply_review_routing() {
     # Apply 2.0 small-bucket overrides. Non-empty fields win; env still
     # trumps via the earlier cascade (TOUCHSTONE_CONDUCTOR_* set on the
     # command line or in the shell override the config-driven bucket).
-    [ -n "$ROUTING_SMALL_WITH" ]   && CONDUCTOR_WITH="${TOUCHSTONE_CONDUCTOR_WITH:-$ROUTING_SMALL_WITH}"
+    [ -n "$ROUTING_SMALL_WITH" ] && CONDUCTOR_WITH="${TOUCHSTONE_CONDUCTOR_WITH:-$ROUTING_SMALL_WITH}"
     [ -n "$ROUTING_SMALL_PREFER" ] && CONDUCTOR_PREFER="${TOUCHSTONE_CONDUCTOR_PREFER:-$ROUTING_SMALL_PREFER}"
     [ -n "$ROUTING_SMALL_EFFORT" ] && CONDUCTOR_EFFORT="${TOUCHSTONE_CONDUCTOR_EFFORT:-$ROUTING_SMALL_EFFORT}"
-    [ -n "$ROUTING_SMALL_TAGS" ]   && CONDUCTOR_TAGS="${TOUCHSTONE_CONDUCTOR_TAGS:-$ROUTING_SMALL_TAGS}"
+    [ -n "$ROUTING_SMALL_TAGS" ] && CONDUCTOR_TAGS="${TOUCHSTONE_CONDUCTOR_TAGS:-$ROUTING_SMALL_TAGS}"
     echo "==> Review routing: small diff ($diff_lines <= $ROUTING_SMALL_MAX_DIFF_LINES) — with=${CONDUCTOR_WITH:-auto} prefer=$CONDUCTOR_PREFER effort=$CONDUCTOR_EFFORT"
   else
     REVIEWER_CASCADE=("${ROUTING_LARGE_REVIEWERS[@]}")
     ROUTING_DECISION="large"
-    [ -n "$ROUTING_LARGE_WITH" ]   && CONDUCTOR_WITH="${TOUCHSTONE_CONDUCTOR_WITH:-$ROUTING_LARGE_WITH}"
+    [ -n "$ROUTING_LARGE_WITH" ] && CONDUCTOR_WITH="${TOUCHSTONE_CONDUCTOR_WITH:-$ROUTING_LARGE_WITH}"
     [ -n "$ROUTING_LARGE_PREFER" ] && CONDUCTOR_PREFER="${TOUCHSTONE_CONDUCTOR_PREFER:-$ROUTING_LARGE_PREFER}"
     [ -n "$ROUTING_LARGE_EFFORT" ] && CONDUCTOR_EFFORT="${TOUCHSTONE_CONDUCTOR_EFFORT:-$ROUTING_LARGE_EFFORT}"
-    [ -n "$ROUTING_LARGE_TAGS" ]   && CONDUCTOR_TAGS="${TOUCHSTONE_CONDUCTOR_TAGS:-$ROUTING_LARGE_TAGS}"
+    [ -n "$ROUTING_LARGE_TAGS" ] && CONDUCTOR_TAGS="${TOUCHSTONE_CONDUCTOR_TAGS:-$ROUTING_LARGE_TAGS}"
     echo "==> Review routing: larger diff ($diff_lines > $ROUTING_SMALL_MAX_DIFF_LINES) — with=${CONDUCTOR_WITH:-auto} prefer=$CONDUCTOR_PREFER effort=$CONDUCTOR_EFFORT"
   fi
 }
@@ -1442,7 +1492,7 @@ run_reviewer() {
 reviewer_label_for() {
   case "$1" in
     conductor) printf 'Conductor' ;;
-    *)         printf '%s' "$1" ;;
+    *) printf '%s' "$1" ;;
   esac
 }
 
@@ -1484,17 +1534,17 @@ run_reviewer_with_timeout() {
   # we want to surface in the transcript. Pre-2.0 reviewers wrote noise to
   # stderr, hence the historical /dev/null redirect; capturing instead is
   # safe because non-[conductor] lines are filtered before display.
-  : > "$REVIEW_STDERR_FILE"
+  : >"$REVIEW_STDERR_FILE"
 
   # No timeout: run directly
   if [ "$timeout_secs" -le 0 ] 2>/dev/null; then
-    run_reviewer "$prompt" > "$output_file" 2>>"$REVIEW_STDERR_FILE"
+    run_reviewer "$prompt" >"$output_file" 2>>"$REVIEW_STDERR_FILE"
     return $?
   fi
 
   # Run reviewer in background, kill if it exceeds timeout.
   (
-    run_reviewer "$prompt" > "$output_file" 2>>"$REVIEW_STDERR_FILE" &
+    run_reviewer "$prompt" >"$output_file" 2>>"$REVIEW_STDERR_FILE" &
     local reviewer_pid=$!
 
     terminate_reviewer() {
@@ -1536,9 +1586,9 @@ handle_error() {
   # log and console output are unambiguous about *why* the safety net opened.
   local fail_open_code
   case "$reason" in
-    timeout*)             fail_open_code="FAIL_OPEN_TIMEOUT" ;;
+    timeout*) fail_open_code="FAIL_OPEN_TIMEOUT" ;;
     "malformed sentinel") fail_open_code="FAIL_OPEN_PARSE_ERROR" ;;
-    *)                    fail_open_code="FAIL_OPEN_REVIEWER_ERROR" ;;
+    *) fail_open_code="FAIL_OPEN_REVIEWER_ERROR" ;;
   esac
 
   if [ "$ON_ERROR" = "fail-closed" ]; then
@@ -1697,9 +1747,9 @@ $(git log --reverse --format='### %s%n%n%b' "$MERGE_BASE"..HEAD 2>/dev/null | se
 
 Examine the diff vs $BASE using your tools.
 $(if [ "$REVIEW_MODE" = "diff-only" ]; then
-printf '\n## Diff (included because mode=diff-only restricts tool access)\n\n```\n'
-git diff "$MERGE_BASE"..HEAD 2>/dev/null
-printf '```\n'
+  printf '\n## Diff (included because mode=diff-only restricts tool access)\n\n```\n'
+  git diff "$MERGE_BASE"..HEAD 2>/dev/null
+  printf '```\n'
 fi)
 
 ## Auto-fix policy
@@ -1707,8 +1757,8 @@ fi)
 $AUTOFIX_POLICY
 $(build_assist_policy)
 $(if [ -n "$REVIEW_CONTEXT_FILE" ]; then
-printf '\n## Project review context\n\n'
-cat "$REVIEW_CONTEXT_FILE"
+  printf '\n## Project review context\n\n'
+  cat "$REVIEW_CONTEXT_FILE"
 fi)
 
 ## Output contract — strict
@@ -1738,7 +1788,6 @@ if [ -n "$SENTINEL_JOURNAL_CONTEXT" ]; then
 ${REVIEW_PROMPT}"
   echo "==> Sentinel cycle journal injected into reviewer context."
 fi
-
 
 # --------------------------------------------------------------------------
 # Clean-review cache
@@ -1873,7 +1922,7 @@ write_clean_review_marker() {
     printf 'head=%s\n' "$(git rev-parse HEAD 2>/dev/null || echo unknown)"
     printf 'diff_lines=%s\n' "$line_count"
     printf 'reviewed_at=%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-  } > "$marker_file" 2>/dev/null || true
+  } >"$marker_file" 2>/dev/null || true
 }
 
 write_clean_review_cache() {
@@ -1893,7 +1942,7 @@ write_clean_review_cache() {
     printf 'head=%s\n' "$(git rev-parse HEAD 2>/dev/null || echo unknown)"
     printf 'diff_lines=%s\n' "$line_count"
     printf 'reviewed_at=%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-  } > "$cache_file" 2>/dev/null || true
+  } >"$cache_file" 2>/dev/null || true
 }
 
 # --------------------------------------------------------------------------
@@ -1959,7 +2008,7 @@ write_review_findings() {
     printf -- '--- findings start ---\n'
     printf '%s\n' "$findings_block"
     printf -- '--- findings end ---\n'
-  } > "$findings_file" 2>/dev/null || true
+  } >"$findings_file" 2>/dev/null || true
 }
 
 clear_review_findings() {
@@ -2060,7 +2109,7 @@ path_is_unsafe() {
         fi
         ;;
     esac
-  done <<< "$UNSAFE_PATHS"
+  done <<<"$UNSAFE_PATHS"
 
   return 1
 }
@@ -2094,7 +2143,7 @@ $path"
         disallowed="$path"
       fi
     fi
-  done <<< "$changed"
+  done <<<"$changed"
 
   printf '%s' "$disallowed"
 }
@@ -2136,9 +2185,9 @@ Commit messages:
 
 $(git log --reverse --format='### %s%n%n%b' "$MERGE_BASE"..HEAD 2>/dev/null | sed '/^$/N;/^\n$/d')
 $(if [ -n "$REVIEW_CONTEXT_FILE" ]; then
-printf '\n## Project review context\n\n'
-cat "$REVIEW_CONTEXT_FILE"
-fi)
+    printf '\n## Project review context\n\n'
+    cat "$REVIEW_CONTEXT_FILE"
+  fi)
 
 ## Diff
 
@@ -2273,10 +2322,16 @@ print_route_log() {
 # shellcheck disable=SC2120  # $1 is intentionally optional with a default.
 parse_primary_provider() {
   local stderr_file="${1:-$REVIEW_STDERR_FILE}"
-  [ -f "$stderr_file" ] || { printf ''; return; }
+  [ -f "$stderr_file" ] || {
+    printf ''
+    return
+  }
   local line
   line="$(grep -m1 '^\[conductor\]' "$stderr_file" 2>/dev/null || true)"
-  [ -n "$line" ] || { printf ''; return; }
+  [ -n "$line" ] || {
+    printf ''
+    return
+  }
   # Extract the provider name following the arrow. Handles:
   #   [conductor] auto (...) → claude (tier: ...)
   #   [conductor] auto (...) -> claude (tier: ...)
@@ -2335,11 +2390,11 @@ run_peer_review() {
   # relies on conductor's own per-provider timeout (currently 300s default).
   peer_output="$(printf '%s' "$peer_prompt" \
     | conductor call --auto \
-        --exclude "$primary_provider" \
-        --tags code-review \
-        --effort medium \
-        --silent-route \
-        2>/dev/null || true)"
+      --exclude "$primary_provider" \
+      --tags code-review \
+      --effort medium \
+      --silent-route \
+      2>/dev/null || true)"
 
   if [ -z "$peer_output" ]; then
     phase "peer review produced no output (skipped)"
@@ -2410,7 +2465,7 @@ check_worktree_invariants() {
 
 print_summary() {
   local elapsed mins secs findings
-  elapsed=$(( $(date +%s) - REVIEW_START_TIME ))
+  elapsed=$(($(date +%s) - REVIEW_START_TIME))
   mins=$((elapsed / 60))
   secs=$((elapsed % 60))
   findings="${REVIEW_FINDINGS_COUNT:-0}"
@@ -2436,7 +2491,7 @@ print_summary() {
     printf '{"reviewer":"%s","route":"%s","mode":"%s","files":%d,"diff_lines":%d,"iterations":%d,"fix_commits":%d,"peer_assists":%d,"findings":%d,"exit_reason":"%s","elapsed_seconds":%d}\n' \
       "$REVIEWER_LABEL" "$ROUTING_DECISION" "$REVIEW_MODE" "$REVIEW_FILES_INSPECTED" "$DIFF_LINE_COUNT" \
       "${iter:-0}" "$FIX_COMMITS" "$ASSIST_ROUNDS" "$findings" "$REVIEW_EXIT_REASON" "$elapsed" \
-      > "$CODEX_REVIEW_SUMMARY_FILE" 2>/dev/null || true
+      >"$CODEX_REVIEW_SUMMARY_FILE" 2>/dev/null || true
   fi
 }
 
@@ -2470,8 +2525,10 @@ tk_paint() {
   # Falls back to plain text if gum is missing, disabled, or fails —
   # the hook is running under `set -euo pipefail`, so silent gum failure
   # would otherwise produce empty strings in the verdict lines.
-  local color="$1"; shift
-  local flag="$1"; shift
+  local color="$1"
+  shift
+  local flag="$1"
+  shift
   local rendered=""
   if [ "$C_TTY" = "1" ] && tk_have_gum; then
     if [ "$flag" = "bold" ]; then
@@ -2503,7 +2560,7 @@ tk_signature_line() {
   # Dim "touchstone vX.Y.Z" line; version resolved via TOUCHSTONE_ROOT when set.
   local version=""
   if [ -n "${TOUCHSTONE_ROOT:-}" ] && [ -f "$TOUCHSTONE_ROOT/VERSION" ]; then
-    version="$(tr -d '[:space:]' < "$TOUCHSTONE_ROOT/VERSION" 2>/dev/null || true)"
+    version="$(tr -d '[:space:]' <"$TOUCHSTONE_ROOT/VERSION" 2>/dev/null || true)"
   fi
   if [ -n "$version" ]; then
     tk_paint "$TK_BRAND_DIM" plain "touchstone v${version}"
@@ -2519,12 +2576,18 @@ tk_verdict() {
   rail="$(tk_rail)"
 
   case "$state" in
-    ok)   mark="$(tk_paint "$TK_BRAND_LIME" plain "✓")"
-          painted_headline="$(tk_paint "$TK_BRAND_LIME" bold "$headline")" ;;
-    fail) mark="$(tk_paint "$TK_BRAND_RED"  plain "✗")"
-          painted_headline="$(tk_paint "$TK_BRAND_RED"  bold "$headline")" ;;
-    *)    mark="$(tk_paint "$TK_BRAND_DIM"  plain "•")"
-          painted_headline="$(tk_paint "$TK_BRAND_DIM"  bold "$headline")" ;;
+    ok)
+      mark="$(tk_paint "$TK_BRAND_LIME" plain "✓")"
+      painted_headline="$(tk_paint "$TK_BRAND_LIME" bold "$headline")"
+      ;;
+    fail)
+      mark="$(tk_paint "$TK_BRAND_RED" plain "✗")"
+      painted_headline="$(tk_paint "$TK_BRAND_RED" bold "$headline")"
+      ;;
+    *)
+      mark="$(tk_paint "$TK_BRAND_DIM" plain "•")"
+      painted_headline="$(tk_paint "$TK_BRAND_DIM" bold "$headline")"
+      ;;
   esac
 
   printf '\n  %s  %s  %s\n' "$rail" "$painted_headline" "$mark"
@@ -2599,8 +2662,8 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
   # peer's verdict does NOT gate the merge; the primary's sentinel wins.
   # Fires once per iteration, respects ASSIST_MAX_ROUNDS.
   if is_truthy "${ASSIST_ENABLED:-false}" \
-      && [ "${ASSIST_ROUNDS_DONE:-0}" -lt "${ASSIST_MAX_ROUNDS:-1}" ] \
-      && [ -n "$OUTPUT" ]; then
+    && [ "${ASSIST_ROUNDS_DONE:-0}" -lt "${ASSIST_MAX_ROUNDS:-1}" ] \
+    && [ -n "$OUTPUT" ]; then
     run_peer_review "$OUTPUT" || true
   fi
 

--- a/hooks/cortex-pr-merged-hook.sh
+++ b/hooks/cortex-pr-merged-hook.sh
@@ -72,7 +72,10 @@ truthy() {
 read_config_value() {
   local config_file="$1" key="$2"
   local line lhs rhs result=""
-  [ -f "$config_file" ] || { printf ''; return 0; }
+  [ -f "$config_file" ] || {
+    printf ''
+    return 0
+  }
   while IFS= read -r line || [ -n "$line" ]; do
     line="${line#"${line%%[![:space:]]*}"}"
     case "$line" in '#'* | '') continue ;; esac
@@ -86,7 +89,7 @@ read_config_value() {
       rhs="${rhs%"${rhs##*[![:space:]]}"}"
       result="$rhs"
     fi
-  done < "$config_file"
+  done <"$config_file"
   printf '%s' "$result"
 }
 

--- a/hooks/emergency-disclosure.sh
+++ b/hooks/emergency-disclosure.sh
@@ -75,7 +75,7 @@ log_file="$log_dir/emergency-bypass.log"
 mkdir -p "$log_dir" 2>/dev/null || true
 {
   printf '%s\t%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$command"
-} >> "$log_file" 2>/dev/null || true
+} >>"$log_file" 2>/dev/null || true
 
 echo "emergency-disclosure: TOUCHSTONE_EMERGENCY=1 — push allowed; logged to ${log_file#"$cwd/"} for next-PR disclosure" >&2
 exit 0

--- a/lib/agents-principles-block.sh
+++ b/lib/agents-principles-block.sh
@@ -110,7 +110,7 @@ agents_principles_block_apply() {
   local block_file out_file
   block_file="$(mktemp -t agents-principles-block.XXXXXX)"
   out_file="$(mktemp -t agents-principles-out.XXXXXX)"
-  agents_principles_block_render > "$block_file"
+  agents_principles_block_render >"$block_file"
 
   if [ "$has_begin" = 1 ]; then
     # Refresh: copy lines, but when we hit the start marker, splice the current
@@ -125,28 +125,28 @@ agents_principles_block_apply() {
       fi
       if [ "$line" = "$AGENTS_PRINCIPLES_BLOCK_BEGIN" ]; then
         if [ "$spliced" = 0 ]; then
-          cat "$block_file" >> "$out_file"
+          cat "$block_file" >>"$out_file"
           spliced=1
         fi
         in_block=1
         continue
       fi
-      printf '%s\n' "$line" >> "$out_file"
-    done < "$target"
+      printf '%s\n' "$line" >>"$out_file"
+    done <"$target"
   else
     # Inject at top, after the first H1 if there is one — otherwise at line 1.
     local first_line
     first_line="$(head -n 1 "$target" || true)"
     if [[ "$first_line" =~ ^\#\  ]]; then
-      printf '%s\n' "$first_line" >> "$out_file"
-      printf '\n' >> "$out_file"
-      cat "$block_file" >> "$out_file"
-      printf '\n' >> "$out_file"
-      tail -n +2 "$target" >> "$out_file"
+      printf '%s\n' "$first_line" >>"$out_file"
+      printf '\n' >>"$out_file"
+      cat "$block_file" >>"$out_file"
+      printf '\n' >>"$out_file"
+      tail -n +2 "$target" >>"$out_file"
     else
-      cat "$block_file" >> "$out_file"
-      printf '\n' >> "$out_file"
-      cat "$target" >> "$out_file"
+      cat "$block_file" >>"$out_file"
+      printf '\n' >>"$out_file"
+      cat "$target" >>"$out_file"
     fi
   fi
 
@@ -156,7 +156,7 @@ agents_principles_block_apply() {
   fi
 
   # Atomic replace; preserve the file's permissions.
-  cat "$out_file" > "$target"
+  cat "$out_file" >"$target"
   rm -f "$block_file" "$out_file"
   return 0
 }

--- a/lib/auto-update.sh
+++ b/lib/auto-update.sh
@@ -39,7 +39,7 @@ touchstone_auto_update() {
   fi
 
   # Record that we're checking now (even if the check fails).
-  date +%s > "$LAST_CHECK_FILE"
+  date +%s >"$LAST_CHECK_FILE"
 
   # Get current version.
   local current_version

--- a/lib/claude-md-principles-ref.sh
+++ b/lib/claude-md-principles-ref.sh
@@ -43,12 +43,15 @@ CLAUDE_MD_PRINCIPLES_MARKER='<!-- touchstone:claude-principles-ref -->'
 # missing config or unmatched grep.
 claude_md_principles_ref_decision() {
   local config="$1/.touchstone-config"
-  [ -f "$config" ] || { printf ''; return 0; }
+  [ -f "$config" ] || {
+    printf ''
+    return 0
+  }
   local val
   val="$(grep -E '^claude_principles_ref=' "$config" 2>/dev/null \
-         | tail -n1 \
-         | cut -d= -f2- \
-         | tr -d '[:space:]' || true)"
+    | tail -n1 \
+    | cut -d= -f2- \
+    | tr -d '[:space:]' || true)"
   printf '%s' "$val"
   return 0
 }
@@ -60,12 +63,12 @@ claude_md_principles_ref_record() {
   local value="$2"
   local config="$project_dir/.touchstone-config"
   case "$value" in
-    connected|skipped) ;;
+    connected | skipped) ;;
     *) return 1 ;;
   esac
 
   if [ ! -f "$config" ]; then
-    printf '# touchstone project profile.\nclaude_principles_ref=%s\n' "$value" > "$config"
+    printf '# touchstone project profile.\nclaude_principles_ref=%s\n' "$value" >"$config"
     return 0
   fi
 
@@ -75,11 +78,11 @@ claude_md_principles_ref_record() {
     awk -v v="$value" '
       /^claude_principles_ref=/ { print "claude_principles_ref=" v; next }
       { print }
-    ' "$config" > "$tmp"
-    cat "$tmp" > "$config"
+    ' "$config" >"$tmp"
+    cat "$tmp" >"$config"
     rm -f "$tmp"
   else
-    printf 'claude_principles_ref=%s\n' "$value" >> "$config"
+    printf 'claude_principles_ref=%s\n' "$value" >>"$config"
   fi
 }
 
@@ -113,7 +116,7 @@ claude_md_insert_missing_principles_refs() {
   while IFS= read -r ref; do
     [ -n "$ref" ] || continue
     if ! grep -qF "$ref" "$target"; then
-      printf '%s\n' "$ref" >> "$missing_file"
+      printf '%s\n' "$ref" >>"$missing_file"
     fi
   done <<'EOF'
 @principles/pre-implementation-checklist.md
@@ -129,17 +132,17 @@ EOF
   local inserted=0 line
   while IFS= read -r line || [ -n "$line" ]; do
     if [ "$inserted" = 0 ] && printf '%s\n' "$line" | grep -qE '^@principles/'; then
-      cat "$missing_file" >> "$out_file"
+      cat "$missing_file" >>"$out_file"
       inserted=1
     fi
-    printf '%s\n' "$line" >> "$out_file"
-  done < "$target"
+    printf '%s\n' "$line" >>"$out_file"
+  done <"$target"
 
   if [ "$inserted" = 0 ]; then
-    cat "$missing_file" >> "$out_file"
+    cat "$missing_file" >>"$out_file"
   fi
 
-  cat "$out_file" > "$target"
+  cat "$out_file" >"$target"
   rm -f "$missing_file" "$out_file"
   return 0
 }
@@ -179,23 +182,23 @@ claude_md_inject_principles_block() {
   local block_file out_file
   block_file="$(mktemp -t claude-md-principles.XXXXXX)"
   out_file="$(mktemp -t claude-md-principles-out.XXXXXX)"
-  claude_md_render_principles_block > "$block_file"
+  claude_md_render_principles_block >"$block_file"
 
   local first_line
   first_line="$(head -n 1 "$target" || true)"
   if [[ "$first_line" =~ ^\#\  ]]; then
-    printf '%s\n' "$first_line" >> "$out_file"
-    printf '\n' >> "$out_file"
-    cat "$block_file" >> "$out_file"
-    printf '\n' >> "$out_file"
-    tail -n +2 "$target" >> "$out_file"
+    printf '%s\n' "$first_line" >>"$out_file"
+    printf '\n' >>"$out_file"
+    cat "$block_file" >>"$out_file"
+    printf '\n' >>"$out_file"
+    tail -n +2 "$target" >>"$out_file"
   else
-    cat "$block_file" >> "$out_file"
-    printf '\n' >> "$out_file"
-    cat "$target" >> "$out_file"
+    cat "$block_file" >>"$out_file"
+    printf '\n' >>"$out_file"
+    cat "$target" >>"$out_file"
   fi
 
-  cat "$out_file" > "$target"
+  cat "$out_file" >"$target"
   rm -f "$block_file" "$out_file"
   return 0
 }
@@ -220,9 +223,9 @@ ensure_claude_principles_ref() {
   local mode="${2:-prompt}"
   local claude_md="$project_dir/CLAUDE.md"
 
-  _epr_say()  { if command -v tk_dim   >/dev/null 2>&1; then tk_dim   "$@"; else echo "$@";   fi; }
-  _epr_ok()   { if command -v tk_ok    >/dev/null 2>&1; then tk_ok    "$@"; else echo "OK: $*"; fi; }
-  _epr_warn() { if command -v tk_warn  >/dev/null 2>&1; then tk_warn  "$@"; else echo "WARN: $*" >&2; fi; }
+  _epr_say() { if command -v tk_dim >/dev/null 2>&1; then tk_dim "$@"; else echo "$@"; fi; }
+  _epr_ok() { if command -v tk_ok >/dev/null 2>&1; then tk_ok "$@"; else echo "OK: $*"; fi; }
+  _epr_warn() { if command -v tk_warn >/dev/null 2>&1; then tk_warn "$@"; else echo "WARN: $*" >&2; fi; }
   _epr_head() { if command -v tk_header >/dev/null 2>&1; then tk_header "$@"; else echo "==> $*"; fi; }
 
   # Respect a prior decision. Once recorded, init never re-prompts. A prior
@@ -269,10 +272,10 @@ ensure_claude_principles_ref() {
       claude_md_principles_ref_record "$project_dir" skipped
       _epr_say "Skipped Touchstone principles in CLAUDE.md (recorded in .touchstone-config)."
       ;;
-    prompt|*)
+    prompt | *)
       if [ ! -t 0 ] || [ ! -t 1 ]; then
         _epr_warn "CLAUDE.md exists but does not import all touchstone principles."
-        _epr_say  "Re-run interactively, or pass --no-claude-principles to skip permanently."
+        _epr_say "Re-run interactively, or pass --no-claude-principles to skip permanently."
         return 0
       fi
       _epr_head "Touchstone — connect CLAUDE.md to engineering principles"
@@ -290,7 +293,7 @@ ensure_claude_principles_ref() {
       printf "  Add the imports to CLAUDE.md? [Y/n] "
       read -r answer || answer=""
       case "$answer" in
-        n|N|no|NO|No)
+        n | N | no | NO | No)
           claude_md_principles_ref_record "$project_dir" skipped
           _epr_say "Skipped. Re-run touchstone init to opt in later."
           ;;

--- a/lib/colors.sh
+++ b/lib/colors.sh
@@ -18,9 +18,9 @@ else
   RED='' GREEN='' YELLOW='' BLUE='' BOLD='' DIM='' RESET=''
 fi
 
-tk_info()    { printf "${BOLD}==> %s${RESET}\n" "$*"; }
-tk_ok()      { printf "  ${GREEN}✓${RESET} %s\n" "$*"; }
-tk_warn()    { printf "  ${YELLOW}!${RESET} %s\n" "$*"; }
-tk_fail()    { printf "  ${RED}✗${RESET} %s\n" "$*"; }
-tk_dim()     { printf "  ${DIM}%s${RESET}\n" "$*"; }
-tk_header()  { printf "\n${BOLD}%s${RESET}\n\n" "$*"; }
+tk_info() { printf "${BOLD}==> %s${RESET}\n" "$*"; }
+tk_ok() { printf "  ${GREEN}✓${RESET} %s\n" "$*"; }
+tk_warn() { printf "  ${YELLOW}!${RESET} %s\n" "$*"; }
+tk_fail() { printf "  ${RED}✗${RESET} %s\n" "$*"; }
+tk_dim() { printf "  ${DIM}%s${RESET}\n" "$*"; }
+tk_header() { printf "\n${BOLD}%s${RESET}\n\n" "$*"; }

--- a/lib/events.sh
+++ b/lib/events.sh
@@ -30,7 +30,7 @@ touchstone_json_string() {
 touchstone_event_value() {
   local value="${1-}"
   case "$value" in
-    ''|*[!0-9]*)
+    '' | *[!0-9]*)
       touchstone_json_string "$value"
       ;;
     *)
@@ -61,7 +61,7 @@ touchstone_emit_event() {
   done
   line="${line}}"
 
-  if ! printf '%s\n' "$line" >> "$events_file" 2>/dev/null; then
+  if ! printf '%s\n' "$line" >>"$events_file" 2>/dev/null; then
     printf 'WARNING: [events] could not append to %s\n' "$events_file" >&2
   fi
 }

--- a/lib/release.sh
+++ b/lib/release.sh
@@ -35,20 +35,30 @@ touchstone_release() {
 
   # Compute new version.
   local major minor patch
-  IFS='.' read -r major minor patch <<< "$current"
+  IFS='.' read -r major minor patch <<<"$current"
   case "$bump_type" in
-    major) major=$((major + 1)); minor=0; patch=0 ;;
-    minor) minor=$((minor + 1)); patch=0 ;;
+    major)
+      major=$((major + 1))
+      minor=0
+      patch=0
+      ;;
+    minor)
+      minor=$((minor + 1))
+      patch=0
+      ;;
     patch) patch=$((patch + 1)) ;;
-    *) tk_fail "Unknown bump type: $bump_type (use --major, --minor, or --patch)"; return 1 ;;
+    *)
+      tk_fail "Unknown bump type: $bump_type (use --major, --minor, or --patch)"
+      return 1
+      ;;
   esac
   local new_version="${major}.${minor}.${patch}"
   tk_info "New version: v${new_version}"
 
   # Bump VERSION file and touchstone's own dogfood stamp.
-  echo "$new_version" > "$TOUCHSTONE_ROOT/VERSION"
+  echo "$new_version" >"$TOUCHSTONE_ROOT/VERSION"
   if [ -f "$TOUCHSTONE_ROOT/.touchstone-version" ]; then
-    echo "$new_version" > "$TOUCHSTONE_ROOT/.touchstone-version"
+    echo "$new_version" >"$TOUCHSTONE_ROOT/.touchstone-version"
   fi
   tk_ok "Bumped VERSION to $new_version"
 

--- a/lib/status.sh
+++ b/lib/status.sh
@@ -33,7 +33,7 @@ _status_projects_file() {
 _status_read_project_version() {
   local project_dir="$1"
   [ -f "$project_dir/.touchstone-version" ] || return 0
-  tr -d '[:space:]' < "$project_dir/.touchstone-version" 2>/dev/null || true
+  tr -d '[:space:]' <"$project_dir/.touchstone-version" 2>/dev/null || true
 }
 
 # Render a recorded id for display. Long SHAs become short SHAs; semver-ish
@@ -168,8 +168,8 @@ _status_age_long() {
   fi
   # `date -r` (BSD/macOS) takes an epoch; `date -d @epoch` is GNU. Try both.
   stamp="$(date -r "$mtime" '+%Y-%m-%d %H:%M' 2>/dev/null \
-        || date -d "@$mtime" '+%Y-%m-%d %H:%M' 2>/dev/null \
-        || echo '')"
+    || date -d "@$mtime" '+%Y-%m-%d %H:%M' 2>/dev/null \
+    || echo '')"
   if [ -n "$stamp" ]; then
     printf '%s (%s)' "$human" "$stamp"
   else
@@ -189,7 +189,7 @@ _status_behind_color() {
   local behind="$1"
   case "$behind" in
     current) printf '%s' "$GREEN" ;;
-    \?)      printf '%s' "$RED" ;;
+    \?) printf '%s' "$RED" ;;
     *)
       # Numeric: 1..3 yellow, 4+ red.
       if [ "$behind" -ge 4 ] 2>/dev/null; then
@@ -238,13 +238,13 @@ _status_ref_contains_required() {
   local current_version
   current_version="$(touchstone_version_str 2>/dev/null || true)"
   if [ -n "$current_version" ] \
-     && { [ "$candidate" = "$current_version" ] || [ "$candidate" = "v$current_version" ]; }; then
+    && { [ "$candidate" = "$current_version" ] || [ "$candidate" = "v$current_version" ]; }; then
     return 0
   fi
 
   if git -C "${TOUCHSTONE_ROOT:-/nonexistent}" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
-     && git -C "$TOUCHSTONE_ROOT" rev-parse --verify "$required^{commit}" >/dev/null 2>&1 \
-     && git -C "$TOUCHSTONE_ROOT" rev-parse --verify "$candidate^{commit}" >/dev/null 2>&1; then
+    && git -C "$TOUCHSTONE_ROOT" rev-parse --verify "$required^{commit}" >/dev/null 2>&1 \
+    && git -C "$TOUCHSTONE_ROOT" rev-parse --verify "$candidate^{commit}" >/dev/null 2>&1; then
     git -C "$TOUCHSTONE_ROOT" merge-base --is-ancestor "$required" "$candidate" >/dev/null 2>&1
     return $?
   fi
@@ -284,8 +284,8 @@ _status_drift_state() {
   local behind="$1"
   case "$behind" in
     current) printf 'up_to_date' ;;
-    \?)      printf 'unknown' ;;
-    *)       printf 'project_files_outdated' ;;
+    \?) printf 'unknown' ;;
+    *) printf 'project_files_outdated' ;;
   esac
 }
 
@@ -362,8 +362,8 @@ status_print_project() {
   local latest_suffix
   case "$behind" in
     current) latest_suffix='(current)' ;;
-    \?)      latest_suffix='(unknown — recorded id not in touchstone history)' ;;
-    *)       latest_suffix="(${behind} commits behind)" ;;
+    \?) latest_suffix='(unknown — recorded id not in touchstone history)' ;;
+    *) latest_suffix="(${behind} commits behind)" ;;
   esac
 
   # Prefer the human-readable VERSION ("2.3.4") for the "latest" label when
@@ -575,7 +575,7 @@ _status_iter_registry() {
     [ -z "$line" ] && continue
     case "$line" in \#*) continue ;; esac
     "$cb" "$line"
-  done < "$projects_file"
+  done <"$projects_file"
   return 0
 }
 

--- a/lib/toml.sh
+++ b/lib/toml.sh
@@ -25,8 +25,14 @@ toml_unquote() {
   local val
   val="$(toml_trim "$1")"
   case "$val" in
-    \"*\") val="${val#\"}"; val="${val%\"}" ;;
-    \'*\') val="${val#\'}"; val="${val%\'}" ;;
+    \"*\")
+      val="${val#\"}"
+      val="${val%\"}"
+      ;;
+    \'*\')
+      val="${val#\'}"
+      val="${val%\'}"
+      ;;
   esac
   printf '%s' "$val"
 }
@@ -140,14 +146,15 @@ toml_parse() {
         "$callback" "$current_section" "$key" "$(toml_unquote "$val")"
       fi
     fi
-  done < "$config_file"
+  done <"$config_file"
 }
 
 # Helper to normalize arrays: strips brackets, quotes, and extra whitespace, returns CSV
 toml_normalize_array() {
   local val="$1"
   local item
-  val="${val#\[}"; val="${val%\]}"
+  val="${val#\[}"
+  val="${val%\]}"
   # Split by comma, unquote each, rejoin with comma
   local IFS=','
   local result=""

--- a/lib/ui.sh
+++ b/lib/ui.sh
@@ -22,7 +22,7 @@ TK_BRAND_LIME="#A3E635"
 TK_BRAND_RED="#EF4444"
 TK_BRAND_DIM="#6B7280"
 
-tk_have_gum()    { command -v gum    >/dev/null 2>&1; }
+tk_have_gum() { command -v gum >/dev/null 2>&1; }
 tk_have_figlet() { command -v figlet >/dev/null 2>&1; }
 
 tk_color_enabled() {
@@ -46,8 +46,10 @@ _tk_rail() {
 }
 
 _tk_paint() {
-  local color="$1"; shift
-  local flag="$1"; shift
+  local color="$1"
+  shift
+  local flag="$1"
+  shift
   local rendered=""
   if tk_color_enabled && tk_have_gum; then
     if [ "$flag" = "bold" ]; then
@@ -72,16 +74,16 @@ tk_verdict() {
   rail="$(_tk_rail)"
 
   case "$state" in
-    ok)   mark="$(_tk_paint "$TK_BRAND_LIME" plain "✓")" ;;
-    fail) mark="$(_tk_paint "$TK_BRAND_RED"  plain "✗")" ;;
-    info) mark="$(_tk_paint "$TK_BRAND_DIM"  plain "•")" ;;
-    *)    mark="$(_tk_paint "$TK_BRAND_DIM"  plain "·")" ;;
+    ok) mark="$(_tk_paint "$TK_BRAND_LIME" plain "✓")" ;;
+    fail) mark="$(_tk_paint "$TK_BRAND_RED" plain "✗")" ;;
+    info) mark="$(_tk_paint "$TK_BRAND_DIM" plain "•")" ;;
+    *) mark="$(_tk_paint "$TK_BRAND_DIM" plain "·")" ;;
   esac
 
   case "$state" in
-    ok)   headline="$(_tk_paint "$TK_BRAND_LIME" bold "$headline")" ;;
-    fail) headline="$(_tk_paint "$TK_BRAND_RED"  bold "$headline")" ;;
-    *)    headline="$(_tk_paint "$TK_BRAND_DIM"  bold "$headline")" ;;
+    ok) headline="$(_tk_paint "$TK_BRAND_LIME" bold "$headline")" ;;
+    fail) headline="$(_tk_paint "$TK_BRAND_RED" bold "$headline")" ;;
+    *) headline="$(_tk_paint "$TK_BRAND_DIM" bold "$headline")" ;;
   esac
 
   printf '\n  %s  %s  %s\n' "$rail" "$headline" "$mark"
@@ -97,7 +99,7 @@ tk_verdict() {
 tk_signature() {
   local version=""
   if [ -n "${TOUCHSTONE_ROOT:-}" ] && [ -f "$TOUCHSTONE_ROOT/VERSION" ]; then
-    version="$(tr -d '[:space:]' < "$TOUCHSTONE_ROOT/VERSION" 2>/dev/null || true)"
+    version="$(tr -d '[:space:]' <"$TOUCHSTONE_ROOT/VERSION" 2>/dev/null || true)"
   fi
   if [ -n "$version" ]; then
     _tk_paint "$TK_BRAND_DIM" plain "touchstone v${version}"
@@ -122,7 +124,7 @@ tk_hero() {
   local subtitle="${1:-}"
   local version=""
   if [ -n "${TOUCHSTONE_ROOT:-}" ] && [ -f "$TOUCHSTONE_ROOT/VERSION" ]; then
-    version="$(tr -d '[:space:]' < "$TOUCHSTONE_ROOT/VERSION" 2>/dev/null || true)"
+    version="$(tr -d '[:space:]' <"$TOUCHSTONE_ROOT/VERSION" 2>/dev/null || true)"
   fi
 
   if tk_have_gum && tk_color_enabled; then

--- a/lib/worker-state.sh
+++ b/lib/worker-state.sh
@@ -89,7 +89,10 @@ derive_worker_state() {
 
     base="$(touchstone_worker_default_ref)"
     branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
-    [ -n "$branch" ] && [ "$branch" != "HEAD" ] || { echo "abandoned"; exit 0; }
+    [ -n "$branch" ] && [ "$branch" != "HEAD" ] || {
+      echo "abandoned"
+      exit 0
+    }
 
     has_commits="$(git log "$base..HEAD" --oneline 2>/dev/null | head -1 || true)"
     has_uncommitted="$(git status --porcelain 2>/dev/null || true)"

--- a/scripts/cleanup-branches.sh
+++ b/scripts/cleanup-branches.sh
@@ -27,7 +27,7 @@ REMOTE_TOO=0
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    --execute|-x)
+    --execute | -x)
       DRY_RUN=0
       shift
       ;;
@@ -39,7 +39,7 @@ while [ "$#" -gt 0 ]; do
       DRY_RUN=1
       shift
       ;;
-    -h|--help)
+    -h | --help)
       # Print the header comment block (skip shebang + leading `#`), stopping
       # at the first non-comment line. Derived instead of hardcoded so future
       # header edits don't silently truncate the help output.
@@ -87,7 +87,7 @@ is_worktree_branch() {
   while IFS= read -r wb; do
     [ -z "$wb" ] && continue
     [ "$b" = "$wb" ] && return 0
-  done <<< "$WORKTREE_BRANCHES"
+  done <<<"$WORKTREE_BRANCHES"
   return 1
 }
 
@@ -134,7 +134,7 @@ is_recorded_squash() {
         return 0
         ;;
     esac
-  done < "$SQUASH_MAP_PATH" 2>/dev/null
+  done <"$SQUASH_MAP_PATH" 2>/dev/null
   return 1
 }
 
@@ -187,7 +187,7 @@ while IFS= read -r branch; do
   else
     UNMERGED_LOCAL+=("$branch")
   fi
-done <<< "$LOCAL_BRANCHES"
+done <<<"$LOCAL_BRANCHES"
 
 if [ "${#MERGED_LOCAL[@]}" -gt 0 ]; then
   echo ""
@@ -256,7 +256,7 @@ if [ "$REMOTE_TOO" -eq 1 ] && [ "$REMOTE_SKIPPED" -eq 0 ]; then
     while IFS= read -r pr_branch; do
       [ -z "$pr_branch" ] && continue
       [ "$b" = "$pr_branch" ] && return 0
-    done <<< "$OPEN_PR_BRANCHES"
+    done <<<"$OPEN_PR_BRANCHES"
     return 1
   }
 
@@ -277,7 +277,7 @@ if [ "$REMOTE_TOO" -eq 1 ] && [ "$REMOTE_SKIPPED" -eq 0 ]; then
     else
       REMOTE_UNIQUE_NO_PR+=("$remote_branch")
     fi
-  done <<< "$REMOTE_BRANCHES"
+  done <<<"$REMOTE_BRANCHES"
 
   if [ "${#REMOTE_DELETABLE[@]}" -gt 0 ]; then
     echo ""

--- a/scripts/cleanup-worktrees.sh
+++ b/scripts/cleanup-worktrees.sh
@@ -40,7 +40,7 @@ usage() {
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    --execute|-x)
+    --execute | -x)
       DRY_RUN=0
       shift
       ;;
@@ -57,7 +57,7 @@ while [ "$#" -gt 0 ]; do
       DRY_RUN=1
       shift
       ;;
-    -h|--help)
+    -h | --help)
       usage
       exit 0
       ;;
@@ -214,7 +214,7 @@ flush_worktree() {
   printf '    head: %s\n' "${current_head:-unknown}"
   printf '    status: %s\n' "$dirty_label"
   if [ "$current_locked" -eq 1 ]; then
-    IFS='|' read -r lock_state lock_pid lock_label <<< "$(classify_lock "$current_lock_reason")"
+    IFS='|' read -r lock_state lock_pid lock_label <<<"$(classify_lock "$current_lock_reason")"
     printf '    lock: %s\n' "$lock_label"
   fi
 
@@ -314,7 +314,7 @@ while IFS= read -r line || [ -n "$line" ]; do
       current_lock_reason=""
       ;;
   esac
-done <<< "$WORKTREE_LIST"
+done <<<"$WORKTREE_LIST"
 flush_worktree
 
 echo ""

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -323,21 +323,24 @@ log_skip_event() {
     # Guard against `set -euo pipefail` propagating a failed pipeline up
     # to the hook's exit code — log_skip_event must never block a push,
     # even on an unreadable log file or a TOCTOU race against rotation.
-    line_count="$(wc -l < "$log_file" 2>/dev/null | tr -d ' ')" || line_count=0
+    line_count="$(wc -l <"$log_file" 2>/dev/null | tr -d ' ')" || line_count=0
     line_count="${line_count:-0}"
     if [ "$line_count" -ge "$TOUCHSTONE_REVIEW_LOG_MAX_LINES" ]; then
       keep_lines=$((TOUCHSTONE_REVIEW_LOG_MAX_LINES - 1))
-      tail -n "$keep_lines" "$log_file" > "$tmp_file" 2>/dev/null || : > "$tmp_file"
+      tail -n "$keep_lines" "$log_file" >"$tmp_file" 2>/dev/null || : >"$tmp_file"
     else
-      cat "$log_file" > "$tmp_file" 2>/dev/null || : > "$tmp_file"
+      cat "$log_file" >"$tmp_file" 2>/dev/null || : >"$tmp_file"
     fi
   else
-    : > "$tmp_file"
+    : >"$tmp_file"
   fi
 
   printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
     "$timestamp" "$REPO_ROOT" "$branch" "$sha" "$reason" "$detail" \
-    >> "$tmp_file" 2>/dev/null || { rm -f "$tmp_file" 2>/dev/null; return 0; }
+    >>"$tmp_file" 2>/dev/null || {
+    rm -f "$tmp_file" 2>/dev/null
+    return 0
+  }
 
   mv "$tmp_file" "$log_file" 2>/dev/null || rm -f "$tmp_file" 2>/dev/null
   return 0
@@ -377,8 +380,8 @@ CONDUCTOR_TAGS=""
 CONDUCTOR_EXCLUDE=""
 ROUTING_ENABLED=true
 ROUTING_SMALL_MAX_DIFF_LINES=400
-ROUTING_SMALL_REVIEWERS=()   # legacy 1.x shape; retained for back-compat parsing
-ROUTING_LARGE_REVIEWERS=()   # legacy 1.x shape; retained for back-compat parsing
+ROUTING_SMALL_REVIEWERS=() # legacy 1.x shape; retained for back-compat parsing
+ROUTING_LARGE_REVIEWERS=() # legacy 1.x shape; retained for back-compat parsing
 # 2.0 routing knobs — override CONDUCTOR_* for small vs large diffs.
 ROUTING_SMALL_WITH=""
 ROUTING_SMALL_PREFER="cheapest"
@@ -428,8 +431,14 @@ strip_toml_string() {
   local value="$1"
   value="$(trim "$value")"
   case "$value" in
-    \"*\") value="${value#\"}"; value="${value%\"}" ;;
-    \'*\') value="${value#\'}"; value="${value%\'}" ;;
+    \"*\")
+      value="${value#\"}"
+      value="${value%\"}"
+      ;;
+    \'*\')
+      value="${value#\'}"
+      value="${value%\'}"
+      ;;
   esac
   printf '%s' "$value"
 }
@@ -487,8 +496,14 @@ append_unsafe_path() {
   value="$(trim "$value")"
 
   case "$value" in
-    \"*\") value="${value#\"}"; value="${value%\"}" ;;
-    \'*\') value="${value#\'}"; value="${value%\'}" ;;
+    \"*\")
+      value="${value#\"}"
+      value="${value%\"}"
+      ;;
+    \'*\')
+      value="${value#\'}"
+      value="${value%\'}"
+      ;;
   esac
 
   [ -z "$value" ] && return
@@ -508,7 +523,7 @@ append_unsafe_paths_csv() {
 
   [ -n "$csv" ] || return 0
 
-  IFS=',' read -r -a items <<< "$csv"
+  IFS=',' read -r -a items <<<"$csv"
   for item in "${items[@]}"; do
     append_unsafe_path "$item"
   done
@@ -521,8 +536,14 @@ append_prompt_context_path() {
   value="$(trim "$value")"
 
   case "$value" in
-    \"*\") value="${value#\"}"; value="${value%\"}" ;;
-    \'*\') value="${value#\'}"; value="${value%\'}" ;;
+    \"*\")
+      value="${value#\"}"
+      value="${value%\"}"
+      ;;
+    \'*\')
+      value="${value#\'}"
+      value="${value%\'}"
+      ;;
   esac
 
   [ -z "$value" ] && return
@@ -542,7 +563,7 @@ append_prompt_context_paths_csv() {
 
   [ -n "$csv" ] || return 0
 
-  IFS=',' read -r -a items <<< "$csv"
+  IFS=',' read -r -a items <<<"$csv"
   for item in "${items[@]}"; do
     append_prompt_context_path "$item"
   done
@@ -554,8 +575,14 @@ append_reviewer() {
   value="${value%,}"
   value="$(trim "$value")"
   case "$value" in
-    \"*\") value="${value#\"}"; value="${value%\"}" ;;
-    \'*\') value="${value#\'}"; value="${value%\'}" ;;
+    \"*\")
+      value="${value#\"}"
+      value="${value%\"}"
+      ;;
+    \'*\')
+      value="${value#\'}"
+      value="${value%\'}"
+      ;;
   esac
   [ -z "$value" ] && return
   REVIEWER_CASCADE+=("$value")
@@ -565,7 +592,7 @@ append_reviewers_csv() {
   local csv="$1" item
   local -a items=()
   [ -n "$csv" ] || return 0
-  IFS=',' read -r -a items <<< "$csv"
+  IFS=',' read -r -a items <<<"$csv"
   for item in "${items[@]}"; do
     append_reviewer "$item"
   done
@@ -577,8 +604,14 @@ append_routing_small_reviewer() {
   value="${value%,}"
   value="$(trim "$value")"
   case "$value" in
-    \"*\") value="${value#\"}"; value="${value%\"}" ;;
-    \'*\') value="${value#\'}"; value="${value%\'}" ;;
+    \"*\")
+      value="${value#\"}"
+      value="${value%\"}"
+      ;;
+    \'*\')
+      value="${value#\'}"
+      value="${value%\'}"
+      ;;
   esac
   [ -z "$value" ] && return
   ROUTING_SMALL_REVIEWERS+=("$value")
@@ -588,7 +621,7 @@ append_routing_small_reviewers_csv() {
   local csv="$1" item
   local -a items=()
   [ -n "$csv" ] || return 0
-  IFS=',' read -r -a items <<< "$csv"
+  IFS=',' read -r -a items <<<"$csv"
   for item in "${items[@]}"; do
     append_routing_small_reviewer "$item"
   done
@@ -600,8 +633,14 @@ append_routing_large_reviewer() {
   value="${value%,}"
   value="$(trim "$value")"
   case "$value" in
-    \"*\") value="${value#\"}"; value="${value%\"}" ;;
-    \'*\') value="${value#\'}"; value="${value%\'}" ;;
+    \"*\")
+      value="${value#\"}"
+      value="${value%\"}"
+      ;;
+    \'*\')
+      value="${value#\'}"
+      value="${value%\'}"
+      ;;
   esac
   [ -z "$value" ] && return
   ROUTING_LARGE_REVIEWERS+=("$value")
@@ -611,7 +650,7 @@ append_routing_large_reviewers_csv() {
   local csv="$1" item
   local -a items=()
   [ -n "$csv" ] || return 0
-  IFS=',' read -r -a items <<< "$csv"
+  IFS=',' read -r -a items <<<"$csv"
   for item in "${items[@]}"; do
     append_routing_large_reviewer "$item"
   done
@@ -623,8 +662,14 @@ append_assist_helper() {
   value="${value%,}"
   value="$(trim "$value")"
   case "$value" in
-    \"*\") value="${value#\"}"; value="${value%\"}" ;;
-    \'*\') value="${value#\'}"; value="${value%\'}" ;;
+    \"*\")
+      value="${value#\"}"
+      value="${value%\"}"
+      ;;
+    \'*\')
+      value="${value#\'}"
+      value="${value%\'}"
+      ;;
   esac
   [ -z "$value" ] && return
   ASSIST_HELPERS+=("$value")
@@ -634,7 +679,7 @@ append_assist_helpers_csv() {
   local csv="$1" item
   local -a items=()
   [ -n "$csv" ] || return 0
-  IFS=',' read -r -a items <<< "$csv"
+  IFS=',' read -r -a items <<<"$csv"
   for item in "${items[@]}"; do
     append_assist_helper "$item"
   done
@@ -650,8 +695,8 @@ normalize_bool() {
   value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
 
   case "$value" in
-    true|1|yes|on) printf 'true' ;;
-    false|0|no|off) printf 'false' ;;
+    true | 1 | yes | on) printf 'true' ;;
+    false | 0 | no | off) printf 'false' ;;
     *) printf '%s' "$value" ;;
   esac
 }
@@ -660,8 +705,14 @@ toml_string_value() {
   local value="$1"
   value="$(trim "$value")"
   case "$value" in
-    \"*\") value="${value#\"}"; value="${value%\"}" ;;
-    \'*\') value="${value#\'}"; value="${value%\'}" ;;
+    \"*\")
+      value="${value#\"}"
+      value="${value%\"}"
+      ;;
+    \'*\')
+      value="${value#\'}"
+      value="${value%\'}"
+      ;;
   esac
   printf '%s' "$value"
 }
@@ -688,25 +739,25 @@ if [ -f "$CONFIG_FILE" ]; then
     case "$section" in
       "review.conductor")
         case "$key" in
-          prefer)  CONDUCTOR_PREFER="${CONDUCTOR_PREFER:-$(toml_unquote "$value")}" ;;
-          effort)  CONDUCTOR_EFFORT="${CONDUCTOR_EFFORT:-$(toml_unquote "$value")}" ;;
-          tags)    CONDUCTOR_TAGS="${CONDUCTOR_TAGS:-$(toml_normalize_array "$value")}" ;;
-          with)    CONDUCTOR_WITH="${CONDUCTOR_WITH:-$(toml_unquote "$value")}" ;;
+          prefer) CONDUCTOR_PREFER="${CONDUCTOR_PREFER:-$(toml_unquote "$value")}" ;;
+          effort) CONDUCTOR_EFFORT="${CONDUCTOR_EFFORT:-$(toml_unquote "$value")}" ;;
+          tags) CONDUCTOR_TAGS="${CONDUCTOR_TAGS:-$(toml_normalize_array "$value")}" ;;
+          with) CONDUCTOR_WITH="${CONDUCTOR_WITH:-$(toml_unquote "$value")}" ;;
           exclude) CONDUCTOR_EXCLUDE="${CONDUCTOR_EXCLUDE:-$(toml_normalize_array "$value")}" ;;
         esac
         ;;
       "review.routing")
         case "$key" in
           enabled) ROUTING_ENABLED="$(normalize_bool "$value")" ;;
-          small_max_diff_lines|small_diff_lines) ROUTING_SMALL_MAX_DIFF_LINES="$value" ;;
-          small_with)   ROUTING_SMALL_WITH="$(toml_unquote "$value")" ;;
+          small_max_diff_lines | small_diff_lines) ROUTING_SMALL_MAX_DIFF_LINES="$value" ;;
+          small_with) ROUTING_SMALL_WITH="$(toml_unquote "$value")" ;;
           small_prefer) ROUTING_SMALL_PREFER="$(toml_unquote "$value")" ;;
           small_effort) ROUTING_SMALL_EFFORT="$(toml_unquote "$value")" ;;
-          small_tags)   ROUTING_SMALL_TAGS="$(toml_unquote "$value")" ;;
-          large_with)   ROUTING_LARGE_WITH="$(toml_unquote "$value")" ;;
+          small_tags) ROUTING_SMALL_TAGS="$(toml_unquote "$value")" ;;
+          large_with) ROUTING_LARGE_WITH="$(toml_unquote "$value")" ;;
           large_prefer) ROUTING_LARGE_PREFER="$(toml_unquote "$value")" ;;
           large_effort) ROUTING_LARGE_EFFORT="$(toml_unquote "$value")" ;;
-          large_tags)   ROUTING_LARGE_TAGS="$(toml_unquote "$value")" ;;
+          large_tags) ROUTING_LARGE_TAGS="$(toml_unquote "$value")" ;;
           small_reviewers)
             if [[ "$value" == "["* ]]; then
               append_routing_small_reviewers_csv "$(toml_normalize_array "$value")"
@@ -741,9 +792,9 @@ if [ -f "$CONFIG_FILE" ]; then
       "review.context")
         case "$key" in
           mode) PROMPT_CONTEXT_MODE="${CODEX_REVIEW_CONTEXT_MODE:-$(toml_unquote "$value")}" ;;
-          small_max_diff_lines|small_diff_lines) PROMPT_CONTEXT_SMALL_MAX_DIFF_LINES="${CODEX_REVIEW_CONTEXT_SMALL_MAX_DIFF_LINES:-$value}" ;;
-          small_max_files|max_files) PROMPT_CONTEXT_SMALL_MAX_FILES="${CODEX_REVIEW_CONTEXT_SMALL_MAX_FILES:-$value}" ;;
-          full_context_paths|full_context_patterns)
+          small_max_diff_lines | small_diff_lines) PROMPT_CONTEXT_SMALL_MAX_DIFF_LINES="${CODEX_REVIEW_CONTEXT_SMALL_MAX_DIFF_LINES:-$value}" ;;
+          small_max_files | max_files) PROMPT_CONTEXT_SMALL_MAX_FILES="${CODEX_REVIEW_CONTEXT_SMALL_MAX_FILES:-$value}" ;;
+          full_context_paths | full_context_patterns)
             if [[ "$value" == "["* ]]; then
               append_prompt_context_paths_csv "$(toml_normalize_array "$value")"
             else
@@ -766,7 +817,7 @@ if [ -f "$CONFIG_FILE" ]; then
         ;;
       "review.local")
         case "$key" in
-          command|auth_command)
+          command | auth_command)
             if [ -z "${CODEX_REVIEW_SUPPRESS_LEGACY_WARNINGS:-}" ]; then
               echo "==> NOTE: [review.local] is ignored in Touchstone 2.0.0." >&2
               echo "    Register your command as a Conductor custom provider" >&2
@@ -776,7 +827,7 @@ if [ -f "$CONFIG_FILE" ]; then
             ;;
         esac
         ;;
-      ""|"codex_review")
+      "" | "codex_review")
         case "$key" in
           max_iterations) MAX_ITERATIONS="${CODEX_REVIEW_MAX_ITERATIONS:-$value}" ;;
           max_diff_lines) MAX_DIFF_LINES="${CODEX_REVIEW_MAX_DIFF_LINES:-$value}" ;;
@@ -845,7 +896,7 @@ REVIEWER_CASCADE=("conductor")
 # v1.x peer-review (ASSIST_HELPERS) is disabled in 2.0.0 and returns in v2.1
 # via `conductor call --exclude <primary_provider>`. Users who had it enabled
 # get a warning; the setting is ignored rather than throwing.
-ASSIST_HELPERS=()  # 1.x helpers field is ignored — Conductor picks the peer.
+ASSIST_HELPERS=() # 1.x helpers field is ignored — Conductor picks the peer.
 
 REVIEW_ENABLED="$(normalize_bool "$REVIEW_ENABLED")"
 ROUTING_ENABLED="$(normalize_bool "$ROUTING_ENABLED")"
@@ -873,7 +924,7 @@ if [ -n "${TOUCHSTONE_REVIEWER:-}" ]; then
       # TOUCHSTONE_REVIEWER is env-scoped, so it trumps the TOML `with=` pin.
       CONDUCTOR_WITH="ollama"
       ;;
-    codex|claude|gemini)
+    codex | claude | gemini)
       echo "==> NOTE: TOUCHSTONE_REVIEWER=$TOUCHSTONE_REVIEWER is deprecated in 2.0.0." >&2
       echo "    Pin an underlying provider with: TOUCHSTONE_CONDUCTOR_WITH=$TOUCHSTONE_REVIEWER" >&2
       CONDUCTOR_WITH="$TOUCHSTONE_REVIEWER"
@@ -915,7 +966,7 @@ resolve_mode() {
   [ -n "$mode" ] || mode="${CONFIG_MODE:-fix}"
 
   case "$mode" in
-    review-only|fix|diff-only|no-tests) ;;
+    review-only | fix | diff-only | no-tests) ;;
     *)
       echo "WARNING: Invalid mode '$mode' — falling back to 'fix'. Valid: review-only, fix, diff-only, no-tests" >&2
       mode="fix"
@@ -926,7 +977,7 @@ resolve_mode() {
 
 REVIEW_MODE="$(resolve_mode)"
 
-mode_allows_fix()  { [ "$REVIEW_MODE" = "fix" ] || [ "$REVIEW_MODE" = "no-tests" ]; }
+mode_allows_fix() { [ "$REVIEW_MODE" = "fix" ] || [ "$REVIEW_MODE" = "no-tests" ]; }
 mode_allows_bash() { [ "$REVIEW_MODE" = "fix" ] || [ "$REVIEW_MODE" = "review-only" ]; }
 
 short_ref_name() {
@@ -982,10 +1033,9 @@ path_matches_context_pattern() {
     */)
       [[ "$path" == "$pattern"* ]] && return 0
       ;;
-    *\**|*\?*|*\[*)
-      case "$path" in
-        $pattern) return 0 ;;
-      esac
+    *\** | *\?* | *\[*)
+      # shellcheck disable=SC2053 # Configured context patterns intentionally use globs.
+      [[ "$path" == $pattern ]] && return 0
       ;;
     *)
       if [ "$path" = "$pattern" ] || [[ "$path" == "$pattern/"* ]]; then
@@ -1013,8 +1063,8 @@ find_path_matching_context_patterns() {
         printf '%s (matched %s)' "$path" "$pattern"
         return 0
       fi
-    done <<< "$patterns"
-  done <<< "$paths"
+    done <<<"$patterns"
+  done <<<"$paths"
 
   return 1
 }
@@ -1028,7 +1078,7 @@ select_prompt_context_mode() {
   requested="$(printf '%s' "${PROMPT_CONTEXT_MODE:-auto}" | tr '[:upper:]' '[:lower:]')"
 
   case "$requested" in
-    auto|bounded|full) ;;
+    auto | bounded | full) ;;
     *)
       echo "WARNING: Invalid review.context.mode='$PROMPT_CONTEXT_MODE' — using auto." >&2
       requested="auto"
@@ -1042,7 +1092,7 @@ select_prompt_context_mode() {
   fi
 
   case "$PROMPT_CONTEXT_SMALL_MAX_DIFF_LINES" in
-    ''|*[!0-9]*)
+    '' | *[!0-9]*)
       PROMPT_CONTEXT_DECISION="full"
       PROMPT_CONTEXT_REASON="invalid review.context.small_max_diff_lines='$PROMPT_CONTEXT_SMALL_MAX_DIFF_LINES'"
       return 0
@@ -1050,7 +1100,7 @@ select_prompt_context_mode() {
   esac
 
   case "$PROMPT_CONTEXT_SMALL_MAX_FILES" in
-    ''|*[!0-9]*)
+    '' | *[!0-9]*)
       PROMPT_CONTEXT_DECISION="full"
       PROMPT_CONTEXT_REASON="invalid review.context.small_max_files='$PROMPT_CONTEXT_SMALL_MAX_FILES'"
       return 0
@@ -1300,7 +1350,7 @@ reviewer_conductor_exec() {
 conductor_subcommand_for_mode() {
   case "$REVIEW_MODE" in
     diff-only) printf 'call' ;;
-    *)         printf 'exec' ;;
+    *) printf 'exec' ;;
   esac
 }
 
@@ -1396,7 +1446,7 @@ apply_review_routing() {
   [ -z "${TOUCHSTONE_REVIEWER:-}" ] || return 0
 
   case "$ROUTING_SMALL_MAX_DIFF_LINES" in
-    ''|*[!0-9]*)
+    '' | *[!0-9]*)
       echo "WARNING: Invalid review.routing.small_max_diff_lines='$ROUTING_SMALL_MAX_DIFF_LINES' — ignoring routing." >&2
       return 0
       ;;
@@ -1419,18 +1469,18 @@ apply_review_routing() {
     # Apply 2.0 small-bucket overrides. Non-empty fields win; env still
     # trumps via the earlier cascade (TOUCHSTONE_CONDUCTOR_* set on the
     # command line or in the shell override the config-driven bucket).
-    [ -n "$ROUTING_SMALL_WITH" ]   && CONDUCTOR_WITH="${TOUCHSTONE_CONDUCTOR_WITH:-$ROUTING_SMALL_WITH}"
+    [ -n "$ROUTING_SMALL_WITH" ] && CONDUCTOR_WITH="${TOUCHSTONE_CONDUCTOR_WITH:-$ROUTING_SMALL_WITH}"
     [ -n "$ROUTING_SMALL_PREFER" ] && CONDUCTOR_PREFER="${TOUCHSTONE_CONDUCTOR_PREFER:-$ROUTING_SMALL_PREFER}"
     [ -n "$ROUTING_SMALL_EFFORT" ] && CONDUCTOR_EFFORT="${TOUCHSTONE_CONDUCTOR_EFFORT:-$ROUTING_SMALL_EFFORT}"
-    [ -n "$ROUTING_SMALL_TAGS" ]   && CONDUCTOR_TAGS="${TOUCHSTONE_CONDUCTOR_TAGS:-$ROUTING_SMALL_TAGS}"
+    [ -n "$ROUTING_SMALL_TAGS" ] && CONDUCTOR_TAGS="${TOUCHSTONE_CONDUCTOR_TAGS:-$ROUTING_SMALL_TAGS}"
     echo "==> Review routing: small diff ($diff_lines <= $ROUTING_SMALL_MAX_DIFF_LINES) — with=${CONDUCTOR_WITH:-auto} prefer=$CONDUCTOR_PREFER effort=$CONDUCTOR_EFFORT"
   else
     REVIEWER_CASCADE=("${ROUTING_LARGE_REVIEWERS[@]}")
     ROUTING_DECISION="large"
-    [ -n "$ROUTING_LARGE_WITH" ]   && CONDUCTOR_WITH="${TOUCHSTONE_CONDUCTOR_WITH:-$ROUTING_LARGE_WITH}"
+    [ -n "$ROUTING_LARGE_WITH" ] && CONDUCTOR_WITH="${TOUCHSTONE_CONDUCTOR_WITH:-$ROUTING_LARGE_WITH}"
     [ -n "$ROUTING_LARGE_PREFER" ] && CONDUCTOR_PREFER="${TOUCHSTONE_CONDUCTOR_PREFER:-$ROUTING_LARGE_PREFER}"
     [ -n "$ROUTING_LARGE_EFFORT" ] && CONDUCTOR_EFFORT="${TOUCHSTONE_CONDUCTOR_EFFORT:-$ROUTING_LARGE_EFFORT}"
-    [ -n "$ROUTING_LARGE_TAGS" ]   && CONDUCTOR_TAGS="${TOUCHSTONE_CONDUCTOR_TAGS:-$ROUTING_LARGE_TAGS}"
+    [ -n "$ROUTING_LARGE_TAGS" ] && CONDUCTOR_TAGS="${TOUCHSTONE_CONDUCTOR_TAGS:-$ROUTING_LARGE_TAGS}"
     echo "==> Review routing: larger diff ($diff_lines > $ROUTING_SMALL_MAX_DIFF_LINES) — with=${CONDUCTOR_WITH:-auto} prefer=$CONDUCTOR_PREFER effort=$CONDUCTOR_EFFORT"
   fi
 }
@@ -1442,7 +1492,7 @@ run_reviewer() {
 reviewer_label_for() {
   case "$1" in
     conductor) printf 'Conductor' ;;
-    *)         printf '%s' "$1" ;;
+    *) printf '%s' "$1" ;;
   esac
 }
 
@@ -1484,17 +1534,17 @@ run_reviewer_with_timeout() {
   # we want to surface in the transcript. Pre-2.0 reviewers wrote noise to
   # stderr, hence the historical /dev/null redirect; capturing instead is
   # safe because non-[conductor] lines are filtered before display.
-  : > "$REVIEW_STDERR_FILE"
+  : >"$REVIEW_STDERR_FILE"
 
   # No timeout: run directly
   if [ "$timeout_secs" -le 0 ] 2>/dev/null; then
-    run_reviewer "$prompt" > "$output_file" 2>>"$REVIEW_STDERR_FILE"
+    run_reviewer "$prompt" >"$output_file" 2>>"$REVIEW_STDERR_FILE"
     return $?
   fi
 
   # Run reviewer in background, kill if it exceeds timeout.
   (
-    run_reviewer "$prompt" > "$output_file" 2>>"$REVIEW_STDERR_FILE" &
+    run_reviewer "$prompt" >"$output_file" 2>>"$REVIEW_STDERR_FILE" &
     local reviewer_pid=$!
 
     terminate_reviewer() {
@@ -1536,9 +1586,9 @@ handle_error() {
   # log and console output are unambiguous about *why* the safety net opened.
   local fail_open_code
   case "$reason" in
-    timeout*)             fail_open_code="FAIL_OPEN_TIMEOUT" ;;
+    timeout*) fail_open_code="FAIL_OPEN_TIMEOUT" ;;
     "malformed sentinel") fail_open_code="FAIL_OPEN_PARSE_ERROR" ;;
-    *)                    fail_open_code="FAIL_OPEN_REVIEWER_ERROR" ;;
+    *) fail_open_code="FAIL_OPEN_REVIEWER_ERROR" ;;
   esac
 
   if [ "$ON_ERROR" = "fail-closed" ]; then
@@ -1697,9 +1747,9 @@ $(git log --reverse --format='### %s%n%n%b' "$MERGE_BASE"..HEAD 2>/dev/null | se
 
 Examine the diff vs $BASE using your tools.
 $(if [ "$REVIEW_MODE" = "diff-only" ]; then
-printf '\n## Diff (included because mode=diff-only restricts tool access)\n\n```\n'
-git diff "$MERGE_BASE"..HEAD 2>/dev/null
-printf '```\n'
+  printf '\n## Diff (included because mode=diff-only restricts tool access)\n\n```\n'
+  git diff "$MERGE_BASE"..HEAD 2>/dev/null
+  printf '```\n'
 fi)
 
 ## Auto-fix policy
@@ -1707,8 +1757,8 @@ fi)
 $AUTOFIX_POLICY
 $(build_assist_policy)
 $(if [ -n "$REVIEW_CONTEXT_FILE" ]; then
-printf '\n## Project review context\n\n'
-cat "$REVIEW_CONTEXT_FILE"
+  printf '\n## Project review context\n\n'
+  cat "$REVIEW_CONTEXT_FILE"
 fi)
 
 ## Output contract — strict
@@ -1738,7 +1788,6 @@ if [ -n "$SENTINEL_JOURNAL_CONTEXT" ]; then
 ${REVIEW_PROMPT}"
   echo "==> Sentinel cycle journal injected into reviewer context."
 fi
-
 
 # --------------------------------------------------------------------------
 # Clean-review cache
@@ -1873,7 +1922,7 @@ write_clean_review_marker() {
     printf 'head=%s\n' "$(git rev-parse HEAD 2>/dev/null || echo unknown)"
     printf 'diff_lines=%s\n' "$line_count"
     printf 'reviewed_at=%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-  } > "$marker_file" 2>/dev/null || true
+  } >"$marker_file" 2>/dev/null || true
 }
 
 write_clean_review_cache() {
@@ -1893,7 +1942,7 @@ write_clean_review_cache() {
     printf 'head=%s\n' "$(git rev-parse HEAD 2>/dev/null || echo unknown)"
     printf 'diff_lines=%s\n' "$line_count"
     printf 'reviewed_at=%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-  } > "$cache_file" 2>/dev/null || true
+  } >"$cache_file" 2>/dev/null || true
 }
 
 # --------------------------------------------------------------------------
@@ -1959,7 +2008,7 @@ write_review_findings() {
     printf -- '--- findings start ---\n'
     printf '%s\n' "$findings_block"
     printf -- '--- findings end ---\n'
-  } > "$findings_file" 2>/dev/null || true
+  } >"$findings_file" 2>/dev/null || true
 }
 
 clear_review_findings() {
@@ -2060,7 +2109,7 @@ path_is_unsafe() {
         fi
         ;;
     esac
-  done <<< "$UNSAFE_PATHS"
+  done <<<"$UNSAFE_PATHS"
 
   return 1
 }
@@ -2094,7 +2143,7 @@ $path"
         disallowed="$path"
       fi
     fi
-  done <<< "$changed"
+  done <<<"$changed"
 
   printf '%s' "$disallowed"
 }
@@ -2136,9 +2185,9 @@ Commit messages:
 
 $(git log --reverse --format='### %s%n%n%b' "$MERGE_BASE"..HEAD 2>/dev/null | sed '/^$/N;/^\n$/d')
 $(if [ -n "$REVIEW_CONTEXT_FILE" ]; then
-printf '\n## Project review context\n\n'
-cat "$REVIEW_CONTEXT_FILE"
-fi)
+    printf '\n## Project review context\n\n'
+    cat "$REVIEW_CONTEXT_FILE"
+  fi)
 
 ## Diff
 
@@ -2273,10 +2322,16 @@ print_route_log() {
 # shellcheck disable=SC2120  # $1 is intentionally optional with a default.
 parse_primary_provider() {
   local stderr_file="${1:-$REVIEW_STDERR_FILE}"
-  [ -f "$stderr_file" ] || { printf ''; return; }
+  [ -f "$stderr_file" ] || {
+    printf ''
+    return
+  }
   local line
   line="$(grep -m1 '^\[conductor\]' "$stderr_file" 2>/dev/null || true)"
-  [ -n "$line" ] || { printf ''; return; }
+  [ -n "$line" ] || {
+    printf ''
+    return
+  }
   # Extract the provider name following the arrow. Handles:
   #   [conductor] auto (...) → claude (tier: ...)
   #   [conductor] auto (...) -> claude (tier: ...)
@@ -2335,11 +2390,11 @@ run_peer_review() {
   # relies on conductor's own per-provider timeout (currently 300s default).
   peer_output="$(printf '%s' "$peer_prompt" \
     | conductor call --auto \
-        --exclude "$primary_provider" \
-        --tags code-review \
-        --effort medium \
-        --silent-route \
-        2>/dev/null || true)"
+      --exclude "$primary_provider" \
+      --tags code-review \
+      --effort medium \
+      --silent-route \
+      2>/dev/null || true)"
 
   if [ -z "$peer_output" ]; then
     phase "peer review produced no output (skipped)"
@@ -2410,7 +2465,7 @@ check_worktree_invariants() {
 
 print_summary() {
   local elapsed mins secs findings
-  elapsed=$(( $(date +%s) - REVIEW_START_TIME ))
+  elapsed=$(($(date +%s) - REVIEW_START_TIME))
   mins=$((elapsed / 60))
   secs=$((elapsed % 60))
   findings="${REVIEW_FINDINGS_COUNT:-0}"
@@ -2436,7 +2491,7 @@ print_summary() {
     printf '{"reviewer":"%s","route":"%s","mode":"%s","files":%d,"diff_lines":%d,"iterations":%d,"fix_commits":%d,"peer_assists":%d,"findings":%d,"exit_reason":"%s","elapsed_seconds":%d}\n' \
       "$REVIEWER_LABEL" "$ROUTING_DECISION" "$REVIEW_MODE" "$REVIEW_FILES_INSPECTED" "$DIFF_LINE_COUNT" \
       "${iter:-0}" "$FIX_COMMITS" "$ASSIST_ROUNDS" "$findings" "$REVIEW_EXIT_REASON" "$elapsed" \
-      > "$CODEX_REVIEW_SUMMARY_FILE" 2>/dev/null || true
+      >"$CODEX_REVIEW_SUMMARY_FILE" 2>/dev/null || true
   fi
 }
 
@@ -2470,8 +2525,10 @@ tk_paint() {
   # Falls back to plain text if gum is missing, disabled, or fails —
   # the hook is running under `set -euo pipefail`, so silent gum failure
   # would otherwise produce empty strings in the verdict lines.
-  local color="$1"; shift
-  local flag="$1"; shift
+  local color="$1"
+  shift
+  local flag="$1"
+  shift
   local rendered=""
   if [ "$C_TTY" = "1" ] && tk_have_gum; then
     if [ "$flag" = "bold" ]; then
@@ -2503,7 +2560,7 @@ tk_signature_line() {
   # Dim "touchstone vX.Y.Z" line; version resolved via TOUCHSTONE_ROOT when set.
   local version=""
   if [ -n "${TOUCHSTONE_ROOT:-}" ] && [ -f "$TOUCHSTONE_ROOT/VERSION" ]; then
-    version="$(tr -d '[:space:]' < "$TOUCHSTONE_ROOT/VERSION" 2>/dev/null || true)"
+    version="$(tr -d '[:space:]' <"$TOUCHSTONE_ROOT/VERSION" 2>/dev/null || true)"
   fi
   if [ -n "$version" ]; then
     tk_paint "$TK_BRAND_DIM" plain "touchstone v${version}"
@@ -2519,12 +2576,18 @@ tk_verdict() {
   rail="$(tk_rail)"
 
   case "$state" in
-    ok)   mark="$(tk_paint "$TK_BRAND_LIME" plain "✓")"
-          painted_headline="$(tk_paint "$TK_BRAND_LIME" bold "$headline")" ;;
-    fail) mark="$(tk_paint "$TK_BRAND_RED"  plain "✗")"
-          painted_headline="$(tk_paint "$TK_BRAND_RED"  bold "$headline")" ;;
-    *)    mark="$(tk_paint "$TK_BRAND_DIM"  plain "•")"
-          painted_headline="$(tk_paint "$TK_BRAND_DIM"  bold "$headline")" ;;
+    ok)
+      mark="$(tk_paint "$TK_BRAND_LIME" plain "✓")"
+      painted_headline="$(tk_paint "$TK_BRAND_LIME" bold "$headline")"
+      ;;
+    fail)
+      mark="$(tk_paint "$TK_BRAND_RED" plain "✗")"
+      painted_headline="$(tk_paint "$TK_BRAND_RED" bold "$headline")"
+      ;;
+    *)
+      mark="$(tk_paint "$TK_BRAND_DIM" plain "•")"
+      painted_headline="$(tk_paint "$TK_BRAND_DIM" bold "$headline")"
+      ;;
   esac
 
   printf '\n  %s  %s  %s\n' "$rail" "$painted_headline" "$mark"
@@ -2599,8 +2662,8 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
   # peer's verdict does NOT gate the merge; the primary's sentinel wins.
   # Fires once per iteration, respects ASSIST_MAX_ROUNDS.
   if is_truthy "${ASSIST_ENABLED:-false}" \
-      && [ "${ASSIST_ROUNDS_DONE:-0}" -lt "${ASSIST_MAX_ROUNDS:-1}" ] \
-      && [ -n "$OUTPUT" ]; then
+    && [ "${ASSIST_ROUNDS_DONE:-0}" -lt "${ASSIST_MAX_ROUNDS:-1}" ] \
+    && [ -n "$OUTPUT" ]; then
     run_peer_review "$OUTPUT" || true
   fi
 

--- a/scripts/cortex-pr-merged-hook.sh
+++ b/scripts/cortex-pr-merged-hook.sh
@@ -72,7 +72,10 @@ truthy() {
 read_config_value() {
   local config_file="$1" key="$2"
   local line lhs rhs result=""
-  [ -f "$config_file" ] || { printf ''; return 0; }
+  [ -f "$config_file" ] || {
+    printf ''
+    return 0
+  }
   while IFS= read -r line || [ -n "$line" ]; do
     line="${line#"${line%%[![:space:]]*}"}"
     case "$line" in '#'* | '') continue ;; esac
@@ -86,7 +89,7 @@ read_config_value() {
       rhs="${rhs%"${rhs##*[![:space:]]}"}"
       result="$rhs"
     fi
-  done < "$config_file"
+  done <"$config_file"
   printf '%s' "$result"
 }
 

--- a/scripts/dogfood-agent-steering.sh
+++ b/scripts/dogfood-agent-steering.sh
@@ -78,32 +78,50 @@ EOF
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --providers)
-      [ "$#" -ge 2 ] || { echo "ERROR: --providers requires a value" >&2; exit 1; }
+      [ "$#" -ge 2 ] || {
+        echo "ERROR: --providers requires a value" >&2
+        exit 1
+      }
       PROVIDERS="$2"
       shift 2
       ;;
     --personas)
-      [ "$#" -ge 2 ] || { echo "ERROR: --personas requires a value" >&2; exit 1; }
+      [ "$#" -ge 2 ] || {
+        echo "ERROR: --personas requires a value" >&2
+        exit 1
+      }
       PERSONAS="$2"
       shift 2
       ;;
     --prefer)
-      [ "$#" -ge 2 ] || { echo "ERROR: --prefer requires a value" >&2; exit 1; }
+      [ "$#" -ge 2 ] || {
+        echo "ERROR: --prefer requires a value" >&2
+        exit 1
+      }
       PREFER="$2"
       shift 2
       ;;
     --effort)
-      [ "$#" -ge 2 ] || { echo "ERROR: --effort requires a value" >&2; exit 1; }
+      [ "$#" -ge 2 ] || {
+        echo "ERROR: --effort requires a value" >&2
+        exit 1
+      }
       EFFORT="$2"
       shift 2
       ;;
     --tags)
-      [ "$#" -ge 2 ] || { echo "ERROR: --tags requires a value" >&2; exit 1; }
+      [ "$#" -ge 2 ] || {
+        echo "ERROR: --tags requires a value" >&2
+        exit 1
+      }
       TAGS="$2"
       shift 2
       ;;
     --timeout)
-      [ "$#" -ge 2 ] || { echo "ERROR: --timeout requires a value" >&2; exit 1; }
+      [ "$#" -ge 2 ] || {
+        echo "ERROR: --timeout requires a value" >&2
+        exit 1
+      }
       TIMEOUT="$2"
       shift 2
       ;;
@@ -112,11 +130,14 @@ while [ "$#" -gt 0 ]; do
       shift
       ;;
     --validate-response)
-      [ "$#" -ge 2 ] || { echo "ERROR: --validate-response requires a file" >&2; exit 1; }
+      [ "$#" -ge 2 ] || {
+        echo "ERROR: --validate-response requires a file" >&2
+        exit 1
+      }
       VALIDATE_RESPONSE_FILE="$2"
       shift 2
       ;;
-    -h|--help)
+    -h | --help)
       usage
       exit 0
       ;;
@@ -171,7 +192,7 @@ bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_DIR" \
   --no-initial-commit >/dev/null
 
 mkdir -p "$PROJECT_DIR/src"
-cat > "$PROJECT_DIR/src/example.py" <<'EOF'
+cat >"$PROJECT_DIR/src/example.py" <<'EOF'
 def load_value(path):
     try:
         with open(path, "r", encoding="utf-8") as handle:
@@ -245,7 +266,7 @@ worker/reviewer router whose provider fallback happens inside Conductor.
 After the machine-check block, add at most five concise bullets explaining the
 evidence you found in the docs.
 EOF
-  } > "$brief_file"
+  } >"$brief_file"
 }
 
 run_conductor() {
@@ -275,8 +296,8 @@ run_conductor() {
   fi
 }
 
-IFS=',' read -r -a provider_list <<< "$PROVIDERS"
-IFS=',' read -r -a persona_list <<< "$PERSONAS"
+IFS=',' read -r -a provider_list <<<"$PROVIDERS"
+IFS=',' read -r -a persona_list <<<"$PERSONAS"
 
 total=0
 failed=0

--- a/scripts/emergency-disclosure.sh
+++ b/scripts/emergency-disclosure.sh
@@ -75,7 +75,7 @@ log_file="$log_dir/emergency-bypass.log"
 mkdir -p "$log_dir" 2>/dev/null || true
 {
   printf '%s\t%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$command"
-} >> "$log_file" 2>/dev/null || true
+} >>"$log_file" 2>/dev/null || true
 
 echo "emergency-disclosure: TOUCHSTONE_EMERGENCY=1 — push allowed; logged to ${log_file#"$cwd/"} for next-PR disclosure" >&2
 exit 0

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -99,7 +99,7 @@ DEFAULT_BRANCH="$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.n
 
 truthy() {
   case "$(printf '%s' "${1:-false}" | tr '[:upper:]' '[:lower:]')" in
-    true|1|yes|on) return 0 ;;
+    true | 1 | yes | on) return 0 ;;
     *) return 1 ;;
   esac
 }
@@ -335,7 +335,7 @@ record_squash_merge() {
   fi
 
   if ! map_path="$(git rev-parse --git-path touchstone/squash-map.jsonl 2>/dev/null)" \
-      || [ -z "$map_path" ]; then
+    || [ -z "$map_path" ]; then
     echo "WARNING: record_squash_merge: could not resolve squash-map path; skipping." >&2
     return 0
   fi
@@ -355,7 +355,7 @@ record_squash_merge() {
   local field
   for field in "$branch" "$pr" "$branch_oid" "$squash_commit" "$ts"; do
     case "$field" in
-      *\"*|*\\*)
+      *\"* | *\\*)
         echo "WARNING: record_squash_merge: field contains quote/backslash, skipping squash-map write." >&2
         return 0
         ;;
@@ -364,7 +364,7 @@ record_squash_merge() {
 
   local line
   line="{\"branch\":\"$branch\",\"pr\":\"$pr\",\"branch_oid\":\"$branch_oid\",\"squash_commit\":\"$squash_commit\",\"ts\":\"$ts\"}"
-  if ! printf '%s\n' "$line" >> "$map_path" 2>/dev/null; then
+  if ! printf '%s\n' "$line" >>"$map_path" 2>/dev/null; then
     echo "WARNING: record_squash_merge: could not append to $map_path; skipping squash-map write." >&2
     return 0
   fi

--- a/scripts/open-pr.sh
+++ b/scripts/open-pr.sh
@@ -142,7 +142,7 @@ cleanup_feature_worktree() {
 
   echo "==> Removing feature worktree $current_path (from $default_path) ..."
   touchstone_emit_event cleanup_started worktree_path="$current_path"
-  if ( cd "$default_path" && git worktree remove "$current_path" ); then
+  if (cd "$default_path" && git worktree remove "$current_path"); then
     echo "==> Worktree removed."
     touchstone_emit_event cleanup_done worktree_path="$current_path" result=removed
   else
@@ -228,13 +228,16 @@ if ! git diff --quiet || ! git diff --cached --quiet || [ -n "$UNTRACKED" ]; the
     echo "         Untracked files detected:" >&2
     while IFS= read -r untracked_file; do
       printf '           %s\n' "$untracked_file" >&2
-    done <<< "$UNTRACKED"
+    done <<<"$UNTRACKED"
   fi
   echo "         Commit them first if they should be part of the PR." >&2
   read -r -p "         Continue anyway? [y/N] " answer
   case "$answer" in
-    y|Y|yes|YES) ;;
-    *) echo "Aborted."; exit 1 ;;
+    y | Y | yes | YES) ;;
+    *)
+      echo "Aborted."
+      exit 1
+      ;;
   esac
 fi
 
@@ -247,9 +250,18 @@ POSITIONAL=()
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    --draft) DRAFT_FLAG="--draft"; shift ;;
-    --auto-merge) AUTO_MERGE=true; shift ;;
-    --cleanup-worktree) CLEANUP_WORKTREE=true; shift ;;
+    --draft)
+      DRAFT_FLAG="--draft"
+      shift
+      ;;
+    --auto-merge)
+      AUTO_MERGE=true
+      shift
+      ;;
+    --cleanup-worktree)
+      CLEANUP_WORKTREE=true
+      shift
+      ;;
     --base)
       if [ "$#" -lt 2 ]; then
         echo "ERROR: --base requires a branch name." >&2
@@ -258,7 +270,10 @@ while [ "$#" -gt 0 ]; do
       BASE_OVERRIDE="$2"
       shift 2
       ;;
-    *) POSITIONAL+=("$1"); shift ;;
+    *)
+      POSITIONAL+=("$1")
+      shift
+      ;;
   esac
 done
 set -- "${POSITIONAL[@]+"${POSITIONAL[@]}"}"
@@ -414,7 +429,7 @@ BODY_FILE="$(mktemp -t touchstone-pr-body.XXXXXX.md)"
     while IFS= read -r issue_number; do
       [ -n "$issue_number" ] || continue
       printf 'Closes #%s\n' "$issue_number"
-    done <<< "$LINKED_ISSUES"
+    done <<<"$LINKED_ISSUES"
     printf '\n'
   fi
   if [ -n "$SENTINEL_BODY" ]; then
@@ -427,7 +442,7 @@ BODY_FILE="$(mktemp -t touchstone-pr-body.XXXXXX.md)"
       cat "$TEMPLATE_PATH"
     fi
   fi
-} > "$BODY_FILE"
+} >"$BODY_FILE"
 
 echo "==> Opening PR against $BASE_BRANCH ..."
 if [ -n "$DRAFT_FLAG" ]; then

--- a/scripts/refresh-principles.sh
+++ b/scripts/refresh-principles.sh
@@ -79,7 +79,7 @@ This block is managed by \`touchstone\` and refreshes on \`touchstone update\` /
 
 # Generate the full block
 tmp_block="$(mktemp)"
-printf "%s\n%s\n%s" "$BLOCK_HEADER" "$(render_principles)" "$BLOCK_FOOTER" > "$tmp_block"
+printf "%s\n%s\n%s" "$BLOCK_HEADER" "$(render_principles)" "$BLOCK_FOOTER" >"$tmp_block"
 
 # Update lib/agents-principles-block.sh
 # We use a sed-like approach to replace the block inside agents_principles_block_render()
@@ -98,9 +98,9 @@ awk '
   in_render && /^BLOCK/ { in_render = 0; print; next }
   in_render && replaced { next }
   { print }
-' "$OUTPUT_LIB" "$tmp_block" > "$tmp_lib"
+' "$OUTPUT_LIB" "$tmp_block" >"$tmp_lib"
 
-cat "$tmp_lib" > "$OUTPUT_LIB"
+cat "$tmp_lib" >"$OUTPUT_LIB"
 rm "$tmp_lib" "$tmp_block"
 
 echo "Successfully refreshed $OUTPUT_LIB from $PRINCIPLES_DIR"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -18,8 +18,11 @@ cd "$REPO_ROOT"
 
 bump="${1:---patch}"
 case "$bump" in
-  --major|--minor|--patch) ;;
-  *) echo "ERROR: unknown bump arg: $bump (use --major, --minor, --patch)" >&2; exit 1 ;;
+  --major | --minor | --patch) ;;
+  *)
+    echo "ERROR: unknown bump arg: $bump (use --major, --minor, --patch)" >&2
+    exit 1
+    ;;
 esac
 
 TOUCHSTONE_NO_AUTO_UPDATE=1 exec bin/touchstone release "$bump"

--- a/scripts/run-pytest-in-venv.sh
+++ b/scripts/run-pytest-in-venv.sh
@@ -79,7 +79,7 @@ find_worktree_parent_root() {
     return 1
   fi
 
-  IFS= read -r gitdir < "$git_file" || {
+  IFS= read -r gitdir <"$git_file" || {
     echo "       Worktree check failed: cannot read gitdir from $git_file" >&2
     return 1
   }

--- a/scripts/spawn-worktree.sh
+++ b/scripts/spawn-worktree.sh
@@ -30,7 +30,7 @@ if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
 fi
 
 case "$1" in
-  -h|--help)
+  -h | --help)
     usage
     exit 0
     ;;
@@ -122,7 +122,7 @@ guard_worktreeinclude_patterns() {
         exit 1
         ;;
     esac
-  done < "$include_file"
+  done <"$include_file"
 }
 
 DEFAULT_REF="$(resolve_default_ref)"
@@ -164,9 +164,9 @@ if [ -f "$INCLUDE_FILE" ]; then
   STANDARD_LIST="$(mktemp)"
   trap 'rm -f "$INCLUDE_LIST" "$STANDARD_LIST"' EXIT
   git ls-files --others --ignored --exclude-from="$INCLUDE_FILE" \
-    | LC_ALL=C sort > "$INCLUDE_LIST"
+    | LC_ALL=C sort >"$INCLUDE_LIST"
   git ls-files --others --ignored --exclude-standard \
-    | LC_ALL=C sort > "$STANDARD_LIST"
+    | LC_ALL=C sort >"$STANDARD_LIST"
 
   while IFS= read -r ignored_file; do
     [ -n "$ignored_file" ] || continue

--- a/scripts/touchstone-run.sh
+++ b/scripts/touchstone-run.sh
@@ -168,7 +168,12 @@ has_package_script() {
 run_shell_command() {
   local command="$1"
   info "$command"
-  env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE bash -c "$command"
+  env \
+    -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE \
+    -u PRE_COMMIT -u PRE_COMMIT_FROM_REF -u PRE_COMMIT_TO_REF \
+    -u PRE_COMMIT_LOCAL_BRANCH -u PRE_COMMIT_REMOTE_BRANCH \
+    -u PRE_COMMIT_REMOTE_NAME -u PRE_COMMIT_REMOTE_URL \
+    bash -c "$command"
 }
 
 configured_command_for_action() {

--- a/scripts/touchstone-run.sh
+++ b/scripts/touchstone-run.sh
@@ -68,7 +68,7 @@ load_config() {
     value="$(trim "${line#*=}")"
 
     case "$key" in
-      project_type | profile) PROJECT_TYPE="$value" ;;
+      project_type|profile) PROJECT_TYPE="$value" ;;
       package_manager) PACKAGE_MANAGER="$value" ;;
       monorepo) MONOREPO="$value" ;;
       targets) TARGETS="$value" ;;
@@ -78,7 +78,7 @@ load_config() {
       test_command) TEST_COMMAND="$value" ;;
       validate_command) VALIDATE_COMMAND="$value" ;;
     esac
-  done <"$CONFIG_FILE"
+  done < "$CONFIG_FILE"
 }
 
 detect_node_package_manager() {
@@ -196,7 +196,7 @@ run_node_script() {
     pnpm) command="pnpm $script" ;;
     yarn) command="yarn $script" ;;
     bun) command="bun run $script" ;;
-    npm | *) command="npm run $script" ;;
+    npm|*) command="npm run $script" ;;
   esac
 
   run_shell_command "$command"
@@ -265,7 +265,7 @@ find_worktree_parent_root() {
     return 1
   fi
 
-  IFS= read -r gitdir <"$git_file" || {
+  IFS= read -r gitdir < "$git_file" || {
     echo "       Worktree check failed: cannot read gitdir from $git_file" >&2
     return 1
   }
@@ -311,7 +311,7 @@ run_node_action() {
   local action="$1"
 
   case "$action" in
-    lint | typecheck | build | test)
+    lint|typecheck|build|test)
       if run_node_script "$action"; then
         return 0
       fi
@@ -430,7 +430,7 @@ run_swift_action() {
         ok "swift-format not installed; skipped"
       fi
       ;;
-    typecheck | build) run_shell_command "swift build" ;;
+    typecheck|build) run_shell_command "swift build" ;;
     test) run_shell_command "swift test" ;;
     build_if_distinct)
       : # swift typecheck IS swift build — running it again would repeat
@@ -452,7 +452,7 @@ run_go_action() {
 
   case "$action" in
     lint) run_shell_command "go vet ./..." ;;
-    typecheck | build) run_shell_command "go build ./..." ;;
+    typecheck|build) run_shell_command "go build ./..." ;;
     test) run_shell_command "go test ./..." ;;
     build_if_distinct)
       : # go typecheck IS go build — running it again would repeat
@@ -468,12 +468,12 @@ run_profile_action() {
   local profile="$1" action="$2"
 
   case "$profile" in
-    node | typescript | ts) run_node_action "$action" ;;
+    node|typescript|ts) run_node_action "$action" ;;
     python) run_python_action "$action" ;;
     rust) run_rust_action "$action" ;;
     swift) run_swift_action "$action" ;;
     go) run_go_action "$action" ;;
-    generic | "")
+    generic|"")
       # build_if_distinct is a validate-time extra — silently no-op for generic
       # so "touchstone run validate" doesn't print a scary "no default command"
       # line on every non-typed project.
@@ -495,7 +495,7 @@ run_targets_action() {
 
   [ -n "$TARGETS" ] || return 1
 
-  IFS=',' read -r -a target_entries <<<"$TARGETS"
+  IFS=',' read -r -a target_entries <<< "$TARGETS"
   for entry in "${target_entries[@]}"; do
     entry="$(trim "$entry")"
     [ -z "$entry" ] && continue
@@ -605,9 +605,9 @@ print_detection() {
 load_config
 
 case "$ACTION" in
-  -h | --help) usage ;;
+  -h|--help) usage ;;
   detect) print_detection ;;
-  lint | typecheck | build | test) run_action "$ACTION" ;;
+  lint|typecheck|build|test) run_action "$ACTION" ;;
   validate) run_validate ;;
   *)
     echo "ERROR: unknown touchstone-run action '$ACTION'" >&2

--- a/scripts/touchstone-run.sh
+++ b/scripts/touchstone-run.sh
@@ -68,7 +68,7 @@ load_config() {
     value="$(trim "${line#*=}")"
 
     case "$key" in
-      project_type|profile) PROJECT_TYPE="$value" ;;
+      project_type | profile) PROJECT_TYPE="$value" ;;
       package_manager) PACKAGE_MANAGER="$value" ;;
       monorepo) MONOREPO="$value" ;;
       targets) TARGETS="$value" ;;
@@ -78,7 +78,7 @@ load_config() {
       test_command) TEST_COMMAND="$value" ;;
       validate_command) VALIDATE_COMMAND="$value" ;;
     esac
-  done < "$CONFIG_FILE"
+  done <"$CONFIG_FILE"
 }
 
 detect_node_package_manager() {
@@ -196,7 +196,7 @@ run_node_script() {
     pnpm) command="pnpm $script" ;;
     yarn) command="yarn $script" ;;
     bun) command="bun run $script" ;;
-    npm|*) command="npm run $script" ;;
+    npm | *) command="npm run $script" ;;
   esac
 
   run_shell_command "$command"
@@ -265,7 +265,7 @@ find_worktree_parent_root() {
     return 1
   fi
 
-  IFS= read -r gitdir < "$git_file" || {
+  IFS= read -r gitdir <"$git_file" || {
     echo "       Worktree check failed: cannot read gitdir from $git_file" >&2
     return 1
   }
@@ -311,7 +311,7 @@ run_node_action() {
   local action="$1"
 
   case "$action" in
-    lint|typecheck|build|test)
+    lint | typecheck | build | test)
       if run_node_script "$action"; then
         return 0
       fi
@@ -430,7 +430,7 @@ run_swift_action() {
         ok "swift-format not installed; skipped"
       fi
       ;;
-    typecheck|build) run_shell_command "swift build" ;;
+    typecheck | build) run_shell_command "swift build" ;;
     test) run_shell_command "swift test" ;;
     build_if_distinct)
       : # swift typecheck IS swift build — running it again would repeat
@@ -452,7 +452,7 @@ run_go_action() {
 
   case "$action" in
     lint) run_shell_command "go vet ./..." ;;
-    typecheck|build) run_shell_command "go build ./..." ;;
+    typecheck | build) run_shell_command "go build ./..." ;;
     test) run_shell_command "go test ./..." ;;
     build_if_distinct)
       : # go typecheck IS go build — running it again would repeat
@@ -468,12 +468,12 @@ run_profile_action() {
   local profile="$1" action="$2"
 
   case "$profile" in
-    node|typescript|ts) run_node_action "$action" ;;
+    node | typescript | ts) run_node_action "$action" ;;
     python) run_python_action "$action" ;;
     rust) run_rust_action "$action" ;;
     swift) run_swift_action "$action" ;;
     go) run_go_action "$action" ;;
-    generic|"")
+    generic | "")
       # build_if_distinct is a validate-time extra — silently no-op for generic
       # so "touchstone run validate" doesn't print a scary "no default command"
       # line on every non-typed project.
@@ -495,7 +495,7 @@ run_targets_action() {
 
   [ -n "$TARGETS" ] || return 1
 
-  IFS=',' read -r -a target_entries <<< "$TARGETS"
+  IFS=',' read -r -a target_entries <<<"$TARGETS"
   for entry in "${target_entries[@]}"; do
     entry="$(trim "$entry")"
     [ -z "$entry" ] && continue
@@ -605,9 +605,9 @@ print_detection() {
 load_config
 
 case "$ACTION" in
-  -h|--help) usage ;;
+  -h | --help) usage ;;
   detect) print_detection ;;
-  lint|typecheck|build|test) run_action "$ACTION" ;;
+  lint | typecheck | build | test) run_action "$ACTION" ;;
   validate) run_validate ;;
   *)
     echo "ERROR: unknown touchstone-run action '$ACTION'" >&2

--- a/scripts/touchstone-run.sh
+++ b/scripts/touchstone-run.sh
@@ -68,7 +68,7 @@ load_config() {
     value="$(trim "${line#*=}")"
 
     case "$key" in
-      project_type|profile) PROJECT_TYPE="$value" ;;
+      project_type | profile) PROJECT_TYPE="$value" ;;
       package_manager) PACKAGE_MANAGER="$value" ;;
       monorepo) MONOREPO="$value" ;;
       targets) TARGETS="$value" ;;
@@ -78,7 +78,7 @@ load_config() {
       test_command) TEST_COMMAND="$value" ;;
       validate_command) VALIDATE_COMMAND="$value" ;;
     esac
-  done < "$CONFIG_FILE"
+  done <"$CONFIG_FILE"
 }
 
 detect_node_package_manager() {
@@ -168,7 +168,7 @@ has_package_script() {
 run_shell_command() {
   local command="$1"
   info "$command"
-  bash -c "$command"
+  env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE bash -c "$command"
 }
 
 configured_command_for_action() {
@@ -196,7 +196,7 @@ run_node_script() {
     pnpm) command="pnpm $script" ;;
     yarn) command="yarn $script" ;;
     bun) command="bun run $script" ;;
-    npm|*) command="npm run $script" ;;
+    npm | *) command="npm run $script" ;;
   esac
 
   run_shell_command "$command"
@@ -265,7 +265,7 @@ find_worktree_parent_root() {
     return 1
   fi
 
-  IFS= read -r gitdir < "$git_file" || {
+  IFS= read -r gitdir <"$git_file" || {
     echo "       Worktree check failed: cannot read gitdir from $git_file" >&2
     return 1
   }
@@ -311,7 +311,7 @@ run_node_action() {
   local action="$1"
 
   case "$action" in
-    lint|typecheck|build|test)
+    lint | typecheck | build | test)
       if run_node_script "$action"; then
         return 0
       fi
@@ -430,7 +430,7 @@ run_swift_action() {
         ok "swift-format not installed; skipped"
       fi
       ;;
-    typecheck|build) run_shell_command "swift build" ;;
+    typecheck | build) run_shell_command "swift build" ;;
     test) run_shell_command "swift test" ;;
     build_if_distinct)
       : # swift typecheck IS swift build — running it again would repeat
@@ -452,7 +452,7 @@ run_go_action() {
 
   case "$action" in
     lint) run_shell_command "go vet ./..." ;;
-    typecheck|build) run_shell_command "go build ./..." ;;
+    typecheck | build) run_shell_command "go build ./..." ;;
     test) run_shell_command "go test ./..." ;;
     build_if_distinct)
       : # go typecheck IS go build — running it again would repeat
@@ -468,12 +468,12 @@ run_profile_action() {
   local profile="$1" action="$2"
 
   case "$profile" in
-    node|typescript|ts) run_node_action "$action" ;;
+    node | typescript | ts) run_node_action "$action" ;;
     python) run_python_action "$action" ;;
     rust) run_rust_action "$action" ;;
     swift) run_swift_action "$action" ;;
     go) run_go_action "$action" ;;
-    generic|"")
+    generic | "")
       # build_if_distinct is a validate-time extra — silently no-op for generic
       # so "touchstone run validate" doesn't print a scary "no default command"
       # line on every non-typed project.
@@ -495,7 +495,7 @@ run_targets_action() {
 
   [ -n "$TARGETS" ] || return 1
 
-  IFS=',' read -r -a target_entries <<< "$TARGETS"
+  IFS=',' read -r -a target_entries <<<"$TARGETS"
   for entry in "${target_entries[@]}"; do
     entry="$(trim "$entry")"
     [ -z "$entry" ] && continue
@@ -605,9 +605,9 @@ print_detection() {
 load_config
 
 case "$ACTION" in
-  -h|--help) usage ;;
+  -h | --help) usage ;;
   detect) print_detection ;;
-  lint|typecheck|build|test) run_action "$ACTION" ;;
+  lint | typecheck | build | test) run_action "$ACTION" ;;
   validate) run_validate ;;
   *)
     echo "ERROR: unknown touchstone-run action '$ACTION'" >&2

--- a/scripts/worker.sh
+++ b/scripts/worker.sh
@@ -68,7 +68,7 @@ sanitize_task_slug() {
 
 require_worker_type() {
   case "$1" in
-    fix|feat|chore|refactor|docs) return 0 ;;
+    fix | feat | chore | refactor | docs) return 0 ;;
     *)
       echo "ERROR: --type must be one of fix, feat, chore, refactor, docs." >&2
       return 1
@@ -152,19 +152,44 @@ cmd_spawn() {
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --task)
-        [ "$#" -ge 2 ] || { echo "ERROR: --task requires a value." >&2; return 2; }
-        task="$2"; shift 2 ;;
+        [ "$#" -ge 2 ] || {
+          echo "ERROR: --task requires a value." >&2
+          return 2
+        }
+        task="$2"
+        shift 2
+        ;;
       --type)
-        [ "$#" -ge 2 ] || { echo "ERROR: --type requires a value." >&2; return 2; }
-        type="$2"; shift 2 ;;
-      --json) json=true; shift ;;
-      -h|--help) usage; return 0 ;;
-      *) echo "ERROR: unknown worker spawn argument '$1'." >&2; return 2 ;;
+        [ "$#" -ge 2 ] || {
+          echo "ERROR: --type requires a value." >&2
+          return 2
+        }
+        type="$2"
+        shift 2
+        ;;
+      --json)
+        json=true
+        shift
+        ;;
+      -h | --help)
+        usage
+        return 0
+        ;;
+      *)
+        echo "ERROR: unknown worker spawn argument '$1'." >&2
+        return 2
+        ;;
     esac
   done
 
-  [ -n "$task" ] || { echo "ERROR: worker spawn requires --task." >&2; return 2; }
-  [ -n "$type" ] || { echo "ERROR: worker spawn requires --type." >&2; return 2; }
+  [ -n "$task" ] || {
+    echo "ERROR: worker spawn requires --task." >&2
+    return 2
+  }
+  [ -n "$type" ] || {
+    echo "ERROR: worker spawn requires --type." >&2
+    return 2
+  }
   require_worker_type "$type"
 
   repo_root="$(repo_root_or_die)"
@@ -200,15 +225,32 @@ cmd_status() {
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --worktree)
-        [ "$#" -ge 2 ] || { echo "ERROR: --worktree requires a path." >&2; return 2; }
-        worktree_path="$2"; shift 2 ;;
-      --json) json=true; shift ;;
-      -h|--help) usage; return 0 ;;
-      *) echo "ERROR: unknown worker status argument '$1'." >&2; return 2 ;;
+        [ "$#" -ge 2 ] || {
+          echo "ERROR: --worktree requires a path." >&2
+          return 2
+        }
+        worktree_path="$2"
+        shift 2
+        ;;
+      --json)
+        json=true
+        shift
+        ;;
+      -h | --help)
+        usage
+        return 0
+        ;;
+      *)
+        echo "ERROR: unknown worker status argument '$1'." >&2
+        return 2
+        ;;
     esac
   done
 
-  [ -n "$worktree_path" ] || { echo "ERROR: worker status requires --worktree." >&2; return 2; }
+  [ -n "$worktree_path" ] || {
+    echo "ERROR: worker status requires --worktree." >&2
+    return 2
+  }
 
   if [ "$json" = true ]; then
     worker_status_json "$worktree_path"
@@ -241,20 +283,45 @@ cmd_ship() {
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --worktree)
-        [ "$#" -ge 2 ] || { echo "ERROR: --worktree requires a path." >&2; return 2; }
-        worktree_path="$2"; shift 2 ;;
+        [ "$#" -ge 2 ] || {
+          echo "ERROR: --worktree requires a path." >&2
+          return 2
+        }
+        worktree_path="$2"
+        shift 2
+        ;;
       --auto-merge) shift ;;
-      --cleanup) cleanup=true; shift ;;
+      --cleanup)
+        cleanup=true
+        shift
+        ;;
       --events-json)
-        [ "$#" -ge 2 ] || { echo "ERROR: --events-json requires a path." >&2; return 2; }
-        events_json="$2"; shift 2 ;;
-      -h|--help) usage; return 0 ;;
-      *) echo "ERROR: unknown worker ship argument '$1'." >&2; return 2 ;;
+        [ "$#" -ge 2 ] || {
+          echo "ERROR: --events-json requires a path." >&2
+          return 2
+        }
+        events_json="$2"
+        shift 2
+        ;;
+      -h | --help)
+        usage
+        return 0
+        ;;
+      *)
+        echo "ERROR: unknown worker ship argument '$1'." >&2
+        return 2
+        ;;
     esac
   done
 
-  [ -n "$worktree_path" ] || { echo "ERROR: worker ship requires --worktree." >&2; return 2; }
-  [ -d "$worktree_path" ] || { echo "ERROR: worktree does not exist: $worktree_path" >&2; return 1; }
+  [ -n "$worktree_path" ] || {
+    echo "ERROR: worker ship requires --worktree." >&2
+    return 2
+  }
+  [ -d "$worktree_path" ] || {
+    echo "ERROR: worktree does not exist: $worktree_path" >&2
+    return 1
+  }
   if [ "$cleanup" = true ]; then
     args+=(--cleanup-worktree)
   fi
@@ -289,20 +356,46 @@ cmd_abandon() {
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --worktree)
-        [ "$#" -ge 2 ] || { echo "ERROR: --worktree requires a path." >&2; return 2; }
-        worktree_path="$2"; shift 2 ;;
-      --dry-run) dry_run=true; shift ;;
-      --force) force=true; shift ;;
-      -h|--help) usage; return 0 ;;
-      *) echo "ERROR: unknown worker abandon argument '$1'." >&2; return 2 ;;
+        [ "$#" -ge 2 ] || {
+          echo "ERROR: --worktree requires a path." >&2
+          return 2
+        }
+        worktree_path="$2"
+        shift 2
+        ;;
+      --dry-run)
+        dry_run=true
+        shift
+        ;;
+      --force)
+        force=true
+        shift
+        ;;
+      -h | --help)
+        usage
+        return 0
+        ;;
+      *)
+        echo "ERROR: unknown worker abandon argument '$1'." >&2
+        return 2
+        ;;
     esac
   done
 
-  [ -n "$worktree_path" ] || { echo "ERROR: worker abandon requires --worktree." >&2; return 2; }
-  [ -d "$worktree_path" ] || { echo "ERROR: worktree does not exist: $worktree_path" >&2; return 1; }
+  [ -n "$worktree_path" ] || {
+    echo "ERROR: worker abandon requires --worktree." >&2
+    return 2
+  }
+  [ -d "$worktree_path" ] || {
+    echo "ERROR: worktree does not exist: $worktree_path" >&2
+    return 1
+  }
 
   branch="$(worker_branch "$worktree_path")"
-  [ -n "$branch" ] && [ "$branch" != "HEAD" ] || { echo "ERROR: cannot abandon detached worktree." >&2; return 1; }
+  [ -n "$branch" ] && [ "$branch" != "HEAD" ] || {
+    echo "ERROR: cannot abandon detached worktree." >&2
+    return 1
+  }
   base="$(cd "$worktree_path" && touchstone_worker_default_ref)"
   unique_commits="$(git -C "$worktree_path" log "$base..HEAD" --oneline 2>/dev/null || true)"
 
@@ -323,7 +416,10 @@ cmd_abandon() {
   fi
 
   manager_path="$(worktree_manager_path "$worktree_path")"
-  [ -n "$manager_path" ] || { echo "ERROR: could not find a git worktree manager for $worktree_path" >&2; return 1; }
+  [ -n "$manager_path" ] || {
+    echo "ERROR: could not find a git worktree manager for $worktree_path" >&2
+    return 1
+  }
   git -C "$manager_path" worktree remove --force "$worktree_path"
   if branch_has_open_or_closed_pr "$branch"; then
     echo "Kept remote branch because a PR exists for: $branch"
@@ -339,11 +435,25 @@ cmd_list() {
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --repo)
-        [ "$#" -ge 2 ] || { echo "ERROR: --repo requires a path." >&2; return 2; }
-        repo_path="$2"; shift 2 ;;
-      --json) json=true; shift ;;
-      -h|--help) usage; return 0 ;;
-      *) echo "ERROR: unknown worker list argument '$1'." >&2; return 2 ;;
+        [ "$#" -ge 2 ] || {
+          echo "ERROR: --repo requires a path." >&2
+          return 2
+        }
+        repo_path="$2"
+        shift 2
+        ;;
+      --json)
+        json=true
+        shift
+        ;;
+      -h | --help)
+        usage
+        return 0
+        ;;
+      *)
+        echo "ERROR: unknown worker list argument '$1'." >&2
+        return 2
+        ;;
     esac
   done
 
@@ -363,7 +473,7 @@ cmd_list() {
       if [ -n "$path" ] && [ -n "$branch_ref" ]; then
         branch="${branch_ref#refs/heads/}"
         case "$branch" in
-          feat/*|fix/*|chore/*|refactor/*|docs/*)
+          feat/* | fix/* | chore/* | refactor/* | docs/*)
             if [ "$json" = true ]; then
               [ "$first" = true ] || printf ','
               worker_status_json "$path" | tr -d '\n'
@@ -382,12 +492,12 @@ cmd_list() {
       worktree\ *) path="${line#worktree }" ;;
       branch\ *) branch_ref="${line#branch }" ;;
     esac
-  done <<< "$list_output"
+  done <<<"$list_output"
 
   if [ -n "$path" ] && [ -n "$branch_ref" ]; then
     branch="${branch_ref#refs/heads/}"
     case "$branch" in
-      feat/*|fix/*|chore/*|refactor/*|docs/*)
+      feat/* | fix/* | chore/* | refactor/* | docs/*)
         if [ "$json" = true ]; then
           [ "$first" = true ] || printf ','
           worker_status_json "$path" | tr -d '\n'
@@ -412,7 +522,7 @@ case "$command" in
   ship) cmd_ship "$@" ;;
   abandon) cmd_abandon "$@" ;;
   list) cmd_list "$@" ;;
-  help|-h|--help) usage ;;
+  help | -h | --help) usage ;;
   *)
     echo "ERROR: unknown worker command '$command'." >&2
     usage >&2

--- a/templates/.markdownlint.json
+++ b/templates/.markdownlint.json
@@ -1,0 +1,19 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD022": false,
+  "MD024": {
+    "siblings_only": true
+  },
+  "MD026": {
+    "punctuation": ".,;:!"
+  },
+  "MD032": false,
+  "MD034": false,
+  "MD033": false,
+  "MD038": false,
+  "MD040": false,
+  "MD041": false,
+  "MD046": false,
+  "MD060": false
+}

--- a/templates/pre-commit-config.yaml
+++ b/templates/pre-commit-config.yaml
@@ -45,21 +45,10 @@ repos:
         args: ['--severity=warning']
 
   - repo: https://github.com/scop/pre-commit-shfmt
-    rev: v3.13.1-1
+    rev: v3.10.0-1
     hooks:
       - id: shfmt
-        # Match Touchstone's 2-space shell style while making case blocks and
-        # binary operators deterministic.
-        args: ['-i', '2', '-ci', '-bn']
-        exclude: ^(completions/|prototypes/)
-
-  - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.46.0
-    hooks:
-      - id: markdownlint
-        args: ['--config', '.markdownlint.json']
-        files: ^([^/]+\.md|principles/.*\.md|audits/.*\.md|feedback/.*\.md|templates/.*\.md)$
-        exclude: ^\.cortex/
+        args: ['-i', '2', '-ci']
 
   # ── Branch naming enforcement ──────────────────────────────────────────
   - repo: local

--- a/templates/pre-commit-config.yaml
+++ b/templates/pre-commit-config.yaml
@@ -53,6 +53,14 @@ repos:
         args: ['-i', '2', '-ci', '-bn']
         exclude: ^(completions/|prototypes/)
 
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.46.0
+    hooks:
+      - id: markdownlint
+        args: ['--config', '.markdownlint.json']
+        files: ^([^/]+\.md|principles/.*\.md|audits/.*\.md|feedback/.*\.md|templates/.*\.md)$
+        exclude: ^\.cortex/
+
   # ── Branch naming enforcement ──────────────────────────────────────────
   - repo: local
     hooks:

--- a/templates/pre-commit-config.yaml
+++ b/templates/pre-commit-config.yaml
@@ -45,10 +45,13 @@ repos:
         args: ['--severity=warning']
 
   - repo: https://github.com/scop/pre-commit-shfmt
-    rev: v3.10.0-1
+    rev: v3.13.1-1
     hooks:
       - id: shfmt
-        args: ['-i', '2', '-ci']
+        # Match Touchstone's 2-space shell style while making case blocks and
+        # binary operators deterministic.
+        args: ['-i', '2', '-ci', '-bn']
+        exclude: ^(completions/|prototypes/)
 
   # ── Branch naming enforcement ──────────────────────────────────────────
   - repo: local

--- a/templates/pre-commit-config.yaml
+++ b/templates/pre-commit-config.yaml
@@ -93,7 +93,13 @@ repos:
     hooks:
       - id: touchstone-validate
         name: Touchstone project validation
-        entry: /usr/bin/env env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE bash scripts/touchstone-run.sh validate
+        entry: >-
+          /usr/bin/env env
+          -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE
+          -u PRE_COMMIT -u PRE_COMMIT_FROM_REF -u PRE_COMMIT_TO_REF
+          -u PRE_COMMIT_LOCAL_BRANCH -u PRE_COMMIT_REMOTE_BRANCH
+          -u PRE_COMMIT_REMOTE_NAME -u PRE_COMMIT_REMOTE_URL
+          bash scripts/touchstone-run.sh validate
         language: system
         stages: [pre-push]
         always_run: true

--- a/templates/pre-commit-config.yaml
+++ b/templates/pre-commit-config.yaml
@@ -45,10 +45,21 @@ repos:
         args: ['--severity=warning']
 
   - repo: https://github.com/scop/pre-commit-shfmt
-    rev: v3.10.0-1
+    rev: v3.13.1-1
     hooks:
       - id: shfmt
-        args: ['-i', '2', '-ci']
+        # Match Touchstone's 2-space shell style while making case blocks and
+        # binary operators deterministic.
+        args: ['-i', '2', '-ci', '-bn']
+        exclude: ^(completions/|prototypes/)
+
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.46.0
+    hooks:
+      - id: markdownlint
+        args: ['--config', '.markdownlint.json']
+        files: ^([^/]+\.md|principles/.*\.md|audits/.*\.md|feedback/.*\.md|templates/.*\.md)$
+        exclude: ^\.cortex/
 
   # ── Branch naming enforcement ──────────────────────────────────────────
   - repo: local
@@ -82,7 +93,7 @@ repos:
     hooks:
       - id: touchstone-validate
         name: Touchstone project validation
-        entry: /usr/bin/env bash scripts/touchstone-run.sh validate
+        entry: /usr/bin/env env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE bash scripts/touchstone-run.sh validate
         language: system
         stages: [pre-push]
         always_run: true

--- a/tests/claude-probe-helper.sh
+++ b/tests/claude-probe-helper.sh
@@ -9,7 +9,7 @@ run_claude_probe() {
   local timeout_secs="${TOUCHSTONE_CLAUDE_PROBE_TIMEOUT:-90}"
 
   case "$timeout_secs" in
-    ''|*[!0-9]*) timeout_secs=90 ;;
+    '' | *[!0-9]*) timeout_secs=90 ;;
   esac
 
   if [ "$timeout_secs" -le 0 ] 2>/dev/null; then
@@ -36,7 +36,7 @@ run_claude_probe() {
     done
 
     if kill -0 "$claude_pid" 2>/dev/null; then
-      printf 'timeout\n' > "$timed_out_file"
+      printf 'timeout\n' >"$timed_out_file"
       kill "$claude_pid" 2>/dev/null || true
       sleep 2
       kill -9 "$claude_pid" 2>/dev/null || true

--- a/tests/fixtures/conductor
+++ b/tests/fixtures/conductor
@@ -29,7 +29,7 @@ JSON
     fi
     exit 0
     ;;
-  list|version|--version|-V|init|ask|call|exec|review|providers)
+  list | version | --version | -V | init | ask | call | exec | review | providers)
     exit 0
     ;;
   "")

--- a/tests/fixtures/cortex
+++ b/tests/fixtures/cortex
@@ -10,20 +10,20 @@
 set -euo pipefail
 
 case "${1:-}" in
-  version|--version|-V)
+  version | --version | -V)
     echo "cortex 0.0.0-stub"
     exit 0
     ;;
   init)
     mkdir -p .cortex/doctrine .cortex/plans .cortex/journal
-    : > .cortex/state.md
-    : > .cortex/README.md
-    : > .cortex/protocol.md
-    echo "0.5.0" > .cortex/SPEC_VERSION
+    : >.cortex/state.md
+    : >.cortex/README.md
+    : >.cortex/protocol.md
+    echo "0.5.0" >.cortex/SPEC_VERSION
     echo "==> stub-cortex init: scaffolded .cortex/"
     exit 0
     ;;
-  doctor|refresh-state|state|journal|grep|retrieve|manifest)
+  doctor | refresh-state | state | journal | grep | retrieve | manifest)
     exit 0
     ;;
   "")

--- a/tests/fixtures/sentinel
+++ b/tests/fixtures/sentinel
@@ -11,21 +11,21 @@
 set -euo pipefail
 
 case "${1:-}" in
-  version|--version|-V)
+  version | --version | -V)
     echo "sentinel, version 0.0.0-stub"
     exit 0
     ;;
   init)
     mkdir -p .sentinel
-    : > .sentinel/config.toml
-    printf 'state/\n' > .sentinel/.gitignore
+    : >.sentinel/config.toml
+    printf 'state/\n' >.sentinel/.gitignore
 
     # Note: the root .gitignore gets a `.claude/` block, NOT `.sentinel/`.
     # Real sentinel keeps `.sentinel/` source-tracked and only ignores the
     # ephemeral `state/` subdir via .sentinel/.gitignore. The R5.2
     # regression check enforces that distinction.
     if [ ! -f .gitignore ] || ! grep -qF '.claude/' .gitignore; then
-      printf '\n# sentinel artifacts — generated per-run, not source\n.claude/\n' >> .gitignore
+      printf '\n# sentinel artifacts — generated per-run, not source\n.claude/\n' >>.gitignore
       # Mirror real sentinel's _commit_gitignore_if_in_repo: when running
       # inside a git repo with HEAD, commit the gitignore so a later
       # `sentinel work --reset` does not throw away the ignore rules.
@@ -33,16 +33,16 @@ case "${1:-}" in
         && git rev-parse --verify HEAD >/dev/null 2>&1; then
         git add .gitignore >/dev/null 2>&1 || true
         git -c user.email=sentinel-stub@touchstone.test \
-            -c user.name=sentinel-stub \
-            commit -m "chore: gitignore sentinel artifacts (.claude/)" \
-            --quiet -- .gitignore >/dev/null 2>&1 || true
+          -c user.name=sentinel-stub \
+          commit -m "chore: gitignore sentinel artifacts (.claude/)" \
+          --quiet -- .gitignore >/dev/null 2>&1 || true
       fi
     fi
 
     echo "==> stub-sentinel init: scaffolded .sentinel/"
     exit 0
     ;;
-  work|run|doctor|status)
+  work | run | doctor | status)
     exit 0
     ;;
   "")

--- a/tests/test-adr.sh
+++ b/tests/test-adr.sh
@@ -52,7 +52,7 @@ mkdir -p "$SKILLS_HOME"
 (
   cd "$TOUCHSTONE_ROOT"
   HOME="$SKILLS_HOME" TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" skills
-) > "$TEST_DIR/skills-list.txt"
+) >"$TEST_DIR/skills-list.txt"
 
 assert_contains "$TEST_DIR/skills-list.txt" 'touchstone-audit'
 assert_contains "$TEST_DIR/skills-list.txt" 'memory-audit'
@@ -60,7 +60,7 @@ assert_contains "$TEST_DIR/skills-list.txt" 'memory-audit'
 (
   cd "$TOUCHSTONE_ROOT"
   HOME="$SKILLS_HOME" TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" skills check
-) > "$TEST_DIR/skills-check.txt"
+) >"$TEST_DIR/skills-check.txt"
 
 assert_contains "$TEST_DIR/skills-check.txt" 'skills valid'
 

--- a/tests/test-agent-steering-contract.sh
+++ b/tests/test-agent-steering-contract.sh
@@ -34,8 +34,7 @@ echo "==> managed AGENTS block exposes the driver/reviewer contract"
 for file in \
   "$TOUCHSTONE_ROOT/AGENTS.md" \
   "$TOUCHSTONE_ROOT/templates/AGENTS.md" \
-  "$TOUCHSTONE_ROOT/lib/agents-principles-block.sh"
-do
+  "$TOUCHSTONE_ROOT/lib/agents-principles-block.sh"; do
   assert_contains "$file" "Agent Roles And Fallbacks"
   assert_contains "$file" "Driving CLI"
   assert_contains "$file" "Conductor worker/reviewer"
@@ -50,8 +49,7 @@ for file in \
   "$TOUCHSTONE_ROOT/CLAUDE.md" \
   "$TOUCHSTONE_ROOT/templates/CLAUDE.md" \
   "$TOUCHSTONE_ROOT/GEMINI.md" \
-  "$TOUCHSTONE_ROOT/templates/GEMINI.md"
-do
+  "$TOUCHSTONE_ROOT/templates/GEMINI.md"; do
   assert_contains "$file" "Agent Roles And Fallbacks"
   assert_contains "$file" "driving CLI"
   assert_contains "$file" "worker/reviewer router"
@@ -67,7 +65,7 @@ assert_not_contains "$TOUCHSTONE_ROOT/principles/git-workflow.md" "codex exec --
 
 echo "==> dogfood harness validates every machine-check field"
 GOOD_RESPONSE="$TEST_DIR/good-response.txt"
-cat > "$GOOD_RESPONSE" <<'EOF'
+cat >"$GOOD_RESPONSE" <<'EOF'
 TOUCHSTONE_DOGFOOD_RESULT: PASS
 BRANCH_BEFORE_EDIT: yes
 FEATURE_BRANCH_COMMAND: git checkout -b fix/log-swallowed-exception
@@ -85,7 +83,7 @@ EOF
 "$TOUCHSTONE_ROOT/scripts/dogfood-agent-steering.sh" --validate-response "$GOOD_RESPONSE" >/dev/null
 
 BAD_RESPONSE="$TEST_DIR/bad-response.txt"
-cat > "$BAD_RESPONSE" <<'EOF'
+cat >"$BAD_RESPONSE" <<'EOF'
 TOUCHSTONE_DOGFOOD_RESULT: PASS
 BRANCH_BEFORE_EDIT: yes
 FEATURE_BRANCH_COMMAND: git checkout -b fix/log-swallowed-exception

--- a/tests/test-agents-principles-block.sh
+++ b/tests/test-agents-principles-block.sh
@@ -59,7 +59,7 @@ assert_eq "missing file rc" 2 "$rc"
 # --- 2. Inject into a file with an H1 --------------------------------------
 echo "==> inject block after H1"
 target="$TEST_DIR/case-h1.md"
-cat > "$target" <<'EOF'
+cat >"$target" <<'EOF'
 # AGENTS.md — AI Reviewer Guide for Foo
 
 You are reviewing pull requests for **Foo**.
@@ -85,7 +85,7 @@ assert_contains "$target" "1. Data integrity."
 # --- 3. Inject when no H1 ---------------------------------------------------
 echo "==> inject block when no H1"
 target="$TEST_DIR/case-no-h1.md"
-cat > "$target" <<'EOF'
+cat >"$target" <<'EOF'
 This file has no H1.
 
 Some body.
@@ -98,7 +98,7 @@ assert_contains "$target" "This file has no H1."
 # --- 4. Idempotent on a current file ----------------------------------------
 echo "==> idempotent on current block"
 target="$TEST_DIR/case-current.md"
-cat > "$target" <<'EOF'
+cat >"$target" <<'EOF'
 # AGENTS.md
 
 EOF
@@ -111,7 +111,7 @@ assert_eq "idempotent sha" "$sha_before" "$sha_after"
 # --- 5. Refresh a stale block ----------------------------------------------
 echo "==> refresh stale block"
 target="$TEST_DIR/case-stale.md"
-cat > "$target" <<EOF
+cat >"$target" <<EOF
 # AGENTS.md
 
 $AGENTS_PRINCIPLES_BLOCK_BEGIN
@@ -134,7 +134,7 @@ assert_contains "$target" "MUST survive a refresh"
 # --- 6. Orphaned sentinel → refuses, file untouched -------------------------
 echo "==> orphaned sentinel refuses"
 target="$TEST_DIR/case-orphan.md"
-cat > "$target" <<EOF
+cat >"$target" <<EOF
 # AGENTS.md
 
 $AGENTS_PRINCIPLES_BLOCK_BEGIN
@@ -154,7 +154,7 @@ assert_eq "orphan untouched" "$sha_before" "$sha_after"
 # --- 7. Block lands BEFORE existing project content (top-of-file priority) --
 echo "==> block lands at top, ahead of project content"
 target="$TEST_DIR/case-ordering.md"
-cat > "$target" <<'EOF'
+cat >"$target" <<'EOF'
 # AGENTS.md — AI Reviewer Guide for Foo
 
 Project-specific intro.

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -38,8 +38,8 @@ cleanup() {
 
   # This test may run on a shared machine, so assert the invariant we own:
   # no project path from this isolated TEST_DIR may leak into the real registry.
-  if [ -n "$REAL_REGISTRY_FILE" ] && [ -f "$REAL_REGISTRY_FILE" ] && \
-     grep -F "$TEST_DIR" "$REAL_REGISTRY_FILE" >/dev/null 2>&1; then
+  if [ -n "$REAL_REGISTRY_FILE" ] && [ -f "$REAL_REGISTRY_FILE" ] \
+    && grep -F "$TEST_DIR" "$REAL_REGISTRY_FILE" >/dev/null 2>&1; then
     echo "FAIL: test wrote isolated temp paths to real registry at $REAL_REGISTRY_FILE" >&2
     registry_changed=true
   fi
@@ -369,7 +369,7 @@ assert_contains "$PROJECT_SWIFT/.swiftlint.yml" '^  - DerivedData$'
 # the case: a pre-existing Swift project that has never been touchstoned.
 PROJECT_SWIFT_EXISTING="$TEST_DIR/existing-swift-repo"
 mkdir -p "$PROJECT_SWIFT_EXISTING"
-printf 'SENTINEL_PACKAGE\n' > "$PROJECT_SWIFT_EXISTING/Package.swift"
+printf 'SENTINEL_PACKAGE\n' >"$PROJECT_SWIFT_EXISTING/Package.swift"
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SWIFT_EXISTING" --no-register --type swift >/dev/null
 assert_contains "$PROJECT_SWIFT_EXISTING/Package.swift" '^SENTINEL_PACKAGE$'
 assert_not_exists "$PROJECT_SWIFT_EXISTING/Sources/ExistingSwiftRepo/ExistingSwiftRepoApp.swift"
@@ -381,7 +381,7 @@ assert_exists "$PROJECT_SWIFT_EXISTING/.swiftlint.yml"
 # bootstrap. copy_file is the project-owned semantic: skip if exists.
 PROJECT_SWIFT_HAND_EDITED="$TEST_DIR/swift-hand-edited-config"
 mkdir -p "$PROJECT_SWIFT_HAND_EDITED"
-printf 'SENTINEL_HAND_EDITED_CONFIG\n' > "$PROJECT_SWIFT_HAND_EDITED/.swiftlint.yml"
+printf 'SENTINEL_HAND_EDITED_CONFIG\n' >"$PROJECT_SWIFT_HAND_EDITED/.swiftlint.yml"
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SWIFT_HAND_EDITED" --no-register --type swift >/dev/null
 assert_contains "$PROJECT_SWIFT_HAND_EDITED/.swiftlint.yml" '^SENTINEL_HAND_EDITED_CONFIG$'
 
@@ -411,9 +411,9 @@ mkdir -p "$PROJECT_SWIFT_IDEMPOTENT"
   printf '*.xcodeproj/\n'
   printf 'DerivedData/\n'
   printf 'Package.resolved\n'
-} > "$PROJECT_SWIFT_IDEMPOTENT/.gitignore"
+} >"$PROJECT_SWIFT_IDEMPOTENT/.gitignore"
 # Also give it existing Swift content so the boilerplate scaffold no-ops.
-printf 'SENTINEL_PACKAGE\n' > "$PROJECT_SWIFT_IDEMPOTENT/Package.swift"
+printf 'SENTINEL_PACKAGE\n' >"$PROJECT_SWIFT_IDEMPOTENT/Package.swift"
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SWIFT_IDEMPOTENT" --no-register --type swift >/dev/null
 SWIFT_BUILD_DUPES="$(grep -c '^\.build/$' "$PROJECT_SWIFT_IDEMPOTENT/.gitignore" 2>/dev/null || echo 0)"
 if [ "$SWIFT_BUILD_DUPES" -ne 1 ]; then
@@ -484,9 +484,9 @@ phase "existing-dir + reviewer/CI/scaffold-tests opt-outs"
 
 # Bootstrap into an existing directory should back up touchstone-owned files before replacing them.
 mkdir -p "$PROJECT_EXISTING/principles" "$PROJECT_EXISTING/scripts"
-printf 'custom principle\n' > "$PROJECT_EXISTING/principles/engineering-principles.md"
-printf 'custom script\n' > "$PROJECT_EXISTING/scripts/open-pr.sh"
-printf 'custom manifest\n' > "$PROJECT_EXISTING/.touchstone-manifest"
+printf 'custom principle\n' >"$PROJECT_EXISTING/principles/engineering-principles.md"
+printf 'custom script\n' >"$PROJECT_EXISTING/scripts/open-pr.sh"
+printf 'custom manifest\n' >"$PROJECT_EXISTING/.touchstone-manifest"
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_EXISTING" --no-register
 assert_exists "$PROJECT_EXISTING/principles/engineering-principles.md.bak"
 assert_exists "$PROJECT_EXISTING/scripts/open-pr.sh.bak"
@@ -502,7 +502,7 @@ mkdir -p "$PROJECT_EXISTING_CONFIG"
   printf 'max_iterations = 9\n'
   printf 'unsafe_paths = []\n'
   printf 'safe_by_default = true\n'
-} > "$PROJECT_EXISTING_CONFIG/.codex-review.toml"
+} >"$PROJECT_EXISTING_CONFIG/.codex-review.toml"
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_EXISTING_CONFIG" --no-register --unsafe-paths "src/auth/"
 assert_contains "$PROJECT_EXISTING_CONFIG/.codex-review.toml" '^unsafe_paths = \[\]$'
 assert_contains "$PROJECT_EXISTING_CONFIG/.codex-review.toml" '^safe_by_default = true$'
@@ -604,7 +604,7 @@ assert_contains "$PROJECT_SCAFFOLD_GO/smoke_test.go" '^package main$'
 # "package github.com" which is invalid and breaks go test ./....
 PROJECT_SCAFFOLD_GO_MOD="$TEST_DIR/test-project-scaffold-go-mod"
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_GO_MOD" --no-register --type go >/dev/null
-printf 'module github.com/acme/widget\n\ngo 1.22\n' > "$PROJECT_SCAFFOLD_GO_MOD/go.mod"
+printf 'module github.com/acme/widget\n\ngo 1.22\n' >"$PROJECT_SCAFFOLD_GO_MOD/go.mod"
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_GO_MOD" --no-register --scaffold-tests >/dev/null
 assert_exists "$PROJECT_SCAFFOLD_GO_MOD/smoke_test.go"
 if grep -q '^package github' "$PROJECT_SCAFFOLD_GO_MOD/smoke_test.go"; then
@@ -617,8 +617,8 @@ assert_contains "$PROJECT_SCAFFOLD_GO_MOD/smoke_test.go" '^package main$'
 # match that package so go test ./... compiles (all files in a dir share one pkg).
 PROJECT_SCAFFOLD_GO_PKG="$TEST_DIR/test-project-scaffold-go-pkg"
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_GO_PKG" --no-register --type go >/dev/null
-printf 'module github.com/acme/widget\n\ngo 1.22\n' > "$PROJECT_SCAFFOLD_GO_PKG/go.mod"
-printf 'package widget\n\nfunc Hello() string { return "hi" }\n' > "$PROJECT_SCAFFOLD_GO_PKG/widget.go"
+printf 'module github.com/acme/widget\n\ngo 1.22\n' >"$PROJECT_SCAFFOLD_GO_PKG/go.mod"
+printf 'package widget\n\nfunc Hello() string { return "hi" }\n' >"$PROJECT_SCAFFOLD_GO_PKG/widget.go"
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_GO_PKG" --no-register --scaffold-tests >/dev/null
 assert_exists "$PROJECT_SCAFFOLD_GO_PKG/smoke_test.go"
 assert_contains "$PROJECT_SCAFFOLD_GO_PKG/smoke_test.go" '^package widget$'
@@ -636,7 +636,7 @@ assert_contains "$TEST_DIR/scaffold-generic.txt" "profile is 'generic'"
 # project that already has tests is a no-op.
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_EXISTING" --no-register --type python >/dev/null
 mkdir -p "$PROJECT_SCAFFOLD_EXISTING/tests"
-printf 'def test_real():\n    assert 1 + 1 == 2\n' > "$PROJECT_SCAFFOLD_EXISTING/tests/test_real.py"
+printf 'def test_real():\n    assert 1 + 1 == 2\n' >"$PROJECT_SCAFFOLD_EXISTING/tests/test_real.py"
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_EXISTING" --no-register --scaffold-tests >/dev/null
 assert_not_exists "$PROJECT_SCAFFOLD_EXISTING/tests/test_smoke.py"
 assert_contains "$PROJECT_SCAFFOLD_EXISTING/tests/test_real.py" 'def test_real'
@@ -647,7 +647,7 @@ assert_contains "$PROJECT_SCAFFOLD_EXISTING/tests/test_real.py" 'def test_real'
 PROJECT_SCAFFOLD_EMPTY_PY="$TEST_DIR/test-project-scaffold-empty-python"
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_EMPTY_PY" --no-register --type python >/dev/null
 mkdir -p "$PROJECT_SCAFFOLD_EMPTY_PY/tests"
-: > "$PROJECT_SCAFFOLD_EMPTY_PY/tests/__init__.py"
+: >"$PROJECT_SCAFFOLD_EMPTY_PY/tests/__init__.py"
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_EMPTY_PY" --no-register --scaffold-tests >/dev/null
 assert_exists "$PROJECT_SCAFFOLD_EMPTY_PY/tests/test_smoke.py"
 
@@ -675,7 +675,7 @@ assert_exists "$PROJECT_SCAFFOLD_REINIT_PY/tests/test_smoke.py"
 PROJECT_SCAFFOLD_SPEC_TSX="$TEST_DIR/test-project-scaffold-spec-tsx"
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_SPEC_TSX" --no-register --type node >/dev/null
 mkdir -p "$PROJECT_SCAFFOLD_SPEC_TSX/src"
-printf 'describe("Button", () => { it("renders", () => {}); });\n' > "$PROJECT_SCAFFOLD_SPEC_TSX/src/Button.spec.tsx"
+printf 'describe("Button", () => { it("renders", () => {}); });\n' >"$PROJECT_SCAFFOLD_SPEC_TSX/src/Button.spec.tsx"
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_SPEC_TSX" --no-register --scaffold-tests >/dev/null
 assert_not_exists "$PROJECT_SCAFFOLD_SPEC_TSX/tests/smoke.test.ts"
 
@@ -685,14 +685,14 @@ assert_not_exists "$PROJECT_SCAFFOLD_SPEC_TSX/tests/smoke.test.ts"
 # (1) project_type=generic then profile=python ->  scaffolder runs python.
 PROJECT_SCAFFOLD_ALIAS="$TEST_DIR/test-project-scaffold-alias-lastwins"
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_ALIAS" --no-register --type generic >/dev/null
-printf 'profile=python\n' >> "$PROJECT_SCAFFOLD_ALIAS/.touchstone-config"
+printf 'profile=python\n' >>"$PROJECT_SCAFFOLD_ALIAS/.touchstone-config"
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_ALIAS" --no-register --scaffold-tests >/dev/null
 assert_exists "$PROJECT_SCAFFOLD_ALIAS/tests/test_smoke.py"
 
 # (2) project_type=generic but pyproject.toml exists -> detect upgrades to python.
 PROJECT_SCAFFOLD_PROMOTE="$TEST_DIR/test-project-scaffold-generic-promoted"
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_PROMOTE" --no-register --type generic >/dev/null
-printf '[project]\nname = "demo"\nversion = "0.0.0"\n' > "$PROJECT_SCAFFOLD_PROMOTE/pyproject.toml"
+printf '[project]\nname = "demo"\nversion = "0.0.0"\n' >"$PROJECT_SCAFFOLD_PROMOTE/pyproject.toml"
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_SCAFFOLD_PROMOTE" --no-register --scaffold-tests >/dev/null
 assert_exists "$PROJECT_SCAFFOLD_PROMOTE/tests/test_smoke.py"
 
@@ -705,7 +705,7 @@ git -C "$PROJECT_INIT_EXISTING_SETUP" init >/dev/null
   printf '#!/usr/bin/env bash\n'
   printf 'echo PROJECT_SETUP_RAN\n'
   printf 'exit 42\n'
-} > "$PROJECT_INIT_EXISTING_SETUP/setup.sh"
+} >"$PROJECT_INIT_EXISTING_SETUP/setup.sh"
 chmod +x "$PROJECT_INIT_EXISTING_SETUP/setup.sh"
 if (cd "$PROJECT_INIT_EXISTING_SETUP" && TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" init --no-register) >"$TEST_DIR/touchstone-init-existing-setup.txt" 2>&1; then
   assert_contains "$TEST_DIR/touchstone-init-existing-setup.txt" 'setup.sh already existed'
@@ -730,7 +730,7 @@ else
 fi
 
 mkdir -p "$PYTEST_WRAPPER_PROJECT/.venv/bin"
-cat > "$PYTEST_WRAPPER_PROJECT/.venv/bin/python" <<'FAKEPYTHON'
+cat >"$PYTEST_WRAPPER_PROJECT/.venv/bin/python" <<'FAKEPYTHON'
 #!/usr/bin/env bash
 printf '%s\n' "$@" > "$PWD/pytest-args.txt"
 if [ "$1" = "-m" ] && [ "$2" = "pytest" ]; then
@@ -750,7 +750,7 @@ assert_contains "$PYTEST_WRAPPER_PROJECT/pytest-args.txt" '^-x$'
 FAKE_BIN="$TEST_DIR/fake-bin"
 UV_LOG="$TEST_DIR/uv.log"
 mkdir -p "$FAKE_BIN" "$PROJECT/agent"
-cat > "$FAKE_BIN/uv" <<'FAKEUV'
+cat >"$FAKE_BIN/uv" <<'FAKEUV'
 #!/usr/bin/env bash
 printf '%s|%s\n' "$PWD" "$*" >> "$UV_LOG"
 mkdir -p .venv/bin
@@ -763,10 +763,10 @@ printf 'uv synced\n'
 FAKEUV
 chmod +x "$FAKE_BIN/uv"
 
-printf '[project]\nname = "root-project"\nversion = "0.0.0"\n' > "$PROJECT/pyproject.toml"
+printf '[project]\nname = "root-project"\nversion = "0.0.0"\n' >"$PROJECT/pyproject.toml"
 touch "$PROJECT/uv.lock"
-printf '[project]\nname = "agent-project"\nversion = "0.0.0"\n' > "$PROJECT/agent/pyproject.toml"
-printf '3.11\n' > "$PROJECT/agent/.python-version"
+printf '[project]\nname = "agent-project"\nversion = "0.0.0"\n' >"$PROJECT/agent/pyproject.toml"
+printf '3.11\n' >"$PROJECT/agent/.python-version"
 
 (cd "$PROJECT" && PATH="$FAKE_BIN:$PATH" UV_LOG="$UV_LOG" bash setup.sh --deps-only) >/dev/null
 assert_exists "$PROJECT/.venv/bin/python"
@@ -784,7 +784,7 @@ SETUP_BRANCH_FAKE_BIN="$TEST_DIR/setup-deps-only-fake-bin"
 SETUP_BRANCH_LOG="$TEST_DIR/setup-deps-only-touchstone.log"
 mkdir -p "$SETUP_BRANCH_PROJECT" "$SETUP_BRANCH_FAKE_BIN"
 cp "$TOUCHSTONE_ROOT/templates/setup.sh" "$SETUP_BRANCH_PROJECT/setup.sh"
-cat > "$SETUP_BRANCH_FAKE_BIN/touchstone" <<'FAKETOUCHSTONE'
+cat >"$SETUP_BRANCH_FAKE_BIN/touchstone" <<'FAKETOUCHSTONE'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "$SETUP_BRANCH_LOG"
 exit 64
@@ -813,8 +813,8 @@ SETUP_MISSING_PIP_PROJECT="$TEST_DIR/setup-missing-pip-project"
 SETUP_MISSING_PIP_BIN="$TEST_DIR/setup-missing-pip-bin"
 mkdir -p "$SETUP_MISSING_PIP_PROJECT" "$SETUP_MISSING_PIP_BIN"
 cp "$TOUCHSTONE_ROOT/templates/setup.sh" "$SETUP_MISSING_PIP_PROJECT/setup.sh"
-printf 'pytest\n' > "$SETUP_MISSING_PIP_PROJECT/requirements.txt"
-cat > "$SETUP_MISSING_PIP_BIN/python3" <<'FAKEPYTHON3'
+printf 'pytest\n' >"$SETUP_MISSING_PIP_PROJECT/requirements.txt"
+cat >"$SETUP_MISSING_PIP_BIN/python3" <<'FAKEPYTHON3'
 #!/usr/bin/env bash
 case "$1" in
   --version)
@@ -873,12 +873,12 @@ bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$SETUP_VERSION_PROJECT" --no-r
   printf 'large_reviewers = ["codex"]\n'
   printf '\n[review.local]\n'
   printf 'command = "local-reviewer --model demo"\n'
-} >> "$SETUP_VERSION_PROJECT/.codex-review.toml"
+} >>"$SETUP_VERSION_PROJECT/.codex-review.toml"
 {
   printf 'git_workflow=gitbutler\n'
   printf 'gitbutler_mcp=false\n'
-} >> "$SETUP_VERSION_PROJECT/.touchstone-config"
-cat > "$SETUP_VERSION_FAKE_BIN/touchstone" <<'FAKETOUCHSTONE'
+} >>"$SETUP_VERSION_PROJECT/.touchstone-config"
+cat >"$SETUP_VERSION_FAKE_BIN/touchstone" <<'FAKETOUCHSTONE'
 #!/usr/bin/env bash
 case "$1" in
   version)
@@ -898,23 +898,23 @@ case "$1" in
 esac
 printf 'fake touchstone %s\n' "$*"
 FAKETOUCHSTONE
-cat > "$SETUP_VERSION_FAKE_BIN/brew" <<'FAKEBREW'
+cat >"$SETUP_VERSION_FAKE_BIN/brew" <<'FAKEBREW'
 #!/usr/bin/env bash
 exit 0
 FAKEBREW
-cat > "$SETUP_VERSION_FAKE_BIN/pre-commit" <<'FAKEPRECOMMIT'
+cat >"$SETUP_VERSION_FAKE_BIN/pre-commit" <<'FAKEPRECOMMIT'
 #!/usr/bin/env bash
 printf 'pre-commit installed\n'
 FAKEPRECOMMIT
-cat > "$SETUP_VERSION_FAKE_BIN/gh" <<'FAKEGH'
+cat >"$SETUP_VERSION_FAKE_BIN/gh" <<'FAKEGH'
 #!/usr/bin/env bash
 printf 'Logged in to github.com\n'
 FAKEGH
-cat > "$SETUP_VERSION_FAKE_BIN/codex" <<'FAKECODEX'
+cat >"$SETUP_VERSION_FAKE_BIN/codex" <<'FAKECODEX'
 #!/usr/bin/env bash
 exit 0
 FAKECODEX
-cat > "$SETUP_VERSION_FAKE_BIN/conductor" <<'FAKECONDUCTOR'
+cat >"$SETUP_VERSION_FAKE_BIN/conductor" <<'FAKECONDUCTOR'
 #!/usr/bin/env bash
 case "$1" in
   doctor)
@@ -924,7 +924,7 @@ case "$1" in
 esac
 exit 0
 FAKECONDUCTOR
-cat > "$SETUP_VERSION_FAKE_BIN/but" <<'FAKEBUT'
+cat >"$SETUP_VERSION_FAKE_BIN/but" <<'FAKEBUT'
 #!/usr/bin/env bash
 exit 0
 FAKEBUT
@@ -949,26 +949,26 @@ RUNNER_FAKE_BIN="$TEST_DIR/runner-fake-bin"
 RUNNER_LOG="$TEST_DIR/runner.log"
 mkdir -p "$RUNNER_FAKE_BIN"
 
-cat > "$RUNNER_FAKE_BIN/pnpm" <<'FAKEPNPM'
+cat >"$RUNNER_FAKE_BIN/pnpm" <<'FAKEPNPM'
 #!/usr/bin/env bash
 printf 'pnpm|%s|%s\n' "$PWD" "$*" >> "$RUNNER_LOG"
 FAKEPNPM
-cat > "$RUNNER_FAKE_BIN/npm" <<'FAKENPM'
+cat >"$RUNNER_FAKE_BIN/npm" <<'FAKENPM'
 #!/usr/bin/env bash
 printf 'npm|%s|%s\n' "$PWD" "$*" >> "$RUNNER_LOG"
 FAKENPM
-cat > "$RUNNER_FAKE_BIN/swift" <<'FAKESWIFT'
+cat >"$RUNNER_FAKE_BIN/swift" <<'FAKESWIFT'
 #!/usr/bin/env bash
 printf 'swift|%s|%s\n' "$PWD" "$*" >> "$RUNNER_LOG"
 FAKESWIFT
-cat > "$RUNNER_FAKE_BIN/cargo" <<'FAKECARGO'
+cat >"$RUNNER_FAKE_BIN/cargo" <<'FAKECARGO'
 #!/usr/bin/env bash
 printf 'cargo|%s|%s\n' "$PWD" "$*" >> "$RUNNER_LOG"
 FAKECARGO
 chmod +x "$RUNNER_FAKE_BIN/"*
 
-printf '{"packageManager":"pnpm@9.0.0","scripts":{"lint":"echo lint","typecheck":"echo typecheck","test":"echo test"}}\n' > "$PROJECT_NODE/package.json"
-: > "$RUNNER_LOG"
+printf '{"packageManager":"pnpm@9.0.0","scripts":{"lint":"echo lint","typecheck":"echo typecheck","test":"echo test"}}\n' >"$PROJECT_NODE/package.json"
+: >"$RUNNER_LOG"
 (cd "$PROJECT_NODE" && PATH="$RUNNER_FAKE_BIN:$PATH" RUNNER_LOG="$RUNNER_LOG" bash scripts/touchstone-run.sh validate) >/dev/null
 assert_contains "$RUNNER_LOG" 'pnpm|.*/test-project-node|lint'
 assert_contains "$RUNNER_LOG" 'pnpm|.*/test-project-node|typecheck'
@@ -986,9 +986,9 @@ fi
 PROJECT_NODE_BUILD="$TEST_DIR/test-project-node-build"
 mkdir -p "$PROJECT_NODE_BUILD/scripts"
 cp "$TOUCHSTONE_ROOT/scripts/touchstone-run.sh" "$PROJECT_NODE_BUILD/scripts/touchstone-run.sh"
-printf 'project_type=node\n' > "$PROJECT_NODE_BUILD/.touchstone-config"
-printf '{"packageManager":"pnpm@9.0.0","scripts":{"lint":"echo lint","typecheck":"echo typecheck","build":"echo build","test":"echo test"}}\n' > "$PROJECT_NODE_BUILD/package.json"
-: > "$RUNNER_LOG"
+printf 'project_type=node\n' >"$PROJECT_NODE_BUILD/.touchstone-config"
+printf '{"packageManager":"pnpm@9.0.0","scripts":{"lint":"echo lint","typecheck":"echo typecheck","build":"echo build","test":"echo test"}}\n' >"$PROJECT_NODE_BUILD/package.json"
+: >"$RUNNER_LOG"
 (cd "$PROJECT_NODE_BUILD" && PATH="$RUNNER_FAKE_BIN:$PATH" RUNNER_LOG="$RUNNER_LOG" bash scripts/touchstone-run.sh validate) >/dev/null
 assert_contains "$RUNNER_LOG" 'pnpm|.*/test-project-node-build|typecheck'
 assert_contains "$RUNNER_LOG" 'pnpm|.*/test-project-node-build|build'
@@ -999,9 +999,9 @@ assert_contains "$RUNNER_LOG" 'pnpm|.*/test-project-node-build|test'
 PROJECT_NODE_BUILD_ONLY="$TEST_DIR/test-project-node-build-only"
 mkdir -p "$PROJECT_NODE_BUILD_ONLY/scripts"
 cp "$TOUCHSTONE_ROOT/scripts/touchstone-run.sh" "$PROJECT_NODE_BUILD_ONLY/scripts/touchstone-run.sh"
-printf 'project_type=node\n' > "$PROJECT_NODE_BUILD_ONLY/.touchstone-config"
-printf '{"packageManager":"pnpm@9.0.0","scripts":{"lint":"echo lint","build":"tsc","test":"echo test"}}\n' > "$PROJECT_NODE_BUILD_ONLY/package.json"
-: > "$RUNNER_LOG"
+printf 'project_type=node\n' >"$PROJECT_NODE_BUILD_ONLY/.touchstone-config"
+printf '{"packageManager":"pnpm@9.0.0","scripts":{"lint":"echo lint","build":"tsc","test":"echo test"}}\n' >"$PROJECT_NODE_BUILD_ONLY/package.json"
+: >"$RUNNER_LOG"
 (cd "$PROJECT_NODE_BUILD_ONLY" && PATH="$RUNNER_FAKE_BIN:$PATH" RUNNER_LOG="$RUNNER_LOG" bash scripts/touchstone-run.sh validate) >/dev/null
 if grep -q 'pnpm|.*/test-project-node-build-only|build' "$RUNNER_LOG"; then
   echo "FAIL: build should not run during validate when typecheck is absent (build IS typecheck)" >&2
@@ -1011,9 +1011,9 @@ fi
 SWIFT_PROJECT="$TEST_DIR/swift-runner"
 mkdir -p "$SWIFT_PROJECT/scripts"
 cp "$TOUCHSTONE_ROOT/scripts/touchstone-run.sh" "$SWIFT_PROJECT/scripts/touchstone-run.sh"
-printf 'project_type=swift\n' > "$SWIFT_PROJECT/.touchstone-config"
-printf '// swift package\n' > "$SWIFT_PROJECT/Package.swift"
-: > "$RUNNER_LOG"
+printf 'project_type=swift\n' >"$SWIFT_PROJECT/.touchstone-config"
+printf '// swift package\n' >"$SWIFT_PROJECT/Package.swift"
+: >"$RUNNER_LOG"
 (cd "$SWIFT_PROJECT" && PATH="$RUNNER_FAKE_BIN:$PATH" RUNNER_LOG="$RUNNER_LOG" bash scripts/touchstone-run.sh validate) >/dev/null
 assert_contains "$RUNNER_LOG" 'swift|.*/swift-runner|build'
 assert_contains "$RUNNER_LOG" 'swift|.*/swift-runner|test'
@@ -1021,9 +1021,9 @@ assert_contains "$RUNNER_LOG" 'swift|.*/swift-runner|test'
 RUST_PROJECT="$TEST_DIR/rust-runner"
 mkdir -p "$RUST_PROJECT/scripts"
 cp "$TOUCHSTONE_ROOT/scripts/touchstone-run.sh" "$RUST_PROJECT/scripts/touchstone-run.sh"
-printf 'project_type=rust\n' > "$RUST_PROJECT/.touchstone-config"
-printf '[package]\nname = "demo"\nversion = "0.0.0"\n' > "$RUST_PROJECT/Cargo.toml"
-: > "$RUNNER_LOG"
+printf 'project_type=rust\n' >"$RUST_PROJECT/.touchstone-config"
+printf '[package]\nname = "demo"\nversion = "0.0.0"\n' >"$RUST_PROJECT/Cargo.toml"
+: >"$RUNNER_LOG"
 (cd "$RUST_PROJECT" && PATH="$RUNNER_FAKE_BIN:$PATH" RUNNER_LOG="$RUNNER_LOG" bash scripts/touchstone-run.sh validate) >/dev/null
 assert_contains "$RUNNER_LOG" 'cargo|.*/rust-runner|fmt -- --check'
 assert_contains "$RUNNER_LOG" 'cargo|.*/rust-runner|clippy --all-targets --all-features -- -D warnings'
@@ -1036,10 +1036,10 @@ cp "$TOUCHSTONE_ROOT/scripts/touchstone-run.sh" "$MONOREPO_PROJECT/scripts/touch
 {
   printf 'project_type=generic\n'
   printf 'targets=web:apps/web:node,api:services/api:rust\n'
-} > "$MONOREPO_PROJECT/.touchstone-config"
-printf '{"scripts":{"test":"echo test"}}\n' > "$MONOREPO_PROJECT/apps/web/package.json"
-printf '[package]\nname = "api"\nversion = "0.0.0"\n' > "$MONOREPO_PROJECT/services/api/Cargo.toml"
-: > "$RUNNER_LOG"
+} >"$MONOREPO_PROJECT/.touchstone-config"
+printf '{"scripts":{"test":"echo test"}}\n' >"$MONOREPO_PROJECT/apps/web/package.json"
+printf '[package]\nname = "api"\nversion = "0.0.0"\n' >"$MONOREPO_PROJECT/services/api/Cargo.toml"
+: >"$RUNNER_LOG"
 (cd "$MONOREPO_PROJECT" && PATH="$RUNNER_FAKE_BIN:$PATH" RUNNER_LOG="$RUNNER_LOG" bash scripts/touchstone-run.sh test) >/dev/null
 assert_contains "$RUNNER_LOG" 'npm|.*/monorepo-runner/apps/web|run test'
 assert_contains "$RUNNER_LOG" 'cargo|.*/monorepo-runner/services/api|test --all'
@@ -1048,17 +1048,17 @@ assert_contains "$RUNNER_LOG" 'cargo|.*/monorepo-runner/services/api|test --all'
 # TOUCHSTONE_SKIP_DEVTOOLS=1 keeps these tests hermetic — we're exercising the
 # dependency dispatch, not the per-profile dev-tool install (which would call
 # real brew/go/rustup on macOS dev machines that have those binaries on PATH).
-: > "$RUNNER_LOG"
+: >"$RUNNER_LOG"
 (cd "$PROJECT_NODE" && PATH="$RUNNER_FAKE_BIN:$PATH" RUNNER_LOG="$RUNNER_LOG" TOUCHSTONE_SKIP_DEVTOOLS=1 bash setup.sh --deps-only) >/dev/null
 assert_contains "$RUNNER_LOG" 'pnpm|.*/test-project-node|install'
 
 cp "$TOUCHSTONE_ROOT/templates/setup.sh" "$SWIFT_PROJECT/setup.sh"
-: > "$RUNNER_LOG"
+: >"$RUNNER_LOG"
 (cd "$SWIFT_PROJECT" && PATH="$RUNNER_FAKE_BIN:$PATH" RUNNER_LOG="$RUNNER_LOG" TOUCHSTONE_SKIP_DEVTOOLS=1 bash setup.sh --deps-only) >/dev/null
 assert_contains "$RUNNER_LOG" 'swift|.*/swift-runner|package resolve'
 
 cp "$TOUCHSTONE_ROOT/templates/setup.sh" "$RUST_PROJECT/setup.sh"
-: > "$RUNNER_LOG"
+: >"$RUNNER_LOG"
 (cd "$RUST_PROJECT" && PATH="$RUNNER_FAKE_BIN:$PATH" RUNNER_LOG="$RUNNER_LOG" TOUCHSTONE_SKIP_DEVTOOLS=1 bash setup.sh --deps-only) >/dev/null
 assert_contains "$RUNNER_LOG" 'cargo|.*/rust-runner|fetch'
 
@@ -1069,7 +1069,7 @@ phase "hook installation propagation"
 HOOKS_FAKE_BIN="$TEST_DIR/hooks-fake-bin"
 HOOKS_LOG="$TEST_DIR/hooks.log"
 mkdir -p "$HOOKS_FAKE_BIN"
-cat > "$HOOKS_FAKE_BIN/pre-commit" <<FAKEPRECOMMIT
+cat >"$HOOKS_FAKE_BIN/pre-commit" <<FAKEPRECOMMIT
 #!/usr/bin/env bash
 printf '%s\n' "\$*" >> "$HOOKS_LOG"
 # Write the pre-commit-framework marker and chmod +x so touchstone doctor
@@ -1095,7 +1095,7 @@ esac
 FAKEPRECOMMIT
 chmod +x "$HOOKS_FAKE_BIN/pre-commit"
 
-: > "$HOOKS_LOG"
+: >"$HOOKS_LOG"
 PATH="$HOOKS_FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_HOOKS_WITH" --no-register >/dev/null
 assert_contains "$HOOKS_LOG" '^install --hook-type pre-commit$'
 assert_contains "$HOOKS_LOG" '^install --hook-type pre-push$'
@@ -1126,7 +1126,7 @@ fi
 # so pre-code repos and new scaffolds don't fail validate.
 PYTEST_FAKE_BIN="$TEST_DIR/pytest-fake-bin"
 mkdir -p "$PYTEST_FAKE_BIN"
-cat > "$PYTEST_FAKE_BIN/python3" <<'FAKEPY'
+cat >"$PYTEST_FAKE_BIN/python3" <<'FAKEPY'
 #!/usr/bin/env bash
 if [ "$1" = "-m" ] && [ "$2" = "pytest" ]; then
   printf 'collected 0 items\n'
@@ -1138,7 +1138,7 @@ chmod +x "$PYTEST_FAKE_BIN/python3"
 
 mkdir -p "$PROJECT_PYTEST_EMPTY/scripts"
 cp "$TOUCHSTONE_ROOT/scripts/touchstone-run.sh" "$PROJECT_PYTEST_EMPTY/scripts/touchstone-run.sh"
-printf 'project_type=python\n' > "$PROJECT_PYTEST_EMPTY/.touchstone-config"
+printf 'project_type=python\n' >"$PROJECT_PYTEST_EMPTY/.touchstone-config"
 if (cd "$PROJECT_PYTEST_EMPTY" && PATH="$PYTEST_FAKE_BIN:$PATH" PYTEST_PYTHON=python3 bash scripts/touchstone-run.sh test) >"$TEST_DIR/pytest-empty-output.txt" 2>&1; then
   assert_contains "$TEST_DIR/pytest-empty-output.txt" 'pytest found no tests; skipped'
 else
@@ -1169,12 +1169,12 @@ assert_not_contains "$TEST_DIR/reinit-output.txt" 'Fill in project details'
 PROJECT_REINIT_SETUP="$TEST_DIR/test-project-reinit-setup"
 PATH="$HOOKS_FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_REINIT_SETUP" --no-register >/dev/null
 rm -f "$PROJECT_REINIT_SETUP/setup.sh"
-cat > "$PROJECT_REINIT_SETUP/setup.sh.marker" <<'MARKER'
+cat >"$PROJECT_REINIT_SETUP/setup.sh.marker" <<'MARKER'
 # Touchstone should never run setup.sh during reconcile; if it does, this test catches it.
 MARKER
 # Replace the template setup.sh with a marker-logging version via a wrapper PATH.
 REINIT_SETUP_LOG="$TEST_DIR/reinit-setup.log"
-: > "$REINIT_SETUP_LOG"
+: >"$REINIT_SETUP_LOG"
 REINIT_SETUP_FAKE_BIN="$TEST_DIR/reinit-setup-fake-bin"
 mkdir -p "$REINIT_SETUP_FAKE_BIN"
 cp "$HOOKS_FAKE_BIN/pre-commit" "$REINIT_SETUP_FAKE_BIN/pre-commit"
@@ -1241,7 +1241,7 @@ fi
 # doesn't accidentally pass on the wrong probe — either convention is valid.
 SIBLING_STUB_BIN="$TEST_DIR/sibling-stub-bin"
 mkdir -p "$SIBLING_STUB_BIN"
-cat > "$SIBLING_STUB_BIN/cortex" <<'CORTEXSTUB'
+cat >"$SIBLING_STUB_BIN/cortex" <<'CORTEXSTUB'
 #!/usr/bin/env bash
 case "${1:-}" in
   version|--version) echo "cortex 9.9.9"; exit 0 ;;
@@ -1249,7 +1249,7 @@ case "${1:-}" in
 esac
 CORTEXSTUB
 chmod +x "$SIBLING_STUB_BIN/cortex"
-cat > "$SIBLING_STUB_BIN/sentinel" <<'SENTINELSTUB'
+cat >"$SIBLING_STUB_BIN/sentinel" <<'SENTINELSTUB'
 #!/usr/bin/env bash
 case "${1:-}" in
   version) echo "Error: no such command" >&2; exit 2 ;;
@@ -1285,10 +1285,10 @@ fi
 PROJECT_DOCTOR_EMPTY_PY="$TEST_DIR/test-project-doctor-empty-python"
 PATH="$HOOKS_FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_DOCTOR_EMPTY_PY" --no-register --type python >/dev/null
 mkdir -p "$PROJECT_DOCTOR_EMPTY_PY/tests"
-: > "$PROJECT_DOCTOR_EMPTY_PY/tests/__init__.py"
+: >"$PROJECT_DOCTOR_EMPTY_PY/tests/__init__.py"
 RUFF_STUB_EMPTY_PY="$TEST_DIR/ruff-stub-empty-py"
 mkdir -p "$RUFF_STUB_EMPTY_PY"
-cat > "$RUFF_STUB_EMPTY_PY/ruff" <<'RUFFSTUBEMPTYPY'
+cat >"$RUFF_STUB_EMPTY_PY/ruff" <<'RUFFSTUBEMPTYPY'
 #!/usr/bin/env bash
 exit 0
 RUFFSTUBEMPTYPY
@@ -1306,7 +1306,7 @@ assert_contains "$TEST_DIR/doctor-empty-py.txt" "tests: not found for profile 'p
 # so the content check (not the executability check) is the one exercised.
 PROJECT_DOCTOR_HOOK_DRIFT="$TEST_DIR/test-project-doctor-hook-drift"
 PATH="$HOOKS_FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_DOCTOR_HOOK_DRIFT" --no-register >/dev/null
-printf '#!/usr/bin/env bash\necho some other framework\n' > "$PROJECT_DOCTOR_HOOK_DRIFT/.git/hooks/pre-push"
+printf '#!/usr/bin/env bash\necho some other framework\n' >"$PROJECT_DOCTOR_HOOK_DRIFT/.git/hooks/pre-push"
 chmod +x "$PROJECT_DOCTOR_HOOK_DRIFT/.git/hooks/pre-push"
 if (cd "$PROJECT_DOCTOR_HOOK_DRIFT" && TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" doctor --project) >"$TEST_DIR/doctor-hook-drift.txt" 2>&1; then
   echo "FAIL: doctor --project should exit nonzero when pre-push is not the pre-commit-framework shim" >&2
@@ -1332,10 +1332,10 @@ fi
 PROJECT_DOCTOR_PY_WITH="$TEST_DIR/test-project-doctor-python-with"
 PATH="$HOOKS_FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_DOCTOR_PY_WITH" --no-register --type python >/dev/null
 mkdir -p "$PROJECT_DOCTOR_PY_WITH/tests"
-printf 'def test_smoke():\n    assert True\n' > "$PROJECT_DOCTOR_PY_WITH/tests/test_smoke.py"
+printf 'def test_smoke():\n    assert True\n' >"$PROJECT_DOCTOR_PY_WITH/tests/test_smoke.py"
 RUFF_STUB_BIN="$TEST_DIR/ruff-stub-bin"
 mkdir -p "$RUFF_STUB_BIN"
-cat > "$RUFF_STUB_BIN/ruff" <<'RUFFSTUB'
+cat >"$RUFF_STUB_BIN/ruff" <<'RUFFSTUB'
 #!/usr/bin/env bash
 exit 0
 RUFFSTUB
@@ -1374,12 +1374,12 @@ fi
 PROJECT_DOCTOR_MONO="$TEST_DIR/test-project-doctor-monorepo"
 PATH="$HOOKS_FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_DOCTOR_MONO" --no-register >/dev/null
 mkdir -p "$PROJECT_DOCTOR_MONO/apps/web" "$PROJECT_DOCTOR_MONO/services/api" "$PROJECT_DOCTOR_MONO/apps/tsapp" "$PROJECT_DOCTOR_MONO/packages/autodetect"
-printf '[package]\nname = "api"\nversion = "0.0.0"\n' > "$PROJECT_DOCTOR_MONO/services/api/Cargo.toml"
-printf '{"scripts":{"lint":"echo lint","test":"echo test"}}\n' > "$PROJECT_DOCTOR_MONO/apps/web/package.json"
+printf '[package]\nname = "api"\nversion = "0.0.0"\n' >"$PROJECT_DOCTOR_MONO/services/api/Cargo.toml"
+printf '{"scripts":{"lint":"echo lint","test":"echo test"}}\n' >"$PROJECT_DOCTOR_MONO/apps/web/package.json"
 # tsapp declares "typescript" profile (alias for node) but has no lint script.
-printf '{}\n' > "$PROJECT_DOCTOR_MONO/apps/tsapp/package.json"
+printf '{}\n' >"$PROJECT_DOCTOR_MONO/apps/tsapp/package.json"
 # autodetect declares no explicit profile — must be detected from manifest (Cargo.toml).
-printf '[package]\nname = "autodetected"\nversion = "0.0.0"\n' > "$PROJECT_DOCTOR_MONO/packages/autodetect/Cargo.toml"
+printf '[package]\nname = "autodetected"\nversion = "0.0.0"\n' >"$PROJECT_DOCTOR_MONO/packages/autodetect/Cargo.toml"
 sed -i '' 's|^targets=.*|targets=web:apps/web:node,api:services/api:rust,tsapp:apps/tsapp:typescript,autodetect:packages/autodetect|' "$PROJECT_DOCTOR_MONO/.touchstone-config"
 if (cd "$PROJECT_DOCTOR_MONO" && TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" doctor --project) >"$TEST_DIR/doctor-monorepo.txt" 2>&1; then
   assert_contains "$TEST_DIR/doctor-monorepo.txt" "target web:"
@@ -1408,7 +1408,7 @@ PATH="$HOOKS_FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$
 # Prepend a stale project_type=generic and keep the real profile=python after it
 # to exercise the last-write-wins tie-breaker.
 sed -i '' 's|^project_type=.*|project_type=generic|' "$PROJECT_DOCTOR_ALIAS_KEY/.touchstone-config"
-printf 'profile=python\n' >> "$PROJECT_DOCTOR_ALIAS_KEY/.touchstone-config"
+printf 'profile=python\n' >>"$PROJECT_DOCTOR_ALIAS_KEY/.touchstone-config"
 if PATH="/usr/bin:/bin" command -v ruff >/dev/null 2>&1; then
   echo "SKIP: ruff on minimal PATH; cannot test project_type/profile last-wins doctor case on this machine" >&2
 else
@@ -1460,8 +1460,8 @@ fi
 PROJECT_DOCTOR_AUTO_TARGETS="$TEST_DIR/test-project-doctor-auto-targets"
 PATH="$HOOKS_FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_DOCTOR_AUTO_TARGETS" --no-register >/dev/null
 mkdir -p "$PROJECT_DOCTOR_AUTO_TARGETS/apps/web" "$PROJECT_DOCTOR_AUTO_TARGETS/services/api"
-printf '{}\n' > "$PROJECT_DOCTOR_AUTO_TARGETS/apps/web/package.json"
-printf '[package]\nname = "api"\nversion = "0.0.0"\n' > "$PROJECT_DOCTOR_AUTO_TARGETS/services/api/Cargo.toml"
+printf '{}\n' >"$PROJECT_DOCTOR_AUTO_TARGETS/apps/web/package.json"
+printf '[package]\nname = "api"\nversion = "0.0.0"\n' >"$PROJECT_DOCTOR_AUTO_TARGETS/services/api/Cargo.toml"
 # Leave targets= empty in .touchstone-config — new-project.sh only fills it when
 # the apps/services dirs exist at bootstrap time.
 if (cd "$PROJECT_DOCTOR_AUTO_TARGETS" && TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" doctor --project) >"$TEST_DIR/doctor-auto-targets.txt" 2>&1; then
@@ -1479,7 +1479,7 @@ fi
 # root config using the alias would silently skip the lint-script check.
 PROJECT_DOCTOR_ALIAS="$TEST_DIR/test-project-doctor-alias"
 PATH="$HOOKS_FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_DOCTOR_ALIAS" --no-register >/dev/null
-printf '{}\n' > "$PROJECT_DOCTOR_ALIAS/package.json"
+printf '{}\n' >"$PROJECT_DOCTOR_ALIAS/package.json"
 sed -i '' 's|^project_type=.*|project_type=typescript|' "$PROJECT_DOCTOR_ALIAS/.touchstone-config"
 if (cd "$PROJECT_DOCTOR_ALIAS" && TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" doctor --project) >"$TEST_DIR/doctor-alias.txt" 2>&1; then
   # No lint script in package.json — the node-profile lint-script check must fire,
@@ -1521,7 +1521,7 @@ fi
 # Generic profile doctor must NOT count missing tests as an issue — a fresh
 # generic project with no test_command configured stays fully armed.
 # (Reuses the PROJECT_DOCTOR repo which was bootstrapped clean above.)
-if (cd "$PROJECT_DOCTOR_HOOK_DRIFT" && printf '#!/usr/bin/env bash\n# File generated by pre-commit: https://pre-commit.com\n' > .git/hooks/pre-push) ; then : ; fi
+if (cd "$PROJECT_DOCTOR_HOOK_DRIFT" && printf '#!/usr/bin/env bash\n# File generated by pre-commit: https://pre-commit.com\n' >.git/hooks/pre-push); then :; fi
 if (cd "$PROJECT_DOCTOR_HOOK_DRIFT" && TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" doctor --project) >"$TEST_DIR/doctor-generic.txt" 2>&1; then
   assert_contains "$TEST_DIR/doctor-generic.txt" 'Project is fully armed'
   assert_contains "$TEST_DIR/doctor-generic.txt" "tests: profile is 'generic'"
@@ -1541,7 +1541,7 @@ fi
 
 # doctor --project on a legacy .toolkit-version repo must point to the migration command.
 mkdir -p "$PROJECT_DOCTOR_LEGACY"
-echo "legacy-sha" > "$PROJECT_DOCTOR_LEGACY/.toolkit-version"
+echo "legacy-sha" >"$PROJECT_DOCTOR_LEGACY/.toolkit-version"
 if (cd "$PROJECT_DOCTOR_LEGACY" && TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" doctor --project) >"$TEST_DIR/doctor-legacy.txt" 2>&1; then
   echo "FAIL: doctor --project should exit nonzero on a legacy .toolkit-version repo" >&2
   ERRORS=$((ERRORS + 1))
@@ -1553,8 +1553,8 @@ fi
 # neither doctor nor init may report healthy in that state.
 PROJECT_MIGRATION_CONFLICT="$TEST_DIR/test-project-migration-conflict"
 mkdir -p "$PROJECT_MIGRATION_CONFLICT"
-echo "legacy-sha" > "$PROJECT_MIGRATION_CONFLICT/.toolkit-version"
-echo "touchstone-sha" > "$PROJECT_MIGRATION_CONFLICT/.touchstone-version"
+echo "legacy-sha" >"$PROJECT_MIGRATION_CONFLICT/.toolkit-version"
+echo "touchstone-sha" >"$PROJECT_MIGRATION_CONFLICT/.touchstone-version"
 if (cd "$PROJECT_MIGRATION_CONFLICT" && TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" doctor --project) >"$TEST_DIR/doctor-conflict.txt" 2>&1; then
   echo "FAIL: doctor --project should exit nonzero when both .toolkit-version and .touchstone-version exist" >&2
   ERRORS=$((ERRORS + 1))
@@ -1574,11 +1574,11 @@ fi
 PATH="$HOOKS_FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_OUTDATED" --no-register >/dev/null
 git -C "$PROJECT_OUTDATED" config user.email test@touchstone
 git -C "$PROJECT_OUTDATED" config user.name test-committer
-echo "0000000000000000000000000000000000000001" > "$PROJECT_OUTDATED/.touchstone-version"
+echo "0000000000000000000000000000000000000001" >"$PROJECT_OUTDATED/.touchstone-version"
 (cd "$PROJECT_OUTDATED" && git commit --no-verify -am "pin to old touchstone" >/dev/null)
 OUTDATED_INIT_BRANCH="$(git -C "$PROJECT_OUTDATED" branch --show-current)"
 mkdir -p "$PROJECT_OUTDATED/.claude"
-printf 'lock\n' > "$PROJECT_OUTDATED/.claude/scheduled_tasks.lock"
+printf 'lock\n' >"$PROJECT_OUTDATED/.claude/scheduled_tasks.lock"
 if (cd "$PROJECT_OUTDATED" && TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" init --no-setup --no-ship --no-register) >"$TEST_DIR/init-outdated.txt" 2>&1; then
   assert_contains "$TEST_DIR/init-outdated.txt" 'reconciling'
   assert_contains "$TEST_DIR/init-outdated.txt" 'reconcile files in place'
@@ -1599,12 +1599,12 @@ PROJECT_OUTDATED_SHIP="$TEST_DIR/outdated-ship-project"
 PATH="$HOOKS_FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_OUTDATED_SHIP" --no-register >/dev/null
 git -C "$PROJECT_OUTDATED_SHIP" config user.email test@touchstone
 git -C "$PROJECT_OUTDATED_SHIP" config user.name test-committer
-echo "0000000000000000000000000000000000000001" > "$PROJECT_OUTDATED_SHIP/.touchstone-version"
+echo "0000000000000000000000000000000000000001" >"$PROJECT_OUTDATED_SHIP/.touchstone-version"
 (cd "$PROJECT_OUTDATED_SHIP" && git commit --no-verify -am "pin to old touchstone" >/dev/null)
 # Stub gh so any accidental shipping attempt fails fast without real network.
 GH_STUB_BIN="$TEST_DIR/gh-stub-bin"
 mkdir -p "$GH_STUB_BIN"
-cat > "$GH_STUB_BIN/gh" <<'GHSTUB'
+cat >"$GH_STUB_BIN/gh" <<'GHSTUB'
 #!/usr/bin/env bash
 echo "gh: stubbed failure" >&2
 exit 1
@@ -1642,8 +1642,8 @@ mkdir -p "$ZERO_ARGS_FAKE_HOME"
 # --no-setup skips running setup.sh but does NOT populate args[] — exactly
 # the zero-args path that triggered the bug. HOOKS_FAKE_BIN stubs pre-commit.
 if (cd "$PROJECT_INIT_ZERO_ARGS" && HOME="$ZERO_ARGS_FAKE_HOME" PATH="$HOOKS_FAKE_BIN:$PATH" \
-    TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" init --no-setup \
-    </dev/null) >"$TEST_DIR/init-zero-args.txt" 2>&1; then
+  TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" init --no-setup \
+  </dev/null) >"$TEST_DIR/init-zero-args.txt" 2>&1; then
   assert_contains "$TEST_DIR/init-zero-args.txt" 'setting up this project'
 else
   echo "FAIL: touchstone init --no-setup (zero args[] to new-project.sh) exited nonzero" >&2
@@ -1657,7 +1657,7 @@ fi
 # python3, so the fixture has to use PYTEST_PYTHON to point at the fake
 # interpreter explicitly. The intent of the assertion is unchanged: a
 # real (exit 1) test failure must propagate, not be swallowed.
-cat > "$PYTEST_FAKE_BIN/python3" <<'FAKEPY'
+cat >"$PYTEST_FAKE_BIN/python3" <<'FAKEPY'
 #!/usr/bin/env bash
 if [ "$1" = "-m" ] && [ "$2" = "pytest" ]; then
   printf 'E   assert False\n'
@@ -1687,9 +1687,9 @@ PROJECT_WIZARD_YES="$TEST_DIR/test-project-wizard-yes"
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_WIZARD_YES" \
   --yes --no-register --no-with-cortex --no-with-sentinel --no-github \
   >"$TEST_DIR/wizard-yes.txt" 2>&1 || {
-    echo "FAIL: --yes bootstrap exited nonzero" >&2
-    ERRORS=$((ERRORS + 1))
-  }
+  echo "FAIL: --yes bootstrap exited nonzero" >&2
+  ERRORS=$((ERRORS + 1))
+}
 
 # --yes must print the "Equivalent to rerun" block so scripters learn flags.
 assert_contains "$TEST_DIR/wizard-yes.txt" 'Equivalent to rerun:'
@@ -1714,9 +1714,9 @@ assert_contains "$TEST_DIR/wizard-yes-flags.txt" '--github-public'
 PROJECT_WIZARD_NON_TTY="$TEST_DIR/test-project-wizard-non-tty"
 YES_MODE=false bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_WIZARD_NON_TTY" --no-register \
   </dev/null >"$TEST_DIR/wizard-non-tty.txt" 2>&1 || {
-    echo "FAIL: non-TTY bootstrap exited nonzero" >&2
-    ERRORS=$((ERRORS + 1))
-  }
+  echo "FAIL: non-TTY bootstrap exited nonzero" >&2
+  ERRORS=$((ERRORS + 1))
+}
 if grep -q 'Equivalent to rerun:' "$TEST_DIR/wizard-non-tty.txt" 2>/dev/null; then
   echo "FAIL: non-TTY bootstrap must not print the wizard 'Equivalent to rerun' block" >&2
   ERRORS=$((ERRORS + 1))
@@ -1749,8 +1749,8 @@ bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_FLAGS_BASELINE" \
   </dev/null >"$TEST_DIR/flags-baseline.txt" 2>&1
 # Diff the tree listings (filenames only, .git excluded) — same structure
 # expected. We compare sorted relative paths, which is stable across runs.
-( cd "$PROJECT_YES_BASELINE" && find . -type f -not -path './.git/*' | sort ) >"$TEST_DIR/yes-tree.txt"
-( cd "$PROJECT_FLAGS_BASELINE" && find . -type f -not -path './.git/*' | sort ) >"$TEST_DIR/flags-tree.txt"
+(cd "$PROJECT_YES_BASELINE" && find . -type f -not -path './.git/*' | sort) >"$TEST_DIR/yes-tree.txt"
+(cd "$PROJECT_FLAGS_BASELINE" && find . -type f -not -path './.git/*' | sort) >"$TEST_DIR/flags-tree.txt"
 if ! diff -q "$TEST_DIR/yes-tree.txt" "$TEST_DIR/flags-tree.txt" >/dev/null 2>&1; then
   echo "FAIL: --yes tree differs from equivalent flag-driven tree" >&2
   diff "$TEST_DIR/yes-tree.txt" "$TEST_DIR/flags-tree.txt" >&2 || true
@@ -1832,7 +1832,7 @@ R5_STUBDIR="$(mktemp -d -t touchstone-r5-stubs.XXXXXX)"
 
 # Fake cortex CLI: creates `.cortex/` with a tracked marker file, exactly the
 # shape the R5.1 fix needs captured in the initial commit.
-cat > "$R5_STUBDIR/cortex" <<'STUB'
+cat >"$R5_STUBDIR/cortex" <<'STUB'
 #!/usr/bin/env bash
 set -euo pipefail
 case "${1:-}" in
@@ -1855,7 +1855,7 @@ chmod +x "$R5_STUBDIR/cortex"
 # between-item `git reset --hard`; the stub mirrors it so the R5.1
 # atomicity assertion below properly exercises the "sentinel committed
 # first" code path in bootstrap/new-project.sh.
-cat > "$R5_STUBDIR/sentinel" <<'STUB'
+cat >"$R5_STUBDIR/sentinel" <<'STUB'
 #!/usr/bin/env bash
 set -euo pipefail
 case "${1:-}" in
@@ -1891,7 +1891,11 @@ chmod +x "$R5_STUBDIR/sentinel"
 PATH="$R5_STUBDIR:$PATH" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" \
   "$PROJECT_R5" --no-register --with-cortex --with-sentinel \
   </dev/null >"$TEST_DIR/r5-bootstrap.txt" 2>&1 \
-  || { echo "FAIL: bootstrap with --with-cortex --with-sentinel exited non-zero"; cat "$TEST_DIR/r5-bootstrap.txt"; ERRORS=$((ERRORS+1)); }
+  || {
+    echo "FAIL: bootstrap with --with-cortex --with-sentinel exited non-zero"
+    cat "$TEST_DIR/r5-bootstrap.txt"
+    ERRORS=$((ERRORS + 1))
+  }
 
 # R5.1 assertions: the integration outputs and the scaffold land in one commit.
 assert_exists "$PROJECT_R5/.cortex"
@@ -1903,7 +1907,7 @@ if [ -d "$PROJECT_R5/.git" ]; then
   if [ "$commit_count" != "1" ]; then
     echo "FAIL: expected 1 commit after --with-cortex --with-sentinel scaffold, got $commit_count" >&2
     git -C "$PROJECT_R5" log --oneline >&2 || true
-    ERRORS=$((ERRORS+1))
+    ERRORS=$((ERRORS + 1))
   fi
 
   # Every integration-authored file must be in the initial commit's tree.
@@ -1913,7 +1917,7 @@ if [ -d "$PROJECT_R5/.git" ]; then
     if ! printf '%s\n' "$tracked" | grep -qxF "$path"; then
       echo "FAIL: expected $path to be tracked in the initial commit; got:" >&2
       printf '%s\n' "$tracked" >&2
-      ERRORS=$((ERRORS+1))
+      ERRORS=$((ERRORS + 1))
     fi
   done
 
@@ -1921,7 +1925,7 @@ if [ -d "$PROJECT_R5/.git" ]; then
   if [ -n "$(git -C "$PROJECT_R5" status --porcelain 2>/dev/null)" ]; then
     echo "FAIL: working tree dirty after scaffold:" >&2
     git -C "$PROJECT_R5" status --porcelain >&2
-    ERRORS=$((ERRORS+1))
+    ERRORS=$((ERRORS + 1))
   fi
 fi
 
@@ -1934,14 +1938,14 @@ fi
 # auto-commit from touchstone (same as pre-R5 behavior).
 PROJECT_R5_EXISTING="$TEST_DIR/test-project-r5-existing-history"
 mkdir -p "$PROJECT_R5_EXISTING"
-( cd "$PROJECT_R5_EXISTING" \
+(cd "$PROJECT_R5_EXISTING" \
   && git init -q -b main \
   && git config user.email "u@test" \
   && git config user.name "User" \
-  && echo "# prior work" > README.md \
+  && echo "# prior work" >README.md \
   && git add README.md \
   && git commit -q -m "feat: user's own initial commit" \
-  && echo "dirty-unrelated" > WIP.txt ) \
+  && echo "dirty-unrelated" >WIP.txt) \
   >/dev/null 2>&1
 USER_HEAD_BEFORE="$(git -C "$PROJECT_R5_EXISTING" rev-parse HEAD 2>/dev/null || echo missing)"
 USER_SUBJECT_BEFORE="$(git -C "$PROJECT_R5_EXISTING" log -1 --pretty=%s HEAD 2>/dev/null || echo missing)"
@@ -1949,19 +1953,23 @@ USER_SUBJECT_BEFORE="$(git -C "$PROJECT_R5_EXISTING" log -1 --pretty=%s HEAD 2>/
 PATH="$R5_STUBDIR:$PATH" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" \
   "$PROJECT_R5_EXISTING" --no-register --with-cortex --with-sentinel \
   </dev/null >"$TEST_DIR/r5-existing-bootstrap.txt" 2>&1 \
-  || { echo "FAIL: bootstrap into existing git repo exited non-zero"; cat "$TEST_DIR/r5-existing-bootstrap.txt"; ERRORS=$((ERRORS+1)); }
+  || {
+    echo "FAIL: bootstrap into existing git repo exited non-zero"
+    cat "$TEST_DIR/r5-existing-bootstrap.txt"
+    ERRORS=$((ERRORS + 1))
+  }
 
 # The user's commit SHA must still be reachable (not rewritten).
 if ! git -C "$PROJECT_R5_EXISTING" cat-file -e "$USER_HEAD_BEFORE" 2>/dev/null; then
   echo "FAIL: touchstone scaffold rewrote user's pre-existing commit $USER_HEAD_BEFORE" >&2
-  ERRORS=$((ERRORS+1))
+  ERRORS=$((ERRORS + 1))
 fi
 
 # The user's commit must still be the first commit on the branch.
 first_subject="$(git -C "$PROJECT_R5_EXISTING" log --reverse --pretty=%s 2>/dev/null | head -1)"
 if [ "$first_subject" != "$USER_SUBJECT_BEFORE" ]; then
   echo "FAIL: first commit subject changed from '$USER_SUBJECT_BEFORE' to '$first_subject'" >&2
-  ERRORS=$((ERRORS+1))
+  ERRORS=$((ERRORS + 1))
 fi
 
 # No "chore: initial touchstone scaffold" commit should exist — that message
@@ -1970,7 +1978,7 @@ fi
 if git -C "$PROJECT_R5_EXISTING" log --pretty=%s 2>/dev/null | grep -qxF 'chore: initial touchstone scaffold'; then
   echo "FAIL: touchstone created an initial-scaffold commit on a pre-existing repo" >&2
   git -C "$PROJECT_R5_EXISTING" log --oneline >&2 || true
-  ERRORS=$((ERRORS+1))
+  ERRORS=$((ERRORS + 1))
 fi
 
 # The user's pre-existing WIP file must still be untracked-and-unstaged —
@@ -1979,10 +1987,10 @@ fi
 # contract. What touchstone itself must not do is sweep the user's tree.)
 wip_status="$(git -C "$PROJECT_R5_EXISTING" status --porcelain WIP.txt 2>/dev/null || true)"
 case "$wip_status" in
-  '?? WIP.txt') : ;;                         # correct — still untracked
+  '?? WIP.txt') : ;; # correct — still untracked
   *)
     echo "FAIL: touchstone staged/committed user's WIP.txt (status: '$wip_status')" >&2
-    ERRORS=$((ERRORS+1))
+    ERRORS=$((ERRORS + 1))
     ;;
 esac
 
@@ -1991,7 +1999,7 @@ esac
 if [ -f "$PROJECT_R5/.gitignore" ]; then
   if grep -qxF '.sentinel/' "$PROJECT_R5/.gitignore"; then
     echo "FAIL: root .gitignore contains '.sentinel/' — R5.2 regression" >&2
-    ERRORS=$((ERRORS+1))
+    ERRORS=$((ERRORS + 1))
   fi
   assert_contains "$PROJECT_R5/.gitignore" '^\.claude/$'
 fi

--- a/tests/test-claude-md-principles-ref.sh
+++ b/tests/test-claude-md-principles-ref.sh
@@ -27,7 +27,10 @@ trap 'rm -rf "$TEST_DIR"' EXIT
 source "$TOUCHSTONE_ROOT/lib/claude-md-principles-ref.sh"
 
 ERRORS=0
-fail() { echo "FAIL: $*" >&2; ERRORS=$((ERRORS + 1)); }
+fail() {
+  echo "FAIL: $*" >&2
+  ERRORS=$((ERRORS + 1))
+}
 assert_contains() {
   local file="$1" needle="$2"
   if ! grep -qF "$needle" "$file"; then
@@ -48,7 +51,7 @@ assert_eq() {
 # --- 1. Detection (complete/partial/absent) ---------------------------------
 echo "==> 1. has_principles_ref detection"
 mkdir -p "$TEST_DIR/case-detect"
-cat > "$TEST_DIR/case-detect/CLAUDE.md" <<'EOF'
+cat >"$TEST_DIR/case-detect/CLAUDE.md" <<'EOF'
 # Project
 
 @principles/git-workflow.md
@@ -59,7 +62,7 @@ fi
 if ! claude_md_has_any_principles_ref "$TEST_DIR/case-detect/CLAUDE.md"; then
   fail "should detect any @principles/ import when present"
 fi
-cat > "$TEST_DIR/case-detect/CLAUDE.md" <<'EOF'
+cat >"$TEST_DIR/case-detect/CLAUDE.md" <<'EOF'
 # Project
 
 @principles/pre-implementation-checklist.md
@@ -69,7 +72,7 @@ EOF
 if ! claude_md_has_principles_ref "$TEST_DIR/case-detect/CLAUDE.md"; then
   fail "should detect full required @principles/ import set"
 fi
-cat > "$TEST_DIR/case-detect/CLAUDE.md" <<'EOF'
+cat >"$TEST_DIR/case-detect/CLAUDE.md" <<'EOF'
 # Project
 
 No imports here, just plain text.
@@ -84,7 +87,7 @@ fi
 # --- 2. Inject when imports missing -----------------------------------------
 echo "==> 2. inject after H1 when imports missing"
 mkdir -p "$TEST_DIR/case-inject"
-cat > "$TEST_DIR/case-inject/CLAUDE.md" <<'EOF'
+cat >"$TEST_DIR/case-inject/CLAUDE.md" <<'EOF'
 # My Project
 
 Some intro text.
@@ -120,7 +123,7 @@ assert_eq "second-inject sha (untouched)" "$sha_before" "$sha_after"
 # --- 4. Inject completes partial legacy imports -----------------------------
 echo "==> 4. inject completes partial legacy imports"
 mkdir -p "$TEST_DIR/case-partial"
-cat > "$TEST_DIR/case-partial/CLAUDE.md" <<'EOF'
+cat >"$TEST_DIR/case-partial/CLAUDE.md" <<'EOF'
 # My Project
 
 Some intro text.
@@ -168,7 +171,7 @@ setup_existing_repo() {
   local dir="$1" with_imports="${2:-no}"
   mkdir -p "$dir"
   if [ "$with_imports" = yes ]; then
-    cat > "$dir/CLAUDE.md" <<'EOF'
+    cat >"$dir/CLAUDE.md" <<'EOF'
 # My Project
 
 @principles/pre-implementation-checklist.md
@@ -176,13 +179,13 @@ setup_existing_repo() {
 @principles/git-workflow.md
 EOF
   elif [ "$with_imports" = partial ]; then
-    cat > "$dir/CLAUDE.md" <<'EOF'
+    cat >"$dir/CLAUDE.md" <<'EOF'
 # My Project
 
 @principles/git-workflow.md
 EOF
   else
-    cat > "$dir/CLAUDE.md" <<'EOF'
+    cat >"$dir/CLAUDE.md" <<'EOF'
 # My Project
 
 Some intro text. No imports.
@@ -223,7 +226,7 @@ echo "==> 9. prior skipped decision is respected"
 E7="$TEST_DIR/e2e-respect"
 setup_existing_repo "$E7" no
 # Pre-record a "skipped" decision before the helper runs.
-printf 'claude_principles_ref=skipped\n' > "$E7/.touchstone-config"
+printf 'claude_principles_ref=skipped\n' >"$E7/.touchstone-config"
 # Caller passes mode=yes, but the prior `skipped` decision wins — the user
 # already opted out and the helper must not re-prompt or silently flip the
 # answer.
@@ -235,7 +238,7 @@ assert_contains "$E7/.touchstone-config" "claude_principles_ref=skipped"
 echo "==> 10. prior connected partial imports are completed"
 E10="$TEST_DIR/e2e-prior-connected-partial"
 setup_existing_repo "$E10" partial
-printf 'claude_principles_ref=connected\n' > "$E10/.touchstone-config"
+printf 'claude_principles_ref=connected\n' >"$E10/.touchstone-config"
 ensure_claude_principles_ref "$E10" prompt >/dev/null
 assert_contains "$E10/CLAUDE.md" "@principles/pre-implementation-checklist.md"
 assert_contains "$E10/CLAUDE.md" "@principles/documentation-ownership.md"

--- a/tests/test-claude-probe-helper.sh
+++ b/tests/test-claude-probe-helper.sh
@@ -24,7 +24,7 @@ assert_contains_text() {
 
 FAKE_BIN="$TEST_DIR/fake-bin"
 mkdir -p "$FAKE_BIN"
-cat > "$FAKE_BIN/claude" <<'FAKECLAUDE'
+cat >"$FAKE_BIN/claude" <<'FAKECLAUDE'
 #!/usr/bin/env bash
 printf 'fast response for: %s\n' "$*"
 FAKECLAUDE

--- a/tests/test-cleanup-branches-squash-map.sh
+++ b/tests/test-cleanup-branches-squash-map.sh
@@ -32,7 +32,7 @@ echo "==> Test: cleanup-branches.sh consults squash-map for squash-merged-then-m
 FAKE_BIN="$TEST_DIR/bin"
 mkdir -p "$FAKE_BIN"
 
-cat > "$FAKE_BIN/gh" <<'EOF'
+cat >"$FAKE_BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 case "$*" in
   "repo view --json defaultBranchRef --jq .defaultBranchRef.name")
@@ -56,7 +56,7 @@ git config user.email "test@example.com"
 git config user.name "Test"
 git remote add origin "$REMOTE"
 
-echo "A" > shared.txt
+echo "A" >shared.txt
 git add shared.txt
 git commit -qm "initial"
 git push -q -u origin main
@@ -67,7 +67,7 @@ git push -q -u origin main
 # false. Without the squash-map record, this branch would land in the
 # "needs human decision" bucket and stay there forever — the issue.
 git checkout -q -b feat/squash-then-moved-past
-echo "BRANCH_CONTENT" > shared.txt
+echo "BRANCH_CONTENT" >shared.txt
 git add shared.txt
 git commit -qm "feat: change shared.txt"
 RECORDED_OID="$(git rev-parse HEAD)"
@@ -78,7 +78,7 @@ git commit -qm "feat: change shared.txt (#100)"
 
 # Main moves on — another commit edits the same file. This is what breaks
 # the tree-equivalence check on feat/squash-then-moved-past.
-echo "EVOLVED_PAST_BRANCH" > shared.txt
+echo "EVOLVED_PAST_BRANCH" >shared.txt
 git add shared.txt
 git commit -qm "chore: further edits"
 
@@ -87,7 +87,7 @@ git commit -qm "chore: further edits"
 # equality check must reject the map record and let is_fully_applied take
 # over (which will correctly classify this branch as not-yet-applied).
 git checkout -q -b feat/squash-then-new-commits-locally
-echo "INITIAL_WORK" > new_file.txt
+echo "INITIAL_WORK" >new_file.txt
 git add new_file.txt
 git commit -qm "feat: initial work"
 STALE_RECORDED_OID="$(git rev-parse HEAD)"
@@ -97,12 +97,12 @@ git merge --squash feat/squash-then-new-commits-locally >/dev/null
 git commit -qm "feat: initial work (#101)"
 
 # Main moves on, breaking tree equivalence for this branch too.
-echo "DRIFT" > new_file.txt
+echo "DRIFT" >new_file.txt
 git add new_file.txt
 git commit -qm "chore: drift"
 
 git checkout -q feat/squash-then-new-commits-locally
-echo "POST_MERGE_LOCAL_WORK" > local_only.txt
+echo "POST_MERGE_LOCAL_WORK" >local_only.txt
 git add local_only.txt
 git commit -qm "feat: post-merge local work (not yet on main)"
 
@@ -112,7 +112,7 @@ git push -q origin main
 # — must survive both classifiers and land in "Has unique commits".
 git checkout -q main
 git checkout -q -b feat/keep-me-unrelated
-echo "UNIQUE" > unique.txt
+echo "UNIQUE" >unique.txt
 git add unique.txt
 git commit -qm "feat: unique work no record"
 
@@ -123,7 +123,7 @@ git checkout -q main
 # does at runtime.
 MAP_PATH="$(git rev-parse --git-path touchstone/squash-map.jsonl)"
 mkdir -p "$(dirname "$MAP_PATH")"
-cat > "$MAP_PATH" <<EOF
+cat >"$MAP_PATH" <<EOF
 {"branch":"feat/squash-then-moved-past","pr":"100","branch_oid":"$RECORDED_OID","squash_commit":"deadbeef","ts":"2026-05-06T00:00:00Z"}
 {"branch":"feat/squash-then-new-commits-locally","pr":"101","branch_oid":"$STALE_RECORDED_OID","squash_commit":"deadbee2","ts":"2026-05-06T00:01:00Z"}
 EOF
@@ -171,7 +171,7 @@ fi
 echo "==> Sub-test: missing squash-map is fail-soft"
 rm -f "$MAP_PATH"
 git checkout -q -b feat/no-map-still-classified
-echo "X" > x.txt
+echo "X" >x.txt
 git add x.txt
 git commit -qm "feat: x"
 git checkout -q main
@@ -181,7 +181,11 @@ git push -q origin main
 
 OUT2="$TEST_DIR/output-no-map.txt"
 PATH="$FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/scripts/cleanup-branches.sh" --execute >"$OUT2" 2>&1 \
-  || { echo "FAIL: cleanup must not fail when squash-map is missing"; cat "$OUT2" >&2; exit 1; }
+  || {
+    echo "FAIL: cleanup must not fail when squash-map is missing"
+    cat "$OUT2" >&2
+    exit 1
+  }
 # This branch should still be classified by the existing tree-equivalence
 # fallback (tree on main matches branch's changed files since main hasn't
 # moved past it on this file).
@@ -191,16 +195,20 @@ fi
 
 echo "==> Sub-test: corrupt squash-map is fail-soft (no records)"
 mkdir -p "$(dirname "$MAP_PATH")"
-printf '{not valid json at all\nsecond garbage line\n' > "$MAP_PATH"
+printf '{not valid json at all\nsecond garbage line\n' >"$MAP_PATH"
 git checkout -q main
 git checkout -q -b feat/corrupt-map-leaves-unique
-echo "Y" > y_unique.txt
+echo "Y" >y_unique.txt
 git add y_unique.txt
 git commit -qm "feat: y (still has unique work)"
 OUT3="$TEST_DIR/output-corrupt-map.txt"
 git checkout -q main
 PATH="$FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/scripts/cleanup-branches.sh" --execute >"$OUT3" 2>&1 \
-  || { echo "FAIL: cleanup must not fail on corrupt squash-map"; cat "$OUT3" >&2; exit 1; }
+  || {
+    echo "FAIL: cleanup must not fail on corrupt squash-map"
+    cat "$OUT3" >&2
+    exit 1
+  }
 if ! git rev-parse --verify --quiet refs/heads/feat/corrupt-map-leaves-unique >/dev/null; then
   fail "feat/corrupt-map-leaves-unique should NOT be deleted; corrupt map must yield no records"
 fi

--- a/tests/test-cleanup-branches.sh
+++ b/tests/test-cleanup-branches.sh
@@ -32,7 +32,7 @@ echo "==> Test: cleanup-branches.sh detects tree-equivalent branches"
 FAKE_BIN="$TEST_DIR/bin"
 mkdir -p "$FAKE_BIN"
 
-cat > "$FAKE_BIN/gh" <<'EOF'
+cat >"$FAKE_BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 case "$*" in
   "repo view --json defaultBranchRef --jq .defaultBranchRef.name")
@@ -56,14 +56,14 @@ git config user.email "test@example.com"
 git config user.name "Test"
 git remote add origin "$REMOTE"
 
-echo "A" > a.txt
+echo "A" >a.txt
 git add a.txt
 git commit -qm "initial"
 git push -q -u origin main
 
 # --- (1) Single-commit squash-merged branch.
 git checkout -q -b feat/single-squash
-echo "S" > s.txt
+echo "S" >s.txt
 git add s.txt
 git commit -qm "feat: single"
 git checkout -q main
@@ -72,17 +72,17 @@ git commit -qm "feat: single (#1)"
 
 # --- (2) Multi-commit squash-merged branch (the case the earlier tool missed).
 git checkout -q -b feat/multi-squash
-echo "M1" > m1.txt && git add m1.txt && git commit -qm "feat: M1"
-echo "M2" > m2.txt && git add m2.txt && git commit -qm "feat: M2"
-echo "M3" > m3.txt && git add m3.txt && git commit -qm "feat: M3"
+echo "M1" >m1.txt && git add m1.txt && git commit -qm "feat: M1"
+echo "M2" >m2.txt && git add m2.txt && git commit -qm "feat: M2"
+echo "M3" >m3.txt && git add m3.txt && git commit -qm "feat: M3"
 git checkout -q main
 git merge --squash feat/multi-squash >/dev/null
 git commit -qm "feat: multi (#2)"
 
 # --- (3) Rebase-merged branch (per-commit patch-id matches on upstream).
 git checkout -q -b feat/rebase-merged
-echo "R1" > r1.txt && git add r1.txt && git commit -qm "feat: R1"
-echo "R2" > r2.txt && git add r2.txt && git commit -qm "feat: R2"
+echo "R1" >r1.txt && git add r1.txt && git commit -qm "feat: R1"
+echo "R2" >r2.txt && git add r2.txt && git commit -qm "feat: R2"
 REBASE_FIRST="$(git rev-parse HEAD~1)"
 REBASE_SECOND="$(git rev-parse HEAD)"
 
@@ -92,14 +92,14 @@ REBASE_SECOND="$(git rev-parse HEAD)"
 # which makes the branch ancestor-reachable and bypasses the patch-id path
 # we actually want to exercise.
 git checkout -q main
-echo "U" > u_unrelated.txt && git add u_unrelated.txt && git commit -qm "chore: unrelated"
+echo "U" >u_unrelated.txt && git add u_unrelated.txt && git commit -qm "chore: unrelated"
 git cherry-pick "$REBASE_FIRST" "$REBASE_SECOND" >/dev/null
 
 git push -q origin main
 
 # --- (4) Control: branch with truly unique work that must be preserved.
 git checkout -q -b feat/keep-me
-echo "U" > u.txt
+echo "U" >u.txt
 git add u.txt
 git commit -qm "feat: unique work"
 
@@ -107,7 +107,7 @@ git commit -qm "feat: unique work"
 # current upstream tree no longer has the branch's changes. Must survive.
 git checkout -q main
 git checkout -q -b feat/added-then-reverted
-echo "DEL" > to_be_reverted.txt
+echo "DEL" >to_be_reverted.txt
 git add to_be_reverted.txt
 git commit -qm "feat: add DEL"
 git checkout -q main
@@ -118,7 +118,7 @@ git revert --no-edit HEAD >/dev/null
 # --- (6) Rename-half: branch renames source→dest; main adds dest
 # independently but does not delete source. The branch's deletion of
 # source is not on main — must survive.
-echo "O" > source_to_rename.txt
+echo "O" >source_to_rename.txt
 git add source_to_rename.txt
 git commit -qm "chore: seed source file for rename test"
 
@@ -127,7 +127,7 @@ git mv source_to_rename.txt dest_after_rename.txt
 git commit -qm "feat: rename source to dest"
 
 git checkout -q main
-echo "O" > dest_after_rename.txt
+echo "O" >dest_after_rename.txt
 git add dest_after_rename.txt
 git commit -qm "chore: add dest (source left in place)"
 git push -q origin main
@@ -187,7 +187,7 @@ done
 # cleanup rather than treat the error as "no open PRs" and delete branches.
 FAIL_BIN="$TEST_DIR/fail-bin"
 mkdir -p "$FAIL_BIN"
-cat > "$FAIL_BIN/gh" <<'EOF'
+cat >"$FAIL_BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 case "$*" in
   "repo view --json defaultBranchRef --jq .defaultBranchRef.name")

--- a/tests/test-cleanup-worktrees-self-pid.sh
+++ b/tests/test-cleanup-worktrees-self-pid.sh
@@ -38,14 +38,14 @@ git -C "$REPO" config user.email "test@example.com"
 git -C "$REPO" config user.name "Test"
 git -C "$REPO" remote add origin "$REMOTE"
 
-echo "base" > "$REPO/base.txt"
+echo "base" >"$REPO/base.txt"
 git -C "$REPO" add base.txt
 git -C "$REPO" commit -qm "initial"
 git -C "$REPO" push -q -u origin main
 git -C "$REPO" remote set-head origin main
 
 git -C "$REPO" worktree add -q "$SELF_PID_WT" -b feat/self-pid main
-echo "self pid" > "$SELF_PID_WT/self-pid.txt"
+echo "self pid" >"$SELF_PID_WT/self-pid.txt"
 git -C "$SELF_PID_WT" add self-pid.txt
 git -C "$SELF_PID_WT" commit -qm "feat: self pid"
 git -C "$REPO" checkout -q main

--- a/tests/test-cleanup-worktrees.sh
+++ b/tests/test-cleanup-worktrees.sh
@@ -64,21 +64,21 @@ git -C "$REPO" config user.email "test@example.com"
 git -C "$REPO" config user.name "Test"
 git -C "$REPO" remote add origin "$REMOTE"
 
-echo "base" > "$REPO/base.txt"
+echo "base" >"$REPO/base.txt"
 git -C "$REPO" add base.txt
 git -C "$REPO" commit -qm "initial"
 git -C "$REPO" push -q -u origin main
 git -C "$REPO" remote set-head origin main
 
 git -C "$REPO" worktree add -q "$MERGED_WT" -b feat/merged main
-echo "merged" > "$MERGED_WT/merged.txt"
+echo "merged" >"$MERGED_WT/merged.txt"
 git -C "$MERGED_WT" add merged.txt
 git -C "$MERGED_WT" commit -qm "feat: merged"
 git -C "$REPO" checkout -q main
 git -C "$REPO" merge --no-ff -q feat/merged -m "merge feat/merged"
 
 git -C "$REPO" worktree add -q "$SQUASH_WT" -b feat/squash main
-echo "squash" > "$SQUASH_WT/squash.txt"
+echo "squash" >"$SQUASH_WT/squash.txt"
 git -C "$SQUASH_WT" add squash.txt
 git -C "$SQUASH_WT" commit -qm "feat: squash"
 git -C "$REPO" checkout -q main
@@ -86,20 +86,20 @@ git -C "$REPO" merge --squash feat/squash >/dev/null
 git -C "$REPO" commit -qm "feat: squash (#1)"
 
 git -C "$REPO" worktree add -q "$UNIQUE_WT" -b feat/unique main
-echo "unique" > "$UNIQUE_WT/unique.txt"
+echo "unique" >"$UNIQUE_WT/unique.txt"
 git -C "$UNIQUE_WT" add unique.txt
 git -C "$UNIQUE_WT" commit -qm "feat: unique"
 
 git -C "$REPO" worktree add -q "$DIRTY_WT" -b feat/dirty main
-echo "dirty" > "$DIRTY_WT/dirty.txt"
+echo "dirty" >"$DIRTY_WT/dirty.txt"
 git -C "$DIRTY_WT" add dirty.txt
 git -C "$DIRTY_WT" commit -qm "feat: dirty"
 git -C "$REPO" checkout -q main
 git -C "$REPO" merge --no-ff -q feat/dirty -m "merge feat/dirty"
-echo "uncommitted" >> "$DIRTY_WT/dirty.txt"
+echo "uncommitted" >>"$DIRTY_WT/dirty.txt"
 
 git -C "$REPO" worktree add -q "$LOCKED_STALE_WT" -b feat/locked-stale main
-echo "locked stale" > "$LOCKED_STALE_WT/locked-stale.txt"
+echo "locked stale" >"$LOCKED_STALE_WT/locked-stale.txt"
 git -C "$LOCKED_STALE_WT" add locked-stale.txt
 git -C "$LOCKED_STALE_WT" commit -qm "feat: locked stale"
 git -C "$REPO" checkout -q main
@@ -108,7 +108,7 @@ DEAD_PID="$(dead_pid)"
 git -C "$REPO" worktree lock --reason "agent pid $DEAD_PID" "$LOCKED_STALE_WT"
 
 git -C "$REPO" worktree add -q "$LOCKED_ALIVE_WT" -b feat/locked-alive main
-echo "locked alive" > "$LOCKED_ALIVE_WT/locked-alive.txt"
+echo "locked alive" >"$LOCKED_ALIVE_WT/locked-alive.txt"
 git -C "$LOCKED_ALIVE_WT" add locked-alive.txt
 git -C "$LOCKED_ALIVE_WT" commit -qm "feat: locked alive"
 git -C "$REPO" checkout -q main
@@ -118,7 +118,7 @@ LOCKED_ALIVE_PID="$!"
 git -C "$REPO" worktree lock --reason "agent pid $LOCKED_ALIVE_PID" "$LOCKED_ALIVE_WT"
 
 git -C "$REPO" worktree add -q "$LOCKED_NOPID_WT" -b feat/locked-nopid main
-echo "locked no pid" > "$LOCKED_NOPID_WT/locked-nopid.txt"
+echo "locked no pid" >"$LOCKED_NOPID_WT/locked-nopid.txt"
 git -C "$LOCKED_NOPID_WT" add locked-nopid.txt
 git -C "$REPO" checkout -q main
 git -C "$LOCKED_NOPID_WT" commit -qm "feat: locked no pid"
@@ -126,7 +126,7 @@ git -C "$REPO" merge --no-ff -q feat/locked-nopid -m "merge feat/locked-nopid"
 git -C "$REPO" worktree lock --reason "manual inspection" "$LOCKED_NOPID_WT"
 
 git -C "$REPO" worktree add -q -b feat/detached-source "$TEST_DIR/demo-detached-source" main
-echo "detached-unique" > "$TEST_DIR/demo-detached-source/detached.txt"
+echo "detached-unique" >"$TEST_DIR/demo-detached-source/detached.txt"
 git -C "$TEST_DIR/demo-detached-source" add detached.txt
 git -C "$TEST_DIR/demo-detached-source" commit -qm "feat: detached unique work"
 DETACHED_SHA="$(git -C "$TEST_DIR/demo-detached-source" rev-parse HEAD)"

--- a/tests/test-codex-review-sentinel.sh
+++ b/tests/test-codex-review-sentinel.sh
@@ -130,20 +130,20 @@ mkdir -p "$REPO_DIR" "$FAKE_BIN"
 git -C "$REPO_DIR" init >/dev/null 2>&1
 git -C "$REPO_DIR" config user.name "Touchstone Test"
 git -C "$REPO_DIR" config user.email "touchstone@example.com"
-printf 'base\n' > "$REPO_DIR/example.txt"
+printf 'base\n' >"$REPO_DIR/example.txt"
 git -C "$REPO_DIR" add example.txt
 git -C "$REPO_DIR" commit -m "base" >/dev/null 2>&1
-printf 'changed\n' >> "$REPO_DIR/example.txt"
+printf 'changed\n' >>"$REPO_DIR/example.txt"
 git -C "$REPO_DIR" add example.txt
 git -C "$REPO_DIR" commit -m "change" >/dev/null 2>&1
 
-cat > "$FAKE_BIN/gh" <<'EOF'
+cat >"$FAKE_BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 echo "main"
 EOF
 
-cat > "$FAKE_BIN/conductor" <<'EOF'
+cat >"$FAKE_BIN/conductor" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 if [ "${1:-}" = "doctor" ]; then
@@ -166,7 +166,7 @@ set +e
     CODEX_REVIEW_BASE="HEAD~1" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
     CODEX_REVIEW_ON_ERROR=fail-closed \
-    bash "$SCRIPT" > "$CLOSED_OUTPUT" 2>&1
+    bash "$SCRIPT" >"$CLOSED_OUTPUT" 2>&1
 )
 CLOSED_EXIT=$?
 set -e
@@ -192,7 +192,7 @@ set +e
     CODEX_REVIEW_BASE="HEAD~1" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
     CODEX_REVIEW_ON_ERROR=fail-open \
-    bash "$SCRIPT" > "$OPEN_OUTPUT" 2>&1
+    bash "$SCRIPT" >"$OPEN_OUTPUT" 2>&1
 )
 OPEN_EXIT=$?
 set -e

--- a/tests/test-cortex-pr-merged-hook.sh
+++ b/tests/test-cortex-pr-merged-hook.sh
@@ -46,7 +46,7 @@ mk_fixture() {
     git init -q -b main
     git config user.email t@e.co
     git config user.name Test
-    : > .keep
+    : >.keep
     git add .keep
     git commit -q -m "init"
   )
@@ -66,7 +66,7 @@ fi
 # Scenario B: .cortex/ present + config explicitly `off` → silent skip.
 B="$(mk_fixture B)"
 mkdir -p "$B/.cortex"
-echo "cortex_pr_merged_hook=off" > "$B/.touchstone-config"
+echo "cortex_pr_merged_hook=off" >"$B/.touchstone-config"
 B_HEAD_BEFORE="$(git -C "$B" rev-parse HEAD)"
 (cd "$B" && TOUCHSTONE_DEFAULT_BRANCH=main bash "$HOOK")
 B_HEAD_AFTER="$(git -C "$B" rev-parse HEAD)"
@@ -84,7 +84,7 @@ C_HEAD_BEFORE="$(git -C "$C" rev-parse HEAD)"
 (
   cd "$C"
   PATH="/usr/bin:/bin" \
-  TOUCHSTONE_DEFAULT_BRANCH=main \
+    TOUCHSTONE_DEFAULT_BRANCH=main \
     bash "$HOOK"
 )
 C_HEAD_AFTER="$(git -C "$C" rev-parse HEAD)"
@@ -112,12 +112,12 @@ fi
 # without firing the writer.
 E="$(mk_fixture E)"
 mkdir -p "$E/.cortex"
-echo "cortex_pr_merged_hook=on" > "$E/.touchstone-config"
+echo "cortex_pr_merged_hook=on" >"$E/.touchstone-config"
 E_HEAD_BEFORE="$(git -C "$E" rev-parse HEAD)"
 (
   cd "$E"
   TOUCHSTONE_DEFAULT_BRANCH=main \
-  TOUCHSTONE_CORTEX_HOOK_DISABLE=1 \
+    TOUCHSTONE_CORTEX_HOOK_DISABLE=1 \
     bash "$HOOK"
 )
 E_HEAD_AFTER="$(git -C "$E" rev-parse HEAD)"
@@ -131,10 +131,10 @@ fi
 # capturing stderr, but we can confirm exit 0 + no commit.
 F="$(mk_fixture F)"
 mkdir -p "$F/.cortex"
-echo "cortex_pr_merged_hook=maybe" > "$F/.touchstone-config"
+echo "cortex_pr_merged_hook=maybe" >"$F/.touchstone-config"
 F_HEAD_BEFORE="$(git -C "$F" rev-parse HEAD)"
 F_STDERR="$TMPROOT/F-stderr"
-(cd "$F" && TOUCHSTONE_DEFAULT_BRANCH=main bash "$HOOK") 2> "$F_STDERR"
+(cd "$F" && TOUCHSTONE_DEFAULT_BRANCH=main bash "$HOOK") 2>"$F_STDERR"
 F_HEAD_AFTER="$(git -C "$F" rev-parse HEAD)"
 if [ "$F_HEAD_BEFORE" != "$F_HEAD_AFTER" ]; then
   echo "FAIL [F]: hook fired on unknown config value 'maybe'" >&2
@@ -166,7 +166,7 @@ fi
 # version or writing real journal entries.
 FAKEBIN="$TMPROOT/fakebin"
 mkdir -p "$FAKEBIN"
-cat > "$FAKEBIN/cortex" <<'EOF'
+cat >"$FAKEBIN/cortex" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -207,14 +207,14 @@ chmod +x "$FAKEBIN/cortex"
 # and includes both files in the same local hook commit.
 H="$(mk_fixture H)"
 mkdir -p "$H/.cortex"
-printf 'stale state\n' > "$H/.cortex/state.md"
+printf 'stale state\n' >"$H/.cortex/state.md"
 (cd "$H" && git add .cortex/state.md && git commit -q -m "add cortex state")
 (
   cd "$H"
   PATH="$FAKEBIN:$PATH" \
-  TOUCHSTONE_DEFAULT_BRANCH=main \
-  TOUCHSTONE_CORTEX_HOOK_SKIP_PUSH=1 \
-  TOUCHSTONE_MERGED_PR=131 \
+    TOUCHSTONE_DEFAULT_BRANCH=main \
+    TOUCHSTONE_CORTEX_HOOK_SKIP_PUSH=1 \
+    TOUCHSTONE_MERGED_PR=131 \
     bash "$HOOK"
 )
 H_CHANGED="$(git -C "$H" show --name-only --format= HEAD)"
@@ -244,17 +244,17 @@ fi
 # the journal entry, and emits an actionable recovery command.
 I="$(mk_fixture I)"
 mkdir -p "$I/.cortex"
-printf 'stale state\n' > "$I/.cortex/state.md"
+printf 'stale state\n' >"$I/.cortex/state.md"
 (cd "$I" && git add .cortex/state.md && git commit -q -m "add cortex state")
 I_STDERR="$TMPROOT/I-stderr"
 (
   cd "$I"
   PATH="$FAKEBIN:$PATH" \
-  FAKE_CORTEX_REFRESH_FAIL=1 \
-  TOUCHSTONE_DEFAULT_BRANCH=main \
-  TOUCHSTONE_CORTEX_HOOK_SKIP_PUSH=1 \
+    FAKE_CORTEX_REFRESH_FAIL=1 \
+    TOUCHSTONE_DEFAULT_BRANCH=main \
+    TOUCHSTONE_CORTEX_HOOK_SKIP_PUSH=1 \
     bash "$HOOK"
-) 2> "$I_STDERR"
+) 2>"$I_STDERR"
 I_CHANGED="$(git -C "$I" show --name-only --format= HEAD)"
 if ! printf '%s\n' "$I_CHANGED" | grep -qx '.cortex/journal/pr-merged.md'; then
   echo "FAIL [I]: hook did not commit journal entry when refresh-state failed cleanly" >&2

--- a/tests/test-empty-array-guard.sh
+++ b/tests/test-empty-array-guard.sh
@@ -36,7 +36,7 @@ check_file() {
     name="$(printf '%s' "$line" | sed 's/^[[:space:]]*//' | sed 's/^local[[:space:]][[:space:]]*//' | sed 's/=().*//')"
     # Ignore if name contains spaces or special chars (not a variable name).
     case "$name" in
-      *[[:space:]]*|*[!a-zA-Z0-9_]*) continue ;;
+      *[[:space:]]* | *[!a-zA-Z0-9_]*) continue ;;
     esac
     declared_arrays+=("$name")
   done < <(grep -E '^\s*(local\s+)?[a-zA-Z_][a-zA-Z0-9_]*=\(\)' "$file" 2>/dev/null || true)
@@ -50,13 +50,13 @@ check_file() {
   for name in ${declared_arrays[@]+"${declared_arrays[@]}"}; do
     # Look for "${name[@]}" — unguarded expansion (fixed-string search avoids
     # bracket-class ambiguity in ERE when name contains no special chars).
-    if grep -Fn '"${'"$name"'[@]}"' "$file" 2>/dev/null | \
-         grep -v 'empty-array-guard: safe' >/dev/null 2>&1; then
+    if grep -Fn '"${'"$name"'[@]}"' "$file" 2>/dev/null \
+      | grep -v 'empty-array-guard: safe' >/dev/null 2>&1; then
       # Treat the expansion as guarded if the file uses any of:
       #   ${name[@]+"${name[@]}"}  — the direct bash 3.2 idiom
       #   ${#name[@]}              — a length check guards the expansion site
-      if ! grep -qF '${'"$name"'[@]+' "$file" 2>/dev/null && \
-         ! grep -qF '${#'"$name"'[@]}' "$file" 2>/dev/null; then
+      if ! grep -qF '${'"$name"'[@]+' "$file" 2>/dev/null \
+        && ! grep -qF '${#'"$name"'[@]}' "$file" 2>/dev/null; then
         echo "  WARN: $file: '${name}' declared =() but expanded as \"\${${name}[@]}\" without guard" >&2
         echo "        Use: \${${name}[@]+\"\${${name}[@]}\"}" >&2
         grep -Fn '"${'"$name"'[@]}"' "$file" 2>/dev/null | head -5 >&2 || true

--- a/tests/test-events-json.sh
+++ b/tests/test-events-json.sh
@@ -69,7 +69,7 @@ setup_git_repo() {
   git -C "$repo" init -b main >/dev/null 2>&1
   git -C "$repo" config user.name "Touchstone Test"
   git -C "$repo" config user.email "touchstone@example.com"
-  printf 'base\n' > "$repo/file.txt"
+  printf 'base\n' >"$repo/file.txt"
   git -C "$repo" add file.txt
   git -C "$repo" commit -m "base commit" >/dev/null 2>&1
 }
@@ -95,7 +95,7 @@ assert_contains "$SPAWN_EVENTS" "\"repo_root\":\"$SPAWN_REPO_REAL\""
 echo "==> Case b/e: open-pr happy-path events and unset no-op"
 OPEN_FIXTURE="$TEST_DIR/open-fixture"
 copy_event_scripts "$OPEN_FIXTURE"
-cat > "$OPEN_FIXTURE/scripts/merge-pr.sh" <<'EOF'
+cat >"$OPEN_FIXTURE/scripts/merge-pr.sh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -110,14 +110,14 @@ OPEN_REPO="$TEST_DIR/open-repo"
 setup_git_repo "$OPEN_REPO"
 OPEN_REPO_REAL="$(cd "$OPEN_REPO" && pwd -P)"
 git -C "$OPEN_REPO" checkout -b feat/open-events >/dev/null 2>&1
-printf 'change\n' >> "$OPEN_REPO/file.txt"
+printf 'change\n' >>"$OPEN_REPO/file.txt"
 git -C "$OPEN_REPO" add file.txt
 git -C "$OPEN_REPO" commit -m "open events" >/dev/null 2>&1
 
 OPEN_BIN="$TEST_DIR/open-bin"
 mkdir -p "$OPEN_BIN"
 REAL_GIT="$(command -v git)"
-cat > "$OPEN_BIN/git" <<EOF
+cat >"$OPEN_BIN/git" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
 if [ "\${1:-}" = "push" ]; then
@@ -135,7 +135,7 @@ fi
 exec "$REAL_GIT" "\$@"
 EOF
 chmod +x "$OPEN_BIN/git"
-cat > "$OPEN_BIN/gh" <<'EOF'
+cat >"$OPEN_BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 case "${1:-} ${2:-}" in
@@ -179,7 +179,7 @@ assert_not_contains "$TEST_DIR/open-no-events.out" '\[events\]'
 echo "==> Cases c/d: merge-pr review blocked and auto-bypass events"
 MERGE_FIXTURE="$TEST_DIR/merge-fixture"
 copy_event_scripts "$MERGE_FIXTURE"
-cat > "$MERGE_FIXTURE/scripts/codex-review.sh" <<'EOF'
+cat >"$MERGE_FIXTURE/scripts/codex-review.sh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 exit "${CODEX_REVIEW_EXIT:-0}"
@@ -189,7 +189,7 @@ chmod +x "$MERGE_FIXTURE/scripts/codex-review.sh"
 MERGE_BIN="$TEST_DIR/merge-bin"
 GIT_PATH_ROOT="$TEST_DIR/git-path"
 mkdir -p "$MERGE_BIN" "$GIT_PATH_ROOT"
-cat > "$MERGE_BIN/gh" <<'EOF'
+cat >"$MERGE_BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 case "${1:-} ${2:-}" in
@@ -212,7 +212,7 @@ case "${1:-} ${2:-}" in
 esac
 EOF
 chmod +x "$MERGE_BIN/gh"
-cat > "$MERGE_BIN/git" <<'EOF'
+cat >"$MERGE_BIN/git" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 case "$*" in
@@ -239,18 +239,18 @@ chmod +x "$MERGE_BIN/git"
 
 BLOCKED_EVENTS="$TEST_DIR/blocked-events.ndjson"
 GH_CHECKOUT_FILE="$TEST_DIR/gh-checkout-blocked" \
-GH_MERGED_MARKER="$TEST_DIR/gh-merged-blocked" \
-GIT_PATH_ROOT="$GIT_PATH_ROOT" \
-PATH="$MERGE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
-TOUCHSTONE_EVENTS_FILE="$BLOCKED_EVENTS" \
-CODEX_REVIEW_EXIT=1 \
+  GH_MERGED_MARKER="$TEST_DIR/gh-merged-blocked" \
+  GIT_PATH_ROOT="$GIT_PATH_ROOT" \
+  PATH="$MERGE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+  TOUCHSTONE_EVENTS_FILE="$BLOCKED_EVENTS" \
+  CODEX_REVIEW_EXIT=1 \
   bash "$MERGE_FIXTURE/scripts/merge-pr.sh" 123 >"$TEST_DIR/blocked.out" 2>&1 && fail "blocked merge unexpectedly exited 0"
 assert_json_lines "$BLOCKED_EVENTS"
 assert_event_order "$BLOCKED_EVENTS" review_started review_blocked failed
 assert_not_contains "$BLOCKED_EVENTS" '"event":"merged"'
 
 mkdir -p "$GIT_PATH_ROOT/touchstone/reviewer-clean"
-cat > "$GIT_PATH_ROOT/touchstone/reviewer-clean/feature_test.clean" <<'EOF'
+cat >"$GIT_PATH_ROOT/touchstone/reviewer-clean/feature_test.clean" <<'EOF'
 result=CODEX_REVIEW_CLEAN
 branch=feature/test
 head=pr-head-oid
@@ -259,11 +259,11 @@ EOF
 BYPASS_EVENTS="$TEST_DIR/bypass-events.ndjson"
 rm -f "$TEST_DIR/gh-checkout-bypass" "$TEST_DIR/gh-merged-bypass"
 GH_CHECKOUT_FILE="$TEST_DIR/gh-checkout-bypass" \
-GH_MERGED_MARKER="$TEST_DIR/gh-merged-bypass" \
-GIT_PATH_ROOT="$GIT_PATH_ROOT" \
-PATH="$MERGE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
-TOUCHSTONE_EVENTS_FILE="$BYPASS_EVENTS" \
-CODEX_REVIEW_EXIT=1 \
+  GH_MERGED_MARKER="$TEST_DIR/gh-merged-bypass" \
+  GIT_PATH_ROOT="$GIT_PATH_ROOT" \
+  PATH="$MERGE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+  TOUCHSTONE_EVENTS_FILE="$BYPASS_EVENTS" \
+  CODEX_REVIEW_EXIT=1 \
   bash "$MERGE_FIXTURE/scripts/merge-pr.sh" 123 >"$TEST_DIR/bypass.out" 2>&1
 assert_json_lines "$BYPASS_EVENTS"
 assert_event_order "$BYPASS_EVENTS" review_started review_bypass merged

--- a/tests/test-find-python-bin.sh
+++ b/tests/test-find-python-bin.sh
@@ -39,9 +39,9 @@ setup_worktree_fixture() {
   worktree="$root/foo"
 
   mkdir -p "$parent/.git/worktrees/foo" "$parent/.venv/bin" "$worktree"
-  printf '#!/usr/bin/env bash\n' > "$parent/.venv/bin/python"
+  printf '#!/usr/bin/env bash\n' >"$parent/.venv/bin/python"
   chmod +x "$parent/.venv/bin/python"
-  printf 'gitdir: %s\n' "$parent/.git/worktrees/foo" > "$worktree/.git"
+  printf 'gitdir: %s\n' "$parent/.git/worktrees/foo" >"$worktree/.git"
 }
 
 run_touchstone_lookup() {
@@ -95,10 +95,10 @@ assert_eq "pytest helper worktree parent venv" "$expected" "$actual"
 # ---------------------------------------------------------------------------
 echo "==> Case 2: worktree without parent venv errors clearly"
 mkdir -p "$tmp/no-venv/parent/.git/worktrees/foo" "$tmp/no-venv/foo"
-printf 'gitdir: %s\n' "$tmp/no-venv/parent/.git/worktrees/foo" > "$tmp/no-venv/foo/.git"
+printf 'gitdir: %s\n' "$tmp/no-venv/parent/.git/worktrees/foo" >"$tmp/no-venv/foo/.git"
 
 err_file="$tmp/touchstone.err"
-if run_touchstone_lookup "$tmp/no-venv/foo" > "$tmp/touchstone.out" 2> "$err_file"; then
+if run_touchstone_lookup "$tmp/no-venv/foo" >"$tmp/touchstone.out" 2>"$err_file"; then
   fail "touchstone lookup should fail without any project venv"
 fi
 err="$(cat "$err_file")"
@@ -107,7 +107,7 @@ assert_contains "touchstone checkout tried" "$err" "Tried: $tmp/no-venv/foo/.ven
 assert_contains "touchstone parent tried" "$err" "Tried: $tmp/no-venv/parent/.venv/bin/python (worktree parent)"
 
 err_file="$tmp/pytest.err"
-if run_pytest_lookup "$tmp/no-venv/foo" > "$tmp/pytest.out" 2> "$err_file"; then
+if run_pytest_lookup "$tmp/no-venv/foo" >"$tmp/pytest.out" 2>"$err_file"; then
   fail "pytest helper lookup should fail without any project venv"
 fi
 err="$(cat "$err_file")"
@@ -120,7 +120,7 @@ assert_contains "pytest parent tried" "$err" "Tried: $tmp/no-venv/parent/.venv/b
 # ---------------------------------------------------------------------------
 echo "==> Case 3: regular checkout with local .venv"
 mkdir -p "$tmp/local/.venv/bin"
-printf '#!/usr/bin/env bash\n' > "$tmp/local/.venv/bin/python"
+printf '#!/usr/bin/env bash\n' >"$tmp/local/.venv/bin/python"
 chmod +x "$tmp/local/.venv/bin/python"
 # Real .git directory marks this as a non-worktree checkout.
 mkdir -p "$tmp/local/.git"

--- a/tests/test-guidance-hooks.sh
+++ b/tests/test-guidance-hooks.sh
@@ -51,7 +51,7 @@ trap 'rm -rf "$TMPDIR"' EXIT
 git -C "$TMPDIR" init --quiet --initial-branch=main
 git -C "$TMPDIR" config user.email "test@touchstone.test"
 git -C "$TMPDIR" config user.name "Touchstone Test"
-echo "seed" > "$TMPDIR/seed.txt"
+echo "seed" >"$TMPDIR/seed.txt"
 git -C "$TMPDIR" add seed.txt
 git -C "$TMPDIR" commit --quiet -m "seed"
 

--- a/tests/test-merge-pr-dirty-tree-narrow.sh
+++ b/tests/test-merge-pr-dirty-tree-narrow.sh
@@ -19,7 +19,7 @@ MERGE_SCRIPT_DIR="$TEST_DIR/scripts"
 GIT_PATH_ROOT="$TEST_DIR/git-path"
 mkdir -p "$FAKE_BIN" "$MERGE_SCRIPT_DIR" "$GIT_PATH_ROOT"
 cp "$TOUCHSTONE_ROOT/scripts/merge-pr.sh" "$MERGE_SCRIPT_DIR/merge-pr.sh"
-cat > "$MERGE_SCRIPT_DIR/codex-review.sh" <<'EOF'
+cat >"$MERGE_SCRIPT_DIR/codex-review.sh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 {
@@ -34,7 +34,7 @@ chmod +x "$MERGE_SCRIPT_DIR/merge-pr.sh" "$MERGE_SCRIPT_DIR/codex-review.sh"
 
 # Fake `gh` — same shape as tests/test-merge-pr.sh, trimmed to what this test
 # exercises (PR view + merge + comment + checkout).
-cat > "$FAKE_BIN/gh" <<'EOF'
+cat >"$FAKE_BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -91,7 +91,7 @@ EOF
 #   GIT_DIRTY_STATUS  — value returned from `git status --porcelain`
 #   GIT_DIFF_PATHS    — newline-separated paths returned from
 #                       `git diff --name-only origin/main...HEAD`
-cat > "$FAKE_BIN/git" <<'EOF'
+cat >"$FAKE_BIN/git" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -203,7 +203,7 @@ echo "==> Test: dirty file outside PR diff lets review proceed"
 reset_case_files
 GIT_DIRTY_STATUS=" M bootstrap/new-project.sh
 " \
-GIT_DIFF_PATHS="scripts/merge-pr.sh
+  GIT_DIFF_PATHS="scripts/merge-pr.sh
 tests/test-merge-pr.sh" \
   run_merge_pr "$TEST_DIR/output-outside.txt" 123
 if grep -q '==> Working tree has uncommitted changes outside PR #123' "$TEST_DIR/output-outside.txt" \
@@ -226,7 +226,7 @@ echo "==> Test: dirty file inside PR diff still refuses the review"
 reset_case_files
 if GIT_DIRTY_STATUS=" M scripts/merge-pr.sh
 " \
-GIT_DIFF_PATHS="scripts/merge-pr.sh
+  GIT_DIFF_PATHS="scripts/merge-pr.sh
 tests/test-merge-pr.sh" \
   run_merge_pr "$TEST_DIR/output-inside.txt" 123; then
   echo "FAIL: dirty path inside PR diff should refuse the review" >&2
@@ -254,7 +254,7 @@ echo "==> Test: dirty rename outside PR diff is handled and lets review proceed"
 reset_case_files
 GIT_DIRTY_STATUS="R  bootstrap/old-name.sh -> bootstrap/new-name.sh
 " \
-GIT_DIFF_PATHS="scripts/merge-pr.sh" \
+  GIT_DIFF_PATHS="scripts/merge-pr.sh" \
   run_merge_pr "$TEST_DIR/output-rename-outside.txt" 123
 if grep -q '==> Running merge review' "$TEST_DIR/output-rename-outside.txt" \
   && grep -q '==> Done\.' "$TEST_DIR/output-rename-outside.txt" \
@@ -274,7 +274,7 @@ echo "==> Test: dirty rename inside PR diff refuses with post-rename path"
 reset_case_files
 if GIT_DIRTY_STATUS="R  scripts/old-name.sh -> scripts/merge-pr.sh
 " \
-GIT_DIFF_PATHS="scripts/merge-pr.sh" \
+  GIT_DIFF_PATHS="scripts/merge-pr.sh" \
   run_merge_pr "$TEST_DIR/output-rename-inside.txt" 123; then
   echo "FAIL: rename whose target is inside PR diff should refuse" >&2
   cat "$TEST_DIR/output-rename-inside.txt" >&2

--- a/tests/test-merge-pr-merge-state-retry.sh
+++ b/tests/test-merge-pr-merge-state-retry.sh
@@ -14,7 +14,7 @@ MERGE_SCRIPT_DIR="$TEST_DIR/scripts"
 GIT_PATH_ROOT="$TEST_DIR/git-path"
 mkdir -p "$FAKE_BIN" "$MERGE_SCRIPT_DIR" "$GIT_PATH_ROOT"
 cp "$TOUCHSTONE_ROOT/scripts/merge-pr.sh" "$MERGE_SCRIPT_DIR/merge-pr.sh"
-cat > "$MERGE_SCRIPT_DIR/codex-review.sh" <<'EOF'
+cat >"$MERGE_SCRIPT_DIR/codex-review.sh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 {
@@ -27,7 +27,7 @@ exit 0
 EOF
 chmod +x "$MERGE_SCRIPT_DIR/merge-pr.sh" "$MERGE_SCRIPT_DIR/codex-review.sh"
 
-cat > "$FAKE_BIN/gh" <<'EOF'
+cat >"$FAKE_BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -91,7 +91,7 @@ case "${1:-} ${2:-}" in
 esac
 EOF
 
-cat > "$FAKE_BIN/git" <<'EOF'
+cat >"$FAKE_BIN/git" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 

--- a/tests/test-merge-pr.sh
+++ b/tests/test-merge-pr.sh
@@ -13,7 +13,7 @@ MERGE_SCRIPT_DIR="$TEST_DIR/scripts"
 GIT_PATH_ROOT="$TEST_DIR/git-path"
 mkdir -p "$FAKE_BIN" "$MERGE_SCRIPT_DIR" "$GIT_PATH_ROOT"
 cp "$TOUCHSTONE_ROOT/scripts/merge-pr.sh" "$MERGE_SCRIPT_DIR/merge-pr.sh"
-cat > "$MERGE_SCRIPT_DIR/codex-review.sh" <<'EOF'
+cat >"$MERGE_SCRIPT_DIR/codex-review.sh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 {
@@ -26,7 +26,7 @@ exit "${CODEX_REVIEW_EXIT:-0}"
 EOF
 chmod +x "$MERGE_SCRIPT_DIR/merge-pr.sh" "$MERGE_SCRIPT_DIR/codex-review.sh"
 
-cat > "$FAKE_BIN/gh" <<'EOF'
+cat >"$FAKE_BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -94,7 +94,7 @@ case "${1:-} ${2:-}" in
 esac
 EOF
 
-cat > "$FAKE_BIN/git" <<'EOF'
+cat >"$FAKE_BIN/git" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -284,7 +284,7 @@ reset_case_files
 # auto-promote to bypass-with-disclosure rather than refusing the merge.
 mkdir -p "$GIT_PATH_ROOT/touchstone/reviewer-clean"
 printf 'result=CODEX_REVIEW_CLEAN\nbranch=feature/test\nbase=origin/main\nmerge_base=base-oid\nhead=pr-head-oid\n' \
-  > "$GIT_PATH_ROOT/touchstone/reviewer-clean/feature_test.clean"
+  >"$GIT_PATH_ROOT/touchstone/reviewer-clean/feature_test.clean"
 if ! CODEX_REVIEW_EXIT=124 run_merge_pr "$TEST_DIR/output-auto-bypass.txt" 123; then
   echo "FAIL: merge-pr.sh did not auto-promote to bypass when review failed and a clean marker exists" >&2
   cat "$TEST_DIR/output-auto-bypass.txt" >&2
@@ -327,7 +327,8 @@ MAIN_WORKTREE="$TEST_DIR/main-worktree"
 FEATURE_WORKTREE="$TEST_DIR/feature-worktree"
 mkdir -p "$MAIN_WORKTREE" "$FEATURE_WORKTREE"
 TEST_CURRENT_WORKTREE="$FEATURE_WORKTREE"
-GIT_WORKTREE_LIST="$(cat <<EOF
+GIT_WORKTREE_LIST="$(
+  cat <<EOF
 worktree $MAIN_WORKTREE
 HEAD main-oid
 branch refs/heads/main
@@ -373,7 +374,8 @@ STALE_MAIN_WORKTREE="$TEST_DIR/missing-main-worktree"
 FEATURE_WORKTREE="$TEST_DIR/feature-worktree"
 mkdir -p "$FEATURE_WORKTREE"
 TEST_CURRENT_WORKTREE="$FEATURE_WORKTREE"
-GIT_WORKTREE_LIST="$(cat <<EOF
+GIT_WORKTREE_LIST="$(
+  cat <<EOF
 worktree $STALE_MAIN_WORKTREE
 HEAD main-oid
 branch refs/heads/main
@@ -402,7 +404,8 @@ fi
 echo "==> Test: gh local-branch-delete failure on a MERGED PR is a warning, not an error"
 reset_case_files
 TEST_CURRENT_WORKTREE="/tmp/touchstone-feature-worktree"
-GIT_WORKTREE_LIST="$(cat <<'EOF'
+GIT_WORKTREE_LIST="$(
+  cat <<'EOF'
 worktree /tmp/touchstone-main-worktree
 HEAD main-oid
 branch refs/heads/main
@@ -466,7 +469,7 @@ fi
 echo "==> Test: bypass after clean marker records disclosure and trailer"
 reset_case_files
 mkdir -p "$GIT_PATH_ROOT/touchstone/reviewer-clean"
-printf 'result=CODEX_REVIEW_CLEAN\nbranch=feature/test\nhead=pr-head-oid\nmerge_base=base-oid\n' > "$GIT_PATH_ROOT/touchstone/reviewer-clean/feature_test.clean"
+printf 'result=CODEX_REVIEW_CLEAN\nbranch=feature/test\nhead=pr-head-oid\nmerge_base=base-oid\n' >"$GIT_PATH_ROOT/touchstone/reviewer-clean/feature_test.clean"
 run_merge_pr "$TEST_DIR/output-bypass.txt" 123 --bypass-with-disclosure="reviewer timed out after prior clean review"
 if grep -q 'BYPASSING REVIEWER GATE' "$TEST_DIR/output-bypass.txt" \
   && grep -q 'reason: reviewer timed out after prior clean review' "$TEST_DIR/output-bypass.txt" \
@@ -484,7 +487,7 @@ fi
 echo "==> Test: stale clean marker is rejected"
 reset_case_files
 mkdir -p "$GIT_PATH_ROOT/touchstone/reviewer-clean"
-printf 'result=CODEX_REVIEW_CLEAN\nbranch=feature/test\nhead=old-head\n' > "$GIT_PATH_ROOT/touchstone/reviewer-clean/feature_test.clean"
+printf 'result=CODEX_REVIEW_CLEAN\nbranch=feature/test\nhead=old-head\n' >"$GIT_PATH_ROOT/touchstone/reviewer-clean/feature_test.clean"
 if run_merge_pr "$TEST_DIR/output-stale.txt" 123 --bypass-with-disclosure="reviewer timed out"; then
   echo "FAIL: bypass with stale marker unexpectedly succeeded" >&2
   exit 1
@@ -502,7 +505,7 @@ fi
 echo "==> Test: old-base clean marker is rejected"
 reset_case_files
 mkdir -p "$GIT_PATH_ROOT/touchstone/reviewer-clean"
-printf 'result=CODEX_REVIEW_CLEAN\nbranch=feature/test\nhead=pr-head-oid\nmerge_base=old-base\n' > "$GIT_PATH_ROOT/touchstone/reviewer-clean/feature_test.clean"
+printf 'result=CODEX_REVIEW_CLEAN\nbranch=feature/test\nhead=pr-head-oid\nmerge_base=old-base\n' >"$GIT_PATH_ROOT/touchstone/reviewer-clean/feature_test.clean"
 if run_merge_pr "$TEST_DIR/output-old-base.txt" 123 --bypass-with-disclosure="reviewer timed out"; then
   echo "FAIL: bypass with old-base marker unexpectedly succeeded" >&2
   exit 1

--- a/tests/test-migrate-review-config.sh
+++ b/tests/test-migrate-review-config.sh
@@ -39,7 +39,7 @@ assert_file_lacks() {
 # ----------------------------------------------------------------------------
 echo "==> Test: full legacy config migrates to 2.0 shape"
 LEGACY="$TEST_DIR/full.toml"
-cat > "$LEGACY" <<'EOF'
+cat >"$LEGACY" <<'EOF'
 [codex_review]
 max_iterations = 3
 
@@ -62,22 +62,22 @@ EOF
 bash "$MIGRATE" --file "$LEGACY" >/dev/null
 
 # 2.0 shape present
-assert_file_contains "$LEGACY" '^reviewer = "conductor"$'              "[review].reviewer scalar"
-assert_file_contains "$LEGACY" '^\[review\.conductor\]$'                "[review.conductor] section appended"
-assert_file_contains "$LEGACY" '^prefer = "best"$'                      "[review.conductor].prefer = best"
-assert_file_contains "$LEGACY" '^effort = "max"$'                       "[review.conductor].effort = max"
-assert_file_contains "$LEGACY" '^tags = "code-review"$'                 "[review.conductor].tags"
-assert_file_contains "$LEGACY" '^with = "claude"$'                      "[review.conductor].with pinned to first reviewer"
+assert_file_contains "$LEGACY" '^reviewer = "conductor"$' "[review].reviewer scalar"
+assert_file_contains "$LEGACY" '^\[review\.conductor\]$' "[review.conductor] section appended"
+assert_file_contains "$LEGACY" '^prefer = "best"$' "[review.conductor].prefer = best"
+assert_file_contains "$LEGACY" '^effort = "max"$' "[review.conductor].effort = max"
+assert_file_contains "$LEGACY" '^tags = "code-review"$' "[review.conductor].tags"
+assert_file_contains "$LEGACY" '^with = "claude"$' "[review.conductor].with pinned to first reviewer"
 assert_file_contains "$LEGACY" '# Original 1.x cascade was: claude, codex, gemini' "fallback chain preserved as comment"
-assert_file_contains "$LEGACY" '^small_with = "ollama"$'                "small_reviewers=local → small_with=ollama"
-assert_file_contains "$LEGACY" '^large_with = "claude"$'                "large_reviewers=claude → large_with=claude"
+assert_file_contains "$LEGACY" '^small_with = "ollama"$' "small_reviewers=local → small_with=ollama"
+assert_file_contains "$LEGACY" '^large_with = "claude"$' "large_reviewers=claude → large_with=claude"
 
 # 1.x markers gone (or commented out)
-assert_file_lacks "$LEGACY" '^reviewers[[:space:]]*=[[:space:]]*\['     "1.x reviewers array removed"
+assert_file_lacks "$LEGACY" '^reviewers[[:space:]]*=[[:space:]]*\[' "1.x reviewers array removed"
 assert_file_lacks "$LEGACY" '^small_reviewers[[:space:]]*=[[:space:]]*\[' "1.x small_reviewers removed"
 assert_file_lacks "$LEGACY" '^large_reviewers[[:space:]]*=[[:space:]]*\[' "1.x large_reviewers removed"
-assert_file_lacks "$LEGACY" '^\[review\.local\][[:space:]]*$'           "[review.local] header commented out"
-assert_file_lacks "$LEGACY" '^\[review\.assist\][[:space:]]*$'          "[review.assist] header commented out"
+assert_file_lacks "$LEGACY" '^\[review\.local\][[:space:]]*$' "[review.local] header commented out"
+assert_file_lacks "$LEGACY" '^\[review\.assist\][[:space:]]*$' "[review.assist] header commented out"
 assert_file_lacks "$LEGACY" '^command[[:space:]]*=[[:space:]]*"my-custom-reviewer' "[review.local].command commented out"
 
 # Backup written
@@ -116,7 +116,7 @@ echo "==> PASS: idempotent"
 # ----------------------------------------------------------------------------
 echo "==> Test: --dry-run leaves file untouched"
 DRY="$TEST_DIR/dry.toml"
-cat > "$DRY" <<'EOF'
+cat >"$DRY" <<'EOF'
 [review]
 reviewers = ["codex"]
 EOF
@@ -138,7 +138,7 @@ echo "==> PASS: --dry-run is read-only"
 # ----------------------------------------------------------------------------
 echo "==> Test: --no-backup skips backup file"
 NB="$TEST_DIR/nobak.toml"
-cat > "$NB" <<'EOF'
+cat >"$NB" <<'EOF'
 [review]
 reviewers = ["claude"]
 EOF
@@ -154,7 +154,7 @@ echo "==> PASS: --no-backup honored"
 # ----------------------------------------------------------------------------
 echo "==> Test: 'local' reviewer maps to 'ollama'"
 LOC="$TEST_DIR/local-reviewer.toml"
-cat > "$LOC" <<'EOF'
+cat >"$LOC" <<'EOF'
 [review]
 reviewers = ["local", "codex"]
 
@@ -171,7 +171,7 @@ echo "==> PASS: local maps to ollama"
 # ----------------------------------------------------------------------------
 echo "==> Test: file with no 1.x markers is a no-op"
 CLEAN="$TEST_DIR/clean.toml"
-cat > "$CLEAN" <<'EOF'
+cat >"$CLEAN" <<'EOF'
 [codex_review]
 max_iterations = 3
 mode = "review-only"
@@ -221,13 +221,13 @@ echo "==> Test: migrated config does not fire migration warnings"
 SCRATCH="$TEST_DIR/scratch-repo"
 mkdir -p "$SCRATCH" && cd "$SCRATCH"
 git init -q && git config user.email t@t && git config user.name t
-echo init > README.md && git add . && git commit -qm i
+echo init >README.md && git add . && git commit -qm i
 cp "$LEGACY" .codex-review.toml
 git add . && git commit -qm cfg
 
 # Mock conductor
 mkdir fakebin
-cat > fakebin/conductor <<'CXEOF'
+cat >fakebin/conductor <<'CXEOF'
 #!/usr/bin/env bash
 if [ "${1:-}" = "doctor" ]; then printf '{"providers":[{"configured":true}]}\n'; exit 0; fi
 cat >/dev/null
@@ -237,12 +237,12 @@ chmod +x fakebin/conductor
 
 # Make a tracked change so there's something to review
 git checkout -qb feat/m
-echo c >> README.md && git add . && git commit -qm change
+echo c >>README.md && git add . && git commit -qm change
 
 PUSH_OUT="$TEST_DIR/push-out.txt"
 PATH="$SCRATCH/fakebin:/usr/bin:/bin" CODEX_REVIEW_BASE=HEAD~1 CODEX_REVIEW_MODE=review-only \
   CODEX_REVIEW_DISABLE_CACHE=1 \
-  bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$PUSH_OUT" 2>&1 || true
+  bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$PUSH_OUT" 2>&1 || true
 
 # These migration-warning lines should NOT appear
 if grep -qE 'is a v1\.x config|is ignored in Touchstone 2\.0|is disabled in Touchstone 2\.0' "$PUSH_OUT"; then

--- a/tests/test-migrate.sh
+++ b/tests/test-migrate.sh
@@ -25,7 +25,7 @@ make_project() {
     git init -q -b main
     git config user.email "test@example.com"
     git config user.name "Test"
-    echo "placeholder" > README.md
+    echo "placeholder" >README.md
     git add README.md
     git commit -q -m "initial"
   )
@@ -35,14 +35,14 @@ write_legacy_state() {
   local project_dir="$1"
   (
     cd "$project_dir"
-    printf 'abc123\n' > .toolkit-version
-    cat > .toolkit-manifest <<'EOF'
+    printf 'abc123\n' >.toolkit-version
+    cat >.toolkit-manifest <<'EOF'
 # Managed by toolkit. These paths may be updated by `toolkit update`.
 .toolkit-manifest
 .toolkit-version
 scripts/toolkit-run.sh
 EOF
-    printf 'project_type=python\n' > .toolkit-config
+    printf 'project_type=python\n' >.toolkit-config
     git add .toolkit-version .toolkit-manifest .toolkit-config
     git commit -q -m "add legacy toolkit files"
   )
@@ -111,7 +111,7 @@ echo "==> Test 3: refuses when working tree is dirty"
 PROJECT_DIR2="$TEST_DIR/project2"
 make_project "$PROJECT_DIR2"
 write_legacy_state "$PROJECT_DIR2"
-echo "dirty" > "$PROJECT_DIR2/uncommitted.txt"
+echo "dirty" >"$PROJECT_DIR2/uncommitted.txt"
 
 set +e
 run_migrate "$PROJECT_DIR2" 2>/dev/null
@@ -134,8 +134,8 @@ PROJECT_DIR3="$TEST_DIR/project3"
 make_project "$PROJECT_DIR3"
 (
   cd "$PROJECT_DIR3"
-  printf 'legacy\n' > .toolkit-version
-  printf 'newer\n'  > .touchstone-version
+  printf 'legacy\n' >.toolkit-version
+  printf 'newer\n' >.touchstone-version
   git add .toolkit-version .touchstone-version
   git commit -q -m "conflicting state"
 )
@@ -167,7 +167,7 @@ set -e
 if [ "$RC" -eq 0 ]; then
   fail "expected update to fail on legacy project"
 fi
-if ! grep -q 'migrate-from-toolkit' <<< "$UPDATE_OUT"; then
+if ! grep -q 'migrate-from-toolkit' <<<"$UPDATE_OUT"; then
   fail "expected update error to mention 'migrate-from-toolkit', got:\n$UPDATE_OUT"
 fi
 

--- a/tests/test-open-pr-cleanup-worktree.sh
+++ b/tests/test-open-pr-cleanup-worktree.sh
@@ -26,14 +26,14 @@ mkdir -p "$SCRIPT_DIR" "$FAKE_BIN"
 
 cp "$TOUCHSTONE_ROOT/scripts/open-pr.sh" "$SCRIPT_DIR/open-pr.sh"
 # merge-pr.sh is invoked by open-pr.sh on --auto-merge; stub it.
-cat > "$SCRIPT_DIR/merge-pr.sh" <<'EOF'
+cat >"$SCRIPT_DIR/merge-pr.sh" <<'EOF'
 #!/usr/bin/env bash
 exit 0
 EOF
 chmod +x "$SCRIPT_DIR/open-pr.sh" "$SCRIPT_DIR/merge-pr.sh"
 
 # Mock gh: returns a stable PR URL on create, claims mergedAt is non-empty.
-cat > "$FAKE_BIN/gh" <<'EOF'
+cat >"$FAKE_BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 case "$1 $2" in
@@ -61,15 +61,15 @@ git -C "$REPO_DIR" switch -c main >/dev/null 2>&1
 git -C "$REPO_DIR" config user.name "Touchstone Test"
 git -C "$REPO_DIR" config user.email "touchstone@example.com"
 mkdir -p "$REPO_DIR/.github"
-printf '## Summary\n' > "$REPO_DIR/.github/pull_request_template.md"
-printf 'base\n' > "$REPO_DIR/file.txt"
+printf '## Summary\n' >"$REPO_DIR/.github/pull_request_template.md"
+printf 'base\n' >"$REPO_DIR/file.txt"
 git -C "$REPO_DIR" add .github/pull_request_template.md file.txt
 git -C "$REPO_DIR" commit -m "base" >/dev/null 2>&1
 git -C "$REPO_DIR" push -u origin main >/dev/null 2>&1
 
 FEATURE_DIR="$TEST_DIR/repo-feature"
 git -C "$REPO_DIR" worktree add "$FEATURE_DIR" -b feat/cleanup-test >/dev/null 2>&1
-printf 'change\n' >> "$FEATURE_DIR/file.txt"
+printf 'change\n' >>"$FEATURE_DIR/file.txt"
 git -C "$FEATURE_DIR" add file.txt
 git -C "$FEATURE_DIR" commit -m "test change" >/dev/null 2>&1
 
@@ -118,7 +118,7 @@ fi
 echo "==> Case 3: existing PR --auto-merge --cleanup-worktree removes the feature worktree"
 EXISTING_FEATURE_DIR="$TEST_DIR/repo-feature-existing"
 git -C "$REPO_DIR" worktree add "$EXISTING_FEATURE_DIR" -b feat/cleanup-existing >/dev/null 2>&1
-printf 'existing\n' >> "$EXISTING_FEATURE_DIR/file.txt"
+printf 'existing\n' >>"$EXISTING_FEATURE_DIR/file.txt"
 git -C "$EXISTING_FEATURE_DIR" add file.txt
 git -C "$EXISTING_FEATURE_DIR" commit -m "test existing change" >/dev/null 2>&1
 

--- a/tests/test-open-pr-exit-contract.sh
+++ b/tests/test-open-pr-exit-contract.sh
@@ -42,18 +42,18 @@ chmod +x "$SCRIPT_DIR/open-pr.sh"
 git -C "$REPO_DIR" init -b main >/dev/null 2>&1
 git -C "$REPO_DIR" config user.name "Touchstone Test"
 git -C "$REPO_DIR" config user.email "touchstone@example.com"
-printf 'base\n' > "$REPO_DIR/file.txt"
+printf 'base\n' >"$REPO_DIR/file.txt"
 git -C "$REPO_DIR" add file.txt
 git -C "$REPO_DIR" commit -m "base commit" >/dev/null 2>&1
 git -C "$REPO_DIR" checkout -b feat/test >/dev/null 2>&1
-printf 'change\n' >> "$REPO_DIR/file.txt"
+printf 'change\n' >>"$REPO_DIR/file.txt"
 git -C "$REPO_DIR" add file.txt
 git -C "$REPO_DIR" commit -m "test change" >/dev/null 2>&1
 
 # Mock gh — behaviour controlled by env vars so each scenario reuses one mock.
 # GH_MERGED_AT  — value returned for `gh pr view --json mergedAt --jq …`
 # GH_HAS_EXISTING_PR — if "1", `gh pr list` returns an existing PR URL
-cat > "$FAKE_BIN/gh" <<'EOF'
+cat >"$FAKE_BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 case "$1 $2" in
@@ -88,7 +88,7 @@ chmod +x "$FAKE_BIN/gh"
 # Stub git push so the script doesn't try to talk to a real remote.
 # We wrap real git via $REAL_GIT for everything else.
 REAL_GIT="$(command -v git)"
-cat > "$FAKE_BIN/git" <<EOF
+cat >"$FAKE_BIN/git" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
 if [ "\${1:-}" = "push" ]; then
@@ -101,7 +101,7 @@ chmod +x "$FAKE_BIN/git"
 
 # Stub merge-pr.sh — behaviour controlled by MERGE_PR_EXIT (default 0).
 # When nonzero, simulates "Conductor blocked" or similar review-failure.
-cat > "$SCRIPT_DIR/merge-pr.sh" <<'EOF'
+cat >"$SCRIPT_DIR/merge-pr.sh" <<'EOF'
 #!/usr/bin/env bash
 echo "[mock merge-pr.sh] called for PR $1"
 exit "${MERGE_PR_EXIT:-0}"
@@ -128,7 +128,7 @@ echo "==> Case 1: happy path"
 OUT="$TEST_DIR/case1.out"
 RC=0
 GH_MERGED_AT="2026-04-28T12:00:00Z" GH_HAS_EXISTING_PR=0 MERGE_PR_EXIT=0 \
-  run_open_pr > "$OUT" 2>&1 || RC=$?
+  run_open_pr >"$OUT" 2>&1 || RC=$?
 
 if [ "$RC" = "0" ] \
   && grep -q '==> Verified: PR #123 merged at 2026-04-28T12:00:00Z' "$OUT" \
@@ -149,7 +149,7 @@ echo "==> Case 2: merge-pr.sh blocks (Conductor blocks review)"
 OUT="$TEST_DIR/case2.out"
 RC=0
 GH_MERGED_AT="" GH_HAS_EXISTING_PR=0 MERGE_PR_EXIT=1 \
-  run_open_pr > "$OUT" 2>&1 || RC=$?
+  run_open_pr >"$OUT" 2>&1 || RC=$?
 
 if [ "$RC" != "0" ] \
   && grep -q 'ORPHAN RISK: PR opened but not merged' "$OUT" \
@@ -173,7 +173,7 @@ echo "==> Case 3: silent orphan — merge-pr.sh exits 0 but PR not actually merg
 OUT="$TEST_DIR/case3.out"
 RC=0
 GH_MERGED_AT="" GH_HAS_EXISTING_PR=0 MERGE_PR_EXIT=0 \
-  run_open_pr > "$OUT" 2>&1 || RC=$?
+  run_open_pr >"$OUT" 2>&1 || RC=$?
 
 if [ "$RC" != "0" ] \
   && grep -q 'merge-pr.sh exited 0 but PR #123 is not merged on GitHub' "$OUT" \
@@ -197,7 +197,7 @@ OUT="$TEST_DIR/case4.out"
 RC=0
 mv "$SCRIPT_DIR/merge-pr.sh" "$SCRIPT_DIR/merge-pr.sh.hidden"
 GH_MERGED_AT="" GH_HAS_EXISTING_PR=0 \
-  run_open_pr > "$OUT" 2>&1 || RC=$?
+  run_open_pr >"$OUT" 2>&1 || RC=$?
 mv "$SCRIPT_DIR/merge-pr.sh.hidden" "$SCRIPT_DIR/merge-pr.sh"
 
 if [ "$RC" != "0" ] \
@@ -223,7 +223,7 @@ echo "==> Case 5: existing-PR path with --auto-merge succeeds and verifies"
 OUT="$TEST_DIR/case5.out"
 RC=0
 GH_MERGED_AT="2026-04-28T13:00:00Z" GH_HAS_EXISTING_PR=1 MERGE_PR_EXIT=0 \
-  run_open_pr > "$OUT" 2>&1 || RC=$?
+  run_open_pr >"$OUT" 2>&1 || RC=$?
 
 if [ "$RC" = "0" ] \
   && grep -q 'PR already open' "$OUT" \

--- a/tests/test-open-pr-linked-issues.sh
+++ b/tests/test-open-pr-linked-issues.sh
@@ -27,7 +27,7 @@ chmod +x "$SCRIPT_DIR/open-pr.sh"
 # Fake gh: captures --body-file content so this test can assert on the exact
 # PR body that would be sent to GitHub. Git push still talks to a real local
 # bare remote so branch/upstream behavior stays realistic.
-cat > "$FAKE_BIN/gh" <<'GHEOF'
+cat >"$FAKE_BIN/gh" <<'GHEOF'
 #!/usr/bin/env bash
 set -euo pipefail
 case "$1 $2" in
@@ -67,7 +67,7 @@ git -C "$REPO_DIR" config user.name "Touchstone Test"
 git -C "$REPO_DIR" config user.email "touchstone@example.com"
 mkdir -p "$REPO_DIR/.github"
 cp "$TOUCHSTONE_ROOT/templates/pull_request_template.md" "$REPO_DIR/.github/pull_request_template.md"
-printf 'base\n' > "$REPO_DIR/file.txt"
+printf 'base\n' >"$REPO_DIR/file.txt"
 git -C "$REPO_DIR" add .github/pull_request_template.md file.txt
 git -C "$REPO_DIR" commit -m "base commit
 
@@ -75,14 +75,14 @@ Closes #99" >/dev/null 2>&1
 git -C "$REPO_DIR" push -u origin main >/dev/null 2>&1
 
 git -C "$REPO_DIR" switch -c feat/issue-close-test >/dev/null 2>&1
-printf 'change\n' >> "$REPO_DIR/file.txt"
+printf 'change\n' >>"$REPO_DIR/file.txt"
 git -C "$REPO_DIR" add file.txt
 git -C "$REPO_DIR" commit -m "test change
 
 Exercise linked issue detection.
 
 Closes #42" >/dev/null 2>&1
-printf 'second change\n' >> "$REPO_DIR/file.txt"
+printf 'second change\n' >>"$REPO_DIR/file.txt"
 git -C "$REPO_DIR" add file.txt
 git -C "$REPO_DIR" commit -m "test trailer
 
@@ -98,7 +98,7 @@ RC=0
   cd "$REPO_DIR"
   PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
     bash "$SCRIPT_DIR/open-pr.sh"
-) > "$OUT" 2>&1 || RC=$?
+) >"$OUT" 2>&1 || RC=$?
 
 if [ "$RC" = "0" ] \
   && grep -q '^## Linked Issues$' "$OUT" \

--- a/tests/test-open-pr-sentinel-body.sh
+++ b/tests/test-open-pr-sentinel-body.sh
@@ -32,7 +32,7 @@ chmod +x "$SCRIPT_DIR/open-pr.sh"
 # Fake gh: captures the --body-file content so tests can assert on it.
 # GH_HAS_EXISTING_PR — unused here (always 0 / no existing PR).
 # ---------------------------------------------------------------------------
-cat > "$FAKE_BIN/gh" <<'GHEOF'
+cat >"$FAKE_BIN/gh" <<'GHEOF'
 #!/usr/bin/env bash
 set -euo pipefail
 case "$1 $2" in
@@ -67,7 +67,7 @@ chmod +x "$FAKE_BIN/gh"
 
 # Stub git push so the script never talks to a real remote.
 REAL_GIT="$(command -v git)"
-cat > "$FAKE_BIN/git" <<EOF
+cat >"$FAKE_BIN/git" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
 if [ "\${1:-}" = "push" ]; then
@@ -90,11 +90,11 @@ make_repo() {
   git -C "$repo" init -b main >/dev/null 2>&1
   git -C "$repo" config user.name "Touchstone Test"
   git -C "$repo" config user.email "touchstone@example.com"
-  printf 'base\n' > "$repo/file.txt"
+  printf 'base\n' >"$repo/file.txt"
   git -C "$repo" add file.txt
   git -C "$repo" commit -m "base commit" >/dev/null 2>&1
   git -C "$repo" checkout -b feat/test >/dev/null 2>&1
-  printf 'change\n' >> "$repo/file.txt"
+  printf 'change\n' >>"$repo/file.txt"
   git -C "$repo" add file.txt
   git -C "$repo" commit -m "test commit subject
 
@@ -122,7 +122,7 @@ REPO1="$TEST_DIR/repo1"
 make_repo "$REPO1" "Commit body: should NOT appear"
 
 mkdir -p "$REPO1/.sentinel/runs"
-cat > "$REPO1/.sentinel/runs/2026-04-28-run.md" <<'RUNEOF'
+cat >"$REPO1/.sentinel/runs/2026-04-28-run.md" <<'RUNEOF'
 ---
 schema-version: 1.0
 ---
@@ -143,7 +143,7 @@ git -C "$REPO1" add .sentinel && git -C "$REPO1" commit -m "chore: add sentinel 
 
 OUT1="$TEST_DIR/case1.out"
 RC1=0
-run_open_pr "$REPO1" > "$OUT1" 2>&1 || RC1=$?
+run_open_pr "$REPO1" >"$OUT1" 2>&1 || RC1=$?
 
 if [ "$RC1" = "0" ] \
   && grep -q "Sentinel authored this PR" "$OUT1" \
@@ -168,7 +168,7 @@ make_repo "$REPO2" "Commit body: expected in PR"
 
 OUT2="$TEST_DIR/case2.out"
 RC2=0
-run_open_pr "$REPO2" > "$OUT2" 2>&1 || RC2=$?
+run_open_pr "$REPO2" >"$OUT2" 2>&1 || RC2=$?
 
 if [ "$RC2" = "0" ] \
   && grep -q "Commit body: expected in PR" "$OUT2" \
@@ -190,7 +190,7 @@ REPO3="$TEST_DIR/repo3"
 make_repo "$REPO3" "Commit body: fallback expected"
 
 mkdir -p "$REPO3/.sentinel/runs"
-cat > "$REPO3/.sentinel/runs/2026-04-28-run.md" <<'RUNEOF'
+cat >"$REPO3/.sentinel/runs/2026-04-28-run.md" <<'RUNEOF'
 ---
 schema-version: 1.0
 ---
@@ -205,7 +205,7 @@ Commit body: fallback expected" >/dev/null 2>&1
 
 OUT3="$TEST_DIR/case3.out"
 RC3=0
-run_open_pr "$REPO3" > "$OUT3" 2>&1 || RC3=$?
+run_open_pr "$REPO3" >"$OUT3" 2>&1 || RC3=$?
 
 if [ "$RC3" = "0" ] \
   && grep -q "Commit body: fallback expected" "$OUT3" \
@@ -227,7 +227,7 @@ REPO4="$TEST_DIR/repo4"
 make_repo "$REPO4" "Commit body: should NOT appear in v2"
 
 mkdir -p "$REPO4/.sentinel/runs"
-cat > "$REPO4/.sentinel/runs/2026-04-28-run.md" <<'RUNEOF'
+cat >"$REPO4/.sentinel/runs/2026-04-28-run.md" <<'RUNEOF'
 ---
 schema-version: 2.0
 ---
@@ -240,7 +240,7 @@ git -C "$REPO4" add .sentinel && git -C "$REPO4" commit -m "chore: add sentinel 
 
 OUT4="$TEST_DIR/case4.out"
 RC4=0
-run_open_pr "$REPO4" > "$OUT4" 2>&1 || RC4=$?
+run_open_pr "$REPO4" >"$OUT4" 2>&1 || RC4=$?
 
 if [ "$RC4" = "0" ] \
   && grep -q "Schema v2 body content" "$OUT4" \
@@ -263,7 +263,7 @@ REPO5="$TEST_DIR/repo5"
 make_repo "$REPO5" "Commit body: malformed fallback"
 
 mkdir -p "$REPO5/.sentinel/runs"
-cat > "$REPO5/.sentinel/runs/2026-04-28-run.md" <<'RUNEOF'
+cat >"$REPO5/.sentinel/runs/2026-04-28-run.md" <<'RUNEOF'
 ---
 schema-version: 1.0
 ---
@@ -278,7 +278,7 @@ Commit body: malformed fallback" >/dev/null 2>&1
 
 OUT5="$TEST_DIR/case5.out"
 RC5=0
-run_open_pr "$REPO5" > "$OUT5" 2>&1 || RC5=$?
+run_open_pr "$REPO5" >"$OUT5" 2>&1 || RC5=$?
 
 if [ "$RC5" = "0" ] \
   && grep -q "Commit body: malformed fallback" "$OUT5" \

--- a/tests/test-open-pr-upstream-mismatch.sh
+++ b/tests/test-open-pr-upstream-mismatch.sh
@@ -29,7 +29,7 @@ cp "$TOUCHSTONE_ROOT/scripts/open-pr.sh" "$SCRIPT_DIR/open-pr.sh"
 chmod +x "$SCRIPT_DIR/open-pr.sh"
 
 # Mock gh — open-pr.sh queries the default branch and creates the PR.
-cat > "$FAKE_BIN/gh" <<'EOF'
+cat >"$FAKE_BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 case "$1 $2" in
@@ -48,7 +48,7 @@ git clone "$REMOTE_DIR" "$REPO_DIR" >/dev/null 2>&1
 git -C "$REPO_DIR" switch -c main >/dev/null 2>&1
 git -C "$REPO_DIR" config user.name "Touchstone Test"
 git -C "$REPO_DIR" config user.email "touchstone@example.com"
-printf 'base\n' > "$REPO_DIR/file.txt"
+printf 'base\n' >"$REPO_DIR/file.txt"
 git -C "$REPO_DIR" add file.txt
 git -C "$REPO_DIR" commit -m "base" >/dev/null 2>&1
 git -C "$REPO_DIR" push -u origin main >/dev/null 2>&1
@@ -57,7 +57,7 @@ git -C "$REPO_DIR" push -u origin main >/dev/null 2>&1
 # canonical "branch from remote ref" form. Git points the new branch's
 # upstream at origin/main, which is what triggers issue #169 on push.
 git -C "$REPO_DIR" checkout -b chore/upstream-mismatch-test origin/main >/dev/null 2>&1
-printf 'change\n' >> "$REPO_DIR/file.txt"
+printf 'change\n' >>"$REPO_DIR/file.txt"
 git -C "$REPO_DIR" add file.txt
 git -C "$REPO_DIR" commit -m "test change" >/dev/null 2>&1
 
@@ -78,7 +78,7 @@ RC=0
   cd "$REPO_DIR"
   PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
     bash "$SCRIPT_DIR/open-pr.sh" "test PR" 2>&1
-) > "$OUT" || RC=$?
+) >"$OUT" || RC=$?
 
 if [ "$RC" -ne 0 ]; then
   echo "FAIL: open-pr.sh exited $RC; expected 0" >&2
@@ -101,7 +101,7 @@ fi
 
 # And the remote should actually have the branch.
 if ! git -C "$REPO_DIR" ls-remote --heads origin chore/upstream-mismatch-test \
-    | grep -q chore/upstream-mismatch-test; then
+  | grep -q chore/upstream-mismatch-test; then
   echo "FAIL: remote does not have the expected branch" >&2
   exit 1
 fi

--- a/tests/test-principles-sync.sh
+++ b/tests/test-principles-sync.sh
@@ -21,7 +21,7 @@ if diff -u "$tmp_lib" lib/agents-principles-block.sh; then
 else
   echo "FAIL: principles have drifted. Run 'bash scripts/refresh-principles.sh' and commit the changes." >&2
   # Restore the old one so the worktree stays as it was if this is run in a check mode
-  cat "$tmp_lib" > lib/agents-principles-block.sh
+  cat "$tmp_lib" >lib/agents-principles-block.sh
   rm "$tmp_lib"
   exit 1
 fi

--- a/tests/test-review-clean-marker.sh
+++ b/tests/test-review-clean-marker.sh
@@ -14,7 +14,7 @@ REPO="$TEST_DIR/repo"
 FAKE_BIN="$TEST_DIR/bin"
 mkdir -p "$REPO" "$FAKE_BIN"
 
-cat > "$FAKE_BIN/conductor" <<'EOF'
+cat >"$FAKE_BIN/conductor" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -42,11 +42,11 @@ if (
   git config user.name "Touchstone Test"
   mkdir -p lib
   cp -r "$TOUCHSTONE_ROOT/lib/"* lib/
-  printf '[review]\nreviewer = "conductor"\nmode = "review-only"\n' > .codex-review.toml
-  printf 'base\n' > example.txt
+  printf '[review]\nreviewer = "conductor"\nmode = "review-only"\n' >.codex-review.toml
+  printf 'base\n' >example.txt
   git add .codex-review.toml example.txt
   git commit -q -m "base"
-  printf 'change\n' >> example.txt
+  printf 'change\n' >>example.txt
   git add example.txt
   git commit -q -m "change"
 
@@ -55,7 +55,7 @@ if (
     CODEX_REVIEW_BRANCH_NAME="feature/clean-marker" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
     TOUCHSTONE_REVIEW_LOG=/dev/null \
-    bash "$TOUCHSTONE_ROOT/scripts/codex-review.sh" > "$TEST_DIR/output.txt" 2>&1
+    bash "$TOUCHSTONE_ROOT/scripts/codex-review.sh" >"$TEST_DIR/output.txt" 2>&1
 
   MARKER="$(git rev-parse --git-path touchstone/reviewer-clean/feature_clean-marker.clean)"
   if [ -f "$MARKER" ] \

--- a/tests/test-review-dry-run.sh
+++ b/tests/test-review-dry-run.sh
@@ -19,7 +19,7 @@ ERRORS=0
 FAKE_BIN="$TEST_DIR/bin"
 ARGS_FILE="$TEST_DIR/conductor-argv.log"
 mkdir -p "$FAKE_BIN"
-cat > "$FAKE_BIN/conductor" <<'CXEOF'
+cat >"$FAKE_BIN/conductor" <<'CXEOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "$ARGS_FILE"
 case "$1" in
@@ -40,7 +40,8 @@ CXEOF
 chmod +x "$FAKE_BIN/conductor"
 
 run_review() {
-  local repo="$1"; shift
+  local repo="$1"
+  shift
   (
     cd "$repo"
     PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
@@ -56,7 +57,7 @@ new_repo() {
   git -C "$dir" init -q
   git -C "$dir" config user.email t@t
   git -C "$dir" config user.name t
-  echo init > "$dir/README.md"
+  echo init >"$dir/README.md"
   git -C "$dir" add . && git -C "$dir" commit -qm init
 }
 
@@ -72,9 +73,9 @@ commit_new_file_with_diff_lines() {
     exit 1
   fi
 
-  : > "$repo/$path"
+  : >"$repo/$path"
   while [ "$i" -le "$content_lines" ]; do
-    printf 'line %03d\n' "$i" >> "$repo/$path"
+    printf 'line %03d\n' "$i" >>"$repo/$path"
     i=$((i + 1))
   done
   git -C "$repo" add "$path" && git -C "$repo" commit -qm "change $target_lines lines"
@@ -91,7 +92,7 @@ commit_new_file_with_diff_lines() {
 echo "==> Test: small default route beats global conductor prefer/effort"
 REPO_AUTO="$TEST_DIR/repo-auto"
 new_repo "$REPO_AUTO"
-cat > "$REPO_AUTO/.codex-review.toml" <<'EOF'
+cat >"$REPO_AUTO/.codex-review.toml" <<'EOF'
 [review]
 enabled = true
 reviewer = "conductor"
@@ -101,9 +102,9 @@ effort = "max"
 tags = "code-review"
 EOF
 git -C "$REPO_AUTO" add . && git -C "$REPO_AUTO" commit -qm cfg
-echo c >> "$REPO_AUTO/README.md" && git -C "$REPO_AUTO" add . && git -C "$REPO_AUTO" commit -qm change
+echo c >>"$REPO_AUTO/README.md" && git -C "$REPO_AUTO" add . && git -C "$REPO_AUTO" commit -qm change
 
-: > "$ARGS_FILE"
+: >"$ARGS_FILE"
 out="$(run_review "$REPO_AUTO" --dry-run --base HEAD~1 2>&1)"
 
 if grep -q '^route' "$ARGS_FILE" \
@@ -126,7 +127,7 @@ REPO_THRESHOLD="$TEST_DIR/repo-threshold"
 new_repo "$REPO_THRESHOLD"
 commit_new_file_with_diff_lines "$REPO_THRESHOLD" 400 threshold.txt
 
-: > "$ARGS_FILE"
+: >"$ARGS_FILE"
 out="$(run_review "$REPO_THRESHOLD" --dry-run --base HEAD~1 2>&1)"
 
 if grep -q '\-\-prefer cheapest' "$ARGS_FILE" \
@@ -146,7 +147,7 @@ REPO_LARGE="$TEST_DIR/repo-large"
 new_repo "$REPO_LARGE"
 commit_new_file_with_diff_lines "$REPO_LARGE" 401 large.txt
 
-: > "$ARGS_FILE"
+: >"$ARGS_FILE"
 out="$(run_review "$REPO_LARGE" --dry-run --base HEAD~1 2>&1)"
 
 if grep -q '\-\-prefer best' "$ARGS_FILE" \
@@ -164,7 +165,7 @@ fi
 echo "==> Test: explicit routing opt-out preserves global conductor config"
 REPO_DISABLED="$TEST_DIR/repo-routing-disabled"
 new_repo "$REPO_DISABLED"
-cat > "$REPO_DISABLED/.codex-review.toml" <<'EOF'
+cat >"$REPO_DISABLED/.codex-review.toml" <<'EOF'
 [review.conductor]
 prefer = "balanced"
 effort = "low"
@@ -172,9 +173,9 @@ effort = "low"
 enabled = false
 EOF
 git -C "$REPO_DISABLED" add . && git -C "$REPO_DISABLED" commit -qm cfg
-echo c >> "$REPO_DISABLED/README.md" && git -C "$REPO_DISABLED" add . && git -C "$REPO_DISABLED" commit -qm change
+echo c >>"$REPO_DISABLED/README.md" && git -C "$REPO_DISABLED" add . && git -C "$REPO_DISABLED" commit -qm change
 
-: > "$ARGS_FILE"
+: >"$ARGS_FILE"
 out="$(run_review "$REPO_DISABLED" --dry-run --base HEAD~1 2>&1)"
 
 if grep -q '\-\-prefer balanced' "$ARGS_FILE" \
@@ -192,7 +193,7 @@ fi
 echo '==> Test: --dry-run with `with =` pinned config skips route preview'
 REPO_PIN="$TEST_DIR/repo-pin"
 new_repo "$REPO_PIN"
-cat > "$REPO_PIN/.codex-review.toml" <<'EOF'
+cat >"$REPO_PIN/.codex-review.toml" <<'EOF'
 [review]
 reviewer = "conductor"
 [review.conductor]
@@ -202,7 +203,7 @@ effort = "max"
 EOF
 git -C "$REPO_PIN" add . && git -C "$REPO_PIN" commit -qm cfg
 
-: > "$ARGS_FILE"
+: >"$ARGS_FILE"
 out="$(run_review "$REPO_PIN" --dry-run --base HEAD 2>&1)"
 
 if echo "$out" | grep -q 'pinned via --with=claude' \
@@ -218,7 +219,7 @@ fi
 
 # ----------------------------------------------------------------------------
 echo "==> Test: env override beats size bucket defaults"
-: > "$ARGS_FILE"
+: >"$ARGS_FILE"
 out="$(
   cd "$REPO_AUTO"
   PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
@@ -243,7 +244,7 @@ echo "==> Test: --mode override changes tools without sandbox flags"
 check_dry_run_mode() {
   local mode="$1"
   local expected_tools="$2"
-  : > "$ARGS_FILE"
+  : >"$ARGS_FILE"
   out="$(run_review "$REPO_AUTO" --dry-run --mode "$mode" --base HEAD~1 2>&1)"
 
   if [ -n "$expected_tools" ]; then
@@ -313,7 +314,7 @@ fi
 
 # ----------------------------------------------------------------------------
 echo "==> Test: TOUCHSTONE_REVIEWER=<legacy> translates to --with pin + deprecation note"
-: > "$ARGS_FILE"
+: >"$ARGS_FILE"
 set +e
 out="$(
   cd "$REPO_AUTO"
@@ -334,7 +335,7 @@ else
 fi
 
 # TOUCHSTONE_REVIEWER=local must map to ollama, not crash or no-op.
-: > "$ARGS_FILE"
+: >"$ARGS_FILE"
 out="$(
   cd "$REPO_AUTO"
   PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
@@ -353,7 +354,7 @@ else
 fi
 
 # Unknown value warns but does not pin (must not silently succeed with junk).
-: > "$ARGS_FILE"
+: >"$ARGS_FILE"
 out="$(
   cd "$REPO_AUTO"
   PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \

--- a/tests/test-review-findings-checkpoint.sh
+++ b/tests/test-review-findings-checkpoint.sh
@@ -25,7 +25,7 @@ mkdir -p "$REPO" "$FAKE_BIN"
 #    FAKE_CONDUCTOR_VERDICT (one of: BLOCKED, CLEAN). For BLOCKED it also
 #    emits two synthetic finding lines so write_review_findings has data
 #    to persist.
-cat > "$FAKE_BIN/conductor" <<'CONDUCTOR_EOF'
+cat >"$FAKE_BIN/conductor" <<'CONDUCTOR_EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -69,41 +69,45 @@ chmod +x "$FAKE_BIN/conductor"
   git config user.name "Touchstone Test"
   mkdir -p lib
   cp -r "$TOUCHSTONE_ROOT/lib/"* lib/
-  printf '[review]\nreviewer = "conductor"\nmode = "review-only"\n' > .codex-review.toml
-  printf 'base\n' > example.txt
+  printf '[review]\nreviewer = "conductor"\nmode = "review-only"\n' >.codex-review.toml
+  printf 'base\n' >example.txt
   git add .codex-review.toml example.txt
   git commit -q -m "base"
-  printf 'change 1\n' >> example.txt
+  printf 'change 1\n' >>example.txt
   git add example.txt
   git commit -q -m "change 1"
 )
 
 run_review() {
   local verdict="$1"
-  ( cd "$REPO" && \
-    PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
-    PROMPT_LOG="$PROMPT_LOG" \
-    FAKE_CONDUCTOR_VERDICT="$verdict" \
-    CODEX_REVIEW_BASE=HEAD~1 \
-    CODEX_REVIEW_BRANCH_NAME="feature/findings-checkpoint" \
-    CODEX_REVIEW_DISABLE_CACHE=1 \
-    TOUCHSTONE_REVIEW_LOG=/dev/null \
-    bash "$TOUCHSTONE_ROOT/scripts/codex-review.sh" \
-    > "$TEST_DIR/run-$verdict.out" 2>&1 \
+  (
+    cd "$REPO" \
+      && PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        PROMPT_LOG="$PROMPT_LOG" \
+        FAKE_CONDUCTOR_VERDICT="$verdict" \
+        CODEX_REVIEW_BASE=HEAD~1 \
+        CODEX_REVIEW_BRANCH_NAME="feature/findings-checkpoint" \
+        CODEX_REVIEW_DISABLE_CACHE=1 \
+        TOUCHSTONE_REVIEW_LOG=/dev/null \
+        bash "$TOUCHSTONE_ROOT/scripts/codex-review.sh" \
+        >"$TEST_DIR/run-$verdict.out" 2>&1
   ) || true
 }
 
 ERRORS=0
-fail() { echo "FAIL: $*" >&2; ERRORS=$((ERRORS + 1)); }
+fail() {
+  echo "FAIL: $*" >&2
+  ERRORS=$((ERRORS + 1))
+}
 
 findings_file() {
   # git rev-parse --git-path returns a path relative to the repo it ran
   # in; we resolve it against $REPO so the assertion can run from any cwd.
   local rel
-  rel="$( cd "$REPO" && git rev-parse --git-path touchstone/reviewer-findings/feature_findings-checkpoint.findings )"
+  rel="$(cd "$REPO" && git rev-parse --git-path touchstone/reviewer-findings/feature_findings-checkpoint.findings)"
   case "$rel" in
     /*) printf '%s' "$rel" ;;
-    *)  printf '%s/%s' "$REPO" "$rel" ;;
+    *) printf '%s/%s' "$REPO" "$rel" ;;
   esac
 }
 
@@ -111,7 +115,7 @@ findings_file() {
 # Step 1: a BLOCKED review must persist its findings.
 # ---------------------------------------------------------------------------
 echo "==> Step 1: BLOCKED review writes findings file"
-: > "$PROMPT_LOG"
+: >"$PROMPT_LOG"
 run_review BLOCKED
 
 FINDINGS_FILE="$(findings_file)"
@@ -136,9 +140,9 @@ fi
 # checkpoint in the prompt and refresh the findings file.
 # ---------------------------------------------------------------------------
 echo "==> Step 2: descendant HEAD prepends verification checkpoint"
-( cd "$REPO" && printf 'change 2\n' >> example.txt && git add example.txt && git commit -q -m "change 2" )
+(cd "$REPO" && printf 'change 2\n' >>example.txt && git add example.txt && git commit -q -m "change 2")
 
-: > "$PROMPT_LOG"
+: >"$PROMPT_LOG"
 run_review BLOCKED
 
 if ! grep -q 'Prior review findings — verify, do not restart' "$PROMPT_LOG"; then
@@ -158,9 +162,9 @@ fi
 # Step 3: a CLEAN review clears the findings file.
 # ---------------------------------------------------------------------------
 echo "==> Step 3: CLEAN review clears findings file"
-( cd "$REPO" && printf 'change 3\n' >> example.txt && git add example.txt && git commit -q -m "change 3" )
+(cd "$REPO" && printf 'change 3\n' >>example.txt && git add example.txt && git commit -q -m "change 3")
 
-: > "$PROMPT_LOG"
+: >"$PROMPT_LOG"
 run_review CLEAN
 if [ -f "$FINDINGS_FILE" ]; then
   fail "CLEAN review did not clear findings file at $FINDINGS_FILE"
@@ -174,7 +178,7 @@ echo "==> Step 4: orphaned prior HEAD is treated as blank slate"
 
 # Re-record findings, then force-reset the branch so prior_head is no
 # longer in the repo.
-: > "$PROMPT_LOG"
+: >"$PROMPT_LOG"
 run_review BLOCKED
 [ -f "$FINDINGS_FILE" ] || fail "could not re-create findings file for step 4"
 
@@ -184,7 +188,7 @@ run_review BLOCKED
   git gc --prune=now >/dev/null 2>&1 || true
 )
 
-: > "$PROMPT_LOG"
+: >"$PROMPT_LOG"
 run_review BLOCKED
 if grep -q 'Prior review findings — verify, do not restart' "$PROMPT_LOG"; then
   fail "blank-slate prompt unexpectedly contained a verification checkpoint after force-reset"

--- a/tests/test-review-hook.sh
+++ b/tests/test-review-hook.sh
@@ -49,21 +49,21 @@ mkdir -p "$FAKE_BIN"
 setup_test_repo "$REPO_DIR"
 
 cp "$TOUCHSTONE_ROOT/.codex-review.toml" "$REPO_DIR/.codex-review.toml"
-printf 'base\n' > "$REPO_DIR/example.txt"
+printf 'base\n' >"$REPO_DIR/example.txt"
 git -C "$REPO_DIR" add .codex-review.toml example.txt
 git -C "$REPO_DIR" commit -m "base" >/dev/null 2>&1
 
-printf 'changed\n' >> "$REPO_DIR/example.txt"
+printf 'changed\n' >>"$REPO_DIR/example.txt"
 git -C "$REPO_DIR" add example.txt
 git -C "$REPO_DIR" commit -m "change" >/dev/null 2>&1
 
-cat > "$FAKE_BIN/gh" <<'EOF'
+cat >"$FAKE_BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 echo "main"
 EOF
 
-cat > "$FAKE_BIN/conductor" <<'EOF'
+cat >"$FAKE_BIN/conductor" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 if [ "${1:-}" = "doctor" ]; then printf '{"providers":[{"configured":true}]}\n'; exit 0; fi
@@ -96,7 +96,7 @@ else
 fi
 
 echo "==> Test: review hook skips feature-branch pushes but runs default-branch pushes"
-cat > "$FAKE_BIN/conductor" <<'EOF'
+cat >"$FAKE_BIN/conductor" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 if [ "${1:-}" = "doctor" ]; then printf '{"providers":[{"configured":true}]}\n'; exit 0; fi
@@ -104,7 +104,7 @@ printf 'called\n' >> "$CODEX_CALLS_FILE"
 printf 'CODEX_REVIEW_CLEAN\n'
 EOF
 chmod +x "$FAKE_BIN/conductor"
-: > "$CODEX_CALLS_FILE"
+: >"$CODEX_CALLS_FILE"
 
 (
   cd "$REPO_DIR"
@@ -115,10 +115,10 @@ chmod +x "$FAKE_BIN/conductor"
     PRE_COMMIT_REMOTE_BRANCH="refs/heads/feature/test" \
     CODEX_REVIEW_BASE="HEAD~1" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
-    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$TEST_DIR/feature-push-output.txt" 2>&1
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$TEST_DIR/feature-push-output.txt" 2>&1
 )
 
-CODEX_CALL_COUNT="$(wc -l < "$CODEX_CALLS_FILE" | tr -d ' ')"
+CODEX_CALL_COUNT="$(wc -l <"$CODEX_CALLS_FILE" | tr -d ' ')"
 if [ "$CODEX_CALL_COUNT" = "0" ] && grep -q 'skipping push to feature/test' "$TEST_DIR/feature-push-output.txt"; then
   echo "==> PASS: feature-branch push skipped review"
 else
@@ -140,7 +140,7 @@ fi
     bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >/dev/null
 )
 
-CODEX_CALL_COUNT="$(wc -l < "$CODEX_CALLS_FILE" | tr -d ' ')"
+CODEX_CALL_COUNT="$(wc -l <"$CODEX_CALLS_FILE" | tr -d ' ')"
 if [ "$CODEX_CALL_COUNT" = "1" ]; then
   echo "==> PASS: default-branch push ran review"
 else
@@ -163,11 +163,11 @@ git -C "$FIRSTPUSH_REPO" config user.name "Touchstone Test"
 git -C "$FIRSTPUSH_REPO" config user.email "touchstone@example.com"
 cp "$TOUCHSTONE_ROOT/.codex-review.toml" "$FIRSTPUSH_REPO/.codex-review.toml"
 cp -r "$TOUCHSTONE_ROOT/lib/"* "$FIRSTPUSH_REPO/lib/"
-printf 'scaffold\n' > "$FIRSTPUSH_REPO/README.md"
+printf 'scaffold\n' >"$FIRSTPUSH_REPO/README.md"
 git -C "$FIRSTPUSH_REPO" add .codex-review.toml README.md
 git -C "$FIRSTPUSH_REPO" commit -m "initial scaffold" >/dev/null 2>&1
 
-: > "$CODEX_CALLS_FILE"
+: >"$CODEX_CALLS_FILE"
 (
   cd "$FIRSTPUSH_REPO"
   PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
@@ -176,10 +176,10 @@ git -C "$FIRSTPUSH_REPO" commit -m "initial scaffold" >/dev/null 2>&1
     PRE_COMMIT_LOCAL_BRANCH="refs/heads/main" \
     PRE_COMMIT_REMOTE_BRANCH="refs/heads/main" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
-    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$FIRSTPUSH_OUTPUT" 2>&1
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$FIRSTPUSH_OUTPUT" 2>&1
 )
 
-CODEX_CALL_COUNT="$(wc -l < "$CODEX_CALLS_FILE" | tr -d ' ')"
+CODEX_CALL_COUNT="$(wc -l <"$CODEX_CALLS_FILE" | tr -d ' ')"
 if [ "$CODEX_CALL_COUNT" = "0" ] \
   && grep -q 'first push on a fresh scaffold' "$FIRSTPUSH_OUTPUT" \
   && grep -q 'HEAD is the initial commit' "$FIRSTPUSH_OUTPUT"; then
@@ -196,11 +196,11 @@ echo "==> Test: review hook does NOT skip when HEAD has 2+ commits on default br
 # first-push exemption must turn off — otherwise any push of only two commits
 # to the default branch would also skip review, which is the opposite of what
 # we want for a stacked hotfix flow.
-printf 'second\n' >> "$FIRSTPUSH_REPO/README.md"
+printf 'second\n' >>"$FIRSTPUSH_REPO/README.md"
 git -C "$FIRSTPUSH_REPO" add README.md
 git -C "$FIRSTPUSH_REPO" commit -m "second commit" >/dev/null 2>&1
 
-: > "$CODEX_CALLS_FILE"
+: >"$CODEX_CALLS_FILE"
 (
   cd "$FIRSTPUSH_REPO"
   PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
@@ -210,10 +210,10 @@ git -C "$FIRSTPUSH_REPO" commit -m "second commit" >/dev/null 2>&1
     PRE_COMMIT_REMOTE_BRANCH="refs/heads/main" \
     CODEX_REVIEW_BASE="HEAD~1" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
-    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$TEST_DIR/firstpush-second-output.txt" 2>&1
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$TEST_DIR/firstpush-second-output.txt" 2>&1
 )
 
-CODEX_CALL_COUNT="$(wc -l < "$CODEX_CALLS_FILE" | tr -d ' ')"
+CODEX_CALL_COUNT="$(wc -l <"$CODEX_CALLS_FILE" | tr -d ' ')"
 if [ "$CODEX_CALL_COUNT" = "1" ] \
   && ! grep -q 'first push on a fresh scaffold' "$TEST_DIR/firstpush-second-output.txt"; then
   echo "==> PASS: second-commit push on default branch ran review (first-push exemption did not misfire)"
@@ -225,7 +225,7 @@ else
 fi
 
 echo "==> Test: review hook skips nested Codex review subprocesses"
-: > "$CODEX_CALLS_FILE"
+: >"$CODEX_CALLS_FILE"
 
 (
   cd "$REPO_DIR"
@@ -234,10 +234,10 @@ echo "==> Test: review hook skips nested Codex review subprocesses"
     CODEX_REVIEW_IN_PROGRESS=1 \
     CODEX_REVIEW_BASE="HEAD~1" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
-    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$TEST_DIR/nested-review-output.txt" 2>&1
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$TEST_DIR/nested-review-output.txt" 2>&1
 )
 
-CODEX_CALL_COUNT="$(wc -l < "$CODEX_CALLS_FILE" | tr -d ' ')"
+CODEX_CALL_COUNT="$(wc -l <"$CODEX_CALLS_FILE" | tr -d ' ')"
 if [ "$CODEX_CALL_COUNT" = "0" ] && grep -q 'skipping nested review' "$TEST_DIR/nested-review-output.txt"; then
   echo "==> PASS: nested review skipped"
 else
@@ -249,7 +249,7 @@ fi
 
 echo "==> Test: review hook caches exact clean reviews"
 rm -rf "$(git -C "$REPO_DIR" rev-parse --absolute-git-dir)/touchstone/codex-review-clean"
-cat > "$FAKE_BIN/conductor" <<'EOF'
+cat >"$FAKE_BIN/conductor" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 if [ "${1:-}" = "doctor" ]; then printf '{"providers":[{"configured":true}]}\n'; exit 0; fi
@@ -257,7 +257,7 @@ printf 'called\n' >> "$CODEX_CALLS_FILE"
 printf 'CODEX_REVIEW_CLEAN\n'
 EOF
 chmod +x "$FAKE_BIN/conductor"
-: > "$CODEX_CALLS_FILE"
+: >"$CODEX_CALLS_FILE"
 
 (
   cd "$REPO_DIR"
@@ -272,10 +272,10 @@ chmod +x "$FAKE_BIN/conductor"
   PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
     CODEX_CALLS_FILE="$CODEX_CALLS_FILE" \
     CODEX_REVIEW_BASE="HEAD~1" \
-    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$CACHE_OUTPUT" 2>&1
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$CACHE_OUTPUT" 2>&1
 )
 
-CODEX_CALL_COUNT="$(wc -l < "$CODEX_CALLS_FILE" | tr -d ' ')"
+CODEX_CALL_COUNT="$(wc -l <"$CODEX_CALLS_FILE" | tr -d ' ')"
 if [ "$CODEX_CALL_COUNT" = "1" ] && grep -q 'previously passed for this exact diff' "$CACHE_OUTPUT"; then
   echo "==> PASS: clean review cache skipped the repeated review call"
 else
@@ -294,7 +294,7 @@ fi
     bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >/dev/null
 )
 
-CODEX_CALL_COUNT="$(wc -l < "$CODEX_CALLS_FILE" | tr -d ' ')"
+CODEX_CALL_COUNT="$(wc -l <"$CODEX_CALLS_FILE" | tr -d ' ')"
 if [ "$CODEX_CALL_COUNT" = "2" ]; then
   echo "==> PASS: CODEX_REVIEW_DISABLE_CACHE forces a fresh review"
 else
@@ -315,7 +315,7 @@ echo "==> Test: changing conductor knobs invalidates the cache"
     TOUCHSTONE_CONDUCTOR_WITH=claude \
     bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >/dev/null
 )
-CODEX_CALL_COUNT="$(wc -l < "$CODEX_CALLS_FILE" | tr -d ' ')"
+CODEX_CALL_COUNT="$(wc -l <"$CODEX_CALLS_FILE" | tr -d ' ')"
 if [ "$CODEX_CALL_COUNT" = "3" ]; then
   echo "==> PASS: TOUCHSTONE_CONDUCTOR_WITH change invalidated cache"
 else
@@ -335,7 +335,7 @@ fi
     TOUCHSTONE_CONDUCTOR_WITH=claude \
     bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >/dev/null
 )
-CODEX_CALL_COUNT="$(wc -l < "$CODEX_CALLS_FILE" | tr -d ' ')"
+CODEX_CALL_COUNT="$(wc -l <"$CODEX_CALLS_FILE" | tr -d ' ')"
 if [ "$CODEX_CALL_COUNT" = "3" ]; then
   echo "==> PASS: same conductor knobs hit the new cache entry"
 else
@@ -354,7 +354,7 @@ fi
     TOUCHSTONE_CONDUCTOR_EFFORT=low \
     bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >/dev/null
 )
-CODEX_CALL_COUNT="$(wc -l < "$CODEX_CALLS_FILE" | tr -d ' ')"
+CODEX_CALL_COUNT="$(wc -l <"$CODEX_CALLS_FILE" | tr -d ' ')"
 if [ "$CODEX_CALL_COUNT" = "4" ]; then
   echo "==> PASS: TOUCHSTONE_CONDUCTOR_EFFORT change invalidated cache"
 else
@@ -372,7 +372,7 @@ echo "==> Test: changing prompt context mode invalidates the cache"
     CODEX_REVIEW_CONTEXT_MODE=full \
     bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >/dev/null
 )
-CODEX_CALL_COUNT="$(wc -l < "$CODEX_CALLS_FILE" | tr -d ' ')"
+CODEX_CALL_COUNT="$(wc -l <"$CODEX_CALLS_FILE" | tr -d ' ')"
 if [ "$CODEX_CALL_COUNT" = "5" ]; then
   echo "==> PASS: CODEX_REVIEW_CONTEXT_MODE=full invalidated bounded-context cache"
 else
@@ -389,7 +389,7 @@ fi
     CODEX_REVIEW_CONTEXT_MODE=full \
     bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >/dev/null
 )
-CODEX_CALL_COUNT="$(wc -l < "$CODEX_CALLS_FILE" | tr -d ' ')"
+CODEX_CALL_COUNT="$(wc -l <"$CODEX_CALLS_FILE" | tr -d ' ')"
 if [ "$CODEX_CALL_COUNT" = "5" ]; then
   echo "==> PASS: repeated full-context review hit its own cache entry"
 else
@@ -399,7 +399,7 @@ else
 fi
 
 echo "==> Test: review hook preserves # inside quoted unsafe_paths"
-cat > "$FAKE_BIN/conductor" <<'EOF'
+cat >"$FAKE_BIN/conductor" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 if [ "${1:-}" = "doctor" ]; then printf '{"providers":[{"configured":true}]}\n'; exit 0; fi
@@ -412,10 +412,10 @@ chmod +x "$FAKE_BIN/conductor"
   printf '[codex_review]\n'
   printf 'safe_by_default = true\n'
   printf 'unsafe_paths = ["src/#secret/", "lib/ok/"] # trailing comment\n'
-} > "$REPO_DIR/.codex-review.toml"
+} >"$REPO_DIR/.codex-review.toml"
 git -C "$REPO_DIR" add .codex-review.toml
 git -C "$REPO_DIR" commit -m "quoted unsafe paths" >/dev/null 2>&1
-printf 'changed again\n' >> "$REPO_DIR/example.txt"
+printf 'changed again\n' >>"$REPO_DIR/example.txt"
 git -C "$REPO_DIR" add example.txt
 git -C "$REPO_DIR" commit -m "change again" >/dev/null 2>&1
 
@@ -444,16 +444,16 @@ setup_test_repo "$REPO_UNSAFE"
   printf '[codex_review]\n'
   printf 'safe_by_default = true\n'
   printf 'unsafe_paths = ["templates/"]\n'
-} > "$REPO_UNSAFE/.codex-review.toml"
-printf 'base\n' > "$REPO_UNSAFE/templates/AGENTS.md"
-printf 'base\n' > "$REPO_UNSAFE/example.txt"
+} >"$REPO_UNSAFE/.codex-review.toml"
+printf 'base\n' >"$REPO_UNSAFE/templates/AGENTS.md"
+printf 'base\n' >"$REPO_UNSAFE/example.txt"
 git -C "$REPO_UNSAFE" add .codex-review.toml templates/AGENTS.md example.txt
 git -C "$REPO_UNSAFE" commit -m "base" >/dev/null 2>&1
-printf 'changed\n' >> "$REPO_UNSAFE/example.txt"
+printf 'changed\n' >>"$REPO_UNSAFE/example.txt"
 git -C "$REPO_UNSAFE" add example.txt
 git -C "$REPO_UNSAFE" commit -m "change" >/dev/null 2>&1
 
-cat > "$FAKE_BIN/conductor" <<'EOF'
+cat >"$FAKE_BIN/conductor" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 if [ "${1:-}" = "doctor" ]; then printf '{"providers":[{"configured":true}]}\n'; exit 0; fi
@@ -469,7 +469,7 @@ set +e
   cd "$REPO_UNSAFE"
   PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
     CODEX_REVIEW_BASE="HEAD~1" \
-    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$UNSAFE_OUTPUT" 2>&1
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$UNSAFE_OUTPUT" 2>&1
 )
 UNSAFE_EXIT=$?
 set -e
@@ -509,10 +509,10 @@ CODEX_ARGS_FILE="$TEST_DIR/conductor-args.txt"
 setup_cascade_repo() {
   rm -rf "$CASCADE_REPO"
   setup_test_repo "$CASCADE_REPO"
-  printf 'base\n' > "$CASCADE_REPO/example.txt"
+  printf 'base\n' >"$CASCADE_REPO/example.txt"
   git -C "$CASCADE_REPO" add example.txt
   git -C "$CASCADE_REPO" commit -m "base" >/dev/null 2>&1
-  printf 'changed\n' >> "$CASCADE_REPO/example.txt"
+  printf 'changed\n' >>"$CASCADE_REPO/example.txt"
   git -C "$CASCADE_REPO" add example.txt
   git -C "$CASCADE_REPO" commit -m "change" >/dev/null 2>&1
 }
@@ -520,10 +520,10 @@ setup_cascade_repo() {
 setup_mode_repo() {
   rm -rf "$MODE_REPO"
   setup_test_repo "$MODE_REPO"
-  printf 'base\n' > "$MODE_REPO/example.txt"
+  printf 'base\n' >"$MODE_REPO/example.txt"
   git -C "$MODE_REPO" add example.txt
   git -C "$MODE_REPO" commit -m "base" >/dev/null 2>&1
-  printf 'changed\n' >> "$MODE_REPO/example.txt"
+  printf 'changed\n' >>"$MODE_REPO/example.txt"
   git -C "$MODE_REPO" add example.txt
   git -C "$MODE_REPO" commit -m "change" >/dev/null 2>&1
 }
@@ -533,13 +533,13 @@ setup_cascade_repo
 {
   printf '[codex_review]\nsafe_by_default = true\n'
   printf '[review]\nreviewers = ["claude", "gemini"]\n'
-} > "$CASCADE_REPO/.codex-review.toml"
+} >"$CASCADE_REPO/.codex-review.toml"
 git -C "$CASCADE_REPO" add .codex-review.toml
 git -C "$CASCADE_REPO" commit -m "config" >/dev/null 2>&1
 
 rm -rf "$CASCADE_BIN"
 mkdir -p "$CASCADE_BIN"
-cat > "$CASCADE_BIN/gh" <<'EOF'
+cat >"$CASCADE_BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 echo "main"
 EOF
@@ -550,7 +550,7 @@ set +e
   cd "$CASCADE_REPO"
   PATH="$CASCADE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
     CODEX_REVIEW_BASE="HEAD~1" \
-    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$CASCADE_OUTPUT" 2>&1
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$CASCADE_OUTPUT" 2>&1
 )
 ALL_UNAVAIL_EXIT=$?
 set -e
@@ -574,24 +574,24 @@ setup_cascade_repo
   printf '[review]\n'
   printf 'enabled = false\n'
   printf 'reviewers = ["codex"]\n'
-} > "$CASCADE_REPO/.codex-review.toml"
+} >"$CASCADE_REPO/.codex-review.toml"
 git -C "$CASCADE_REPO" add .codex-review.toml
 git -C "$CASCADE_REPO" commit -m "review disabled" >/dev/null 2>&1
 
 rm -rf "$CASCADE_BIN"
 mkdir -p "$CASCADE_BIN"
-cat > "$CASCADE_BIN/gh" <<'EOF'
+cat >"$CASCADE_BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 echo "main"
 EOF
-cat > "$CASCADE_BIN/conductor" <<'CXEOF'
+cat >"$CASCADE_BIN/conductor" <<'CXEOF'
 #!/usr/bin/env bash
 if [ "${1:-}" = "doctor" ]; then printf '{"providers":[{"configured":true}]}\n'; exit 0; fi
 printf '%s\n' "codex-called" >> "$CASCADE_CALLS"
 printf 'CODEX_REVIEW_CLEAN\n'
 CXEOF
 chmod +x "$CASCADE_BIN/gh" "$CASCADE_BIN/conductor"
-: > "$CASCADE_CALLS"
+: >"$CASCADE_CALLS"
 
 (
   cd "$CASCADE_REPO"
@@ -599,7 +599,7 @@ chmod +x "$CASCADE_BIN/gh" "$CASCADE_BIN/conductor"
     CASCADE_CALLS="$CASCADE_CALLS" \
     CODEX_REVIEW_BASE="HEAD~1" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
-    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$CASCADE_OUTPUT" 2>&1
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$CASCADE_OUTPUT" 2>&1
 )
 
 if [ ! -s "$CASCADE_CALLS" ] && grep -q 'AI review disabled' "$CASCADE_OUTPUT"; then
@@ -615,11 +615,11 @@ echo "==> Test: CODEX_REVIEW_NO_AUTOFIX backward compat maps to review-only"
 setup_mode_repo
 rm -rf "$MODE_BIN"
 mkdir -p "$MODE_BIN"
-cat > "$MODE_BIN/gh" <<'EOF'
+cat >"$MODE_BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 echo "main"
 EOF
-cat > "$MODE_BIN/conductor" <<'CXEOF'
+cat >"$MODE_BIN/conductor" <<'CXEOF'
 #!/usr/bin/env bash
 if [ "${1:-}" = "doctor" ]; then printf '{"providers":[{"configured":true}]}\n'; exit 0; fi
 printf '%s\n' "$*" > "$CODEX_ARGS_FILE"
@@ -629,7 +629,7 @@ chmod +x "$MODE_BIN/gh" "$MODE_BIN/conductor"
 
 {
   printf '[codex_review]\nsafe_by_default = true\n'
-} > "$MODE_REPO/.codex-review.toml"
+} >"$MODE_REPO/.codex-review.toml"
 git -C "$MODE_REPO" add .codex-review.toml
 git -C "$MODE_REPO" commit -m "codex config" >/dev/null 2>&1
 
@@ -640,7 +640,7 @@ git -C "$MODE_REPO" commit -m "codex config" >/dev/null 2>&1
     CODEX_REVIEW_BASE="HEAD~1" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
     CODEX_REVIEW_NO_AUTOFIX=1 \
-    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$MODE_OUTPUT" 2>&1
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$MODE_OUTPUT" 2>&1
 )
 
 if grep -q -- '--tools Read,Grep,Glob,Bash' "$CODEX_ARGS_FILE" \
@@ -655,11 +655,11 @@ fi
 echo "==> Test: FIXED sentinel in review-only mode exits 1"
 rm -rf "$MODE_BIN"
 mkdir -p "$MODE_BIN"
-cat > "$MODE_BIN/gh" <<'EOF'
+cat >"$MODE_BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 echo "main"
 EOF
-cat > "$MODE_BIN/conductor" <<'CXEOF'
+cat >"$MODE_BIN/conductor" <<'CXEOF'
 #!/usr/bin/env bash
 if [ "${1:-}" = "doctor" ]; then printf '{"providers":[{"configured":true}]}\n'; exit 0; fi
 printf 'CODEX_REVIEW_FIXED\n'
@@ -673,7 +673,7 @@ set +e
     CODEX_REVIEW_BASE="HEAD~1" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
     CODEX_REVIEW_MODE=review-only \
-    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$MODE_OUTPUT" 2>&1
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$MODE_OUTPUT" 2>&1
 )
 FIXED_RO_EXIT=$?
 set -e
@@ -691,11 +691,11 @@ echo "==> Test: invalid mode warns and falls back to fix"
 setup_mode_repo
 rm -rf "$MODE_BIN"
 mkdir -p "$MODE_BIN"
-cat > "$MODE_BIN/gh" <<'EOF'
+cat >"$MODE_BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 echo "main"
 EOF
-cat > "$MODE_BIN/conductor" <<'CXEOF'
+cat >"$MODE_BIN/conductor" <<'CXEOF'
 #!/usr/bin/env bash
 if [ "${1:-}" = "doctor" ]; then printf '{"providers":[{"configured":true}]}\n'; exit 0; fi
 printf '%s\n' "$*" > "$CODEX_ARGS_FILE"
@@ -710,7 +710,7 @@ chmod +x "$MODE_BIN/gh" "$MODE_BIN/conductor"
     CODEX_REVIEW_BASE="HEAD~1" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
     CODEX_REVIEW_MODE=invalid \
-    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$MODE_OUTPUT" 2>&1
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$MODE_OUTPUT" 2>&1
 )
 
 if grep -q "Invalid mode" "$MODE_OUTPUT" \
@@ -728,11 +728,11 @@ echo "==> Test: review modes map to conductor argv/tools without sandbox flag"
 setup_mode_repo
 rm -rf "$MODE_BIN"
 mkdir -p "$MODE_BIN"
-cat > "$MODE_BIN/gh" <<'EOF'
+cat >"$MODE_BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 echo "main"
 EOF
-cat > "$MODE_BIN/conductor" <<'CXEOF'
+cat >"$MODE_BIN/conductor" <<'CXEOF'
 #!/usr/bin/env bash
 if [ "${1:-}" = "doctor" ]; then printf '{"providers":[{"configured":true}]}\n'; exit 0; fi
 printf '%s\n' "$*" > "$CODEX_ARGS_FILE"
@@ -745,7 +745,7 @@ check_mode_argv() {
   local mode="$1"
   local expected_subcommand="$2"
   local expected_tools="$3"
-  : > "$CODEX_ARGS_FILE"
+  : >"$CODEX_ARGS_FILE"
   (
     cd "$MODE_REPO"
     PATH="$MODE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
@@ -753,7 +753,7 @@ check_mode_argv() {
       CODEX_REVIEW_BASE="HEAD~1" \
       CODEX_REVIEW_DISABLE_CACHE=1 \
       CODEX_REVIEW_MODE="$mode" \
-      bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$MODE_OUTPUT" 2>&1
+      bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$MODE_OUTPUT" 2>&1
   )
 
   if ! grep -q "^$expected_subcommand" "$CODEX_ARGS_FILE"; then
@@ -806,10 +806,10 @@ TIMEOUT_CHILD_PID_FILE="$TEST_DIR/timeout-reviewer-child.pid"
 setup_timeout_repo() {
   rm -rf "$TIMEOUT_REPO"
   setup_test_repo "$TIMEOUT_REPO"
-  printf 'base\n' > "$TIMEOUT_REPO/example.txt"
+  printf 'base\n' >"$TIMEOUT_REPO/example.txt"
   git -C "$TIMEOUT_REPO" add example.txt
   git -C "$TIMEOUT_REPO" commit -m "base" >/dev/null 2>&1
-  printf 'changed\n' >> "$TIMEOUT_REPO/example.txt"
+  printf 'changed\n' >>"$TIMEOUT_REPO/example.txt"
   git -C "$TIMEOUT_REPO" add example.txt
   git -C "$TIMEOUT_REPO" commit -m "change" >/dev/null 2>&1
 }
@@ -834,11 +834,11 @@ setup_timeout_repo
 TIMEOUT_BIN="$TEST_DIR/timeout-bin"
 rm -rf "$TIMEOUT_BIN"
 mkdir -p "$TIMEOUT_BIN"
-cat > "$TIMEOUT_BIN/gh" <<'EOF'
+cat >"$TIMEOUT_BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 echo "main"
 EOF
-cat > "$TIMEOUT_BIN/conductor" <<'CXEOF'
+cat >"$TIMEOUT_BIN/conductor" <<'CXEOF'
 #!/usr/bin/env bash
 if [ "${1:-}" = "doctor" ]; then printf '{"providers":[{"configured":true}]}\n'; exit 0; fi
 printf 'CODEX_REVIEW_CLEAN\n'
@@ -852,7 +852,7 @@ set +e
     CODEX_REVIEW_BASE="HEAD~1" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
     CODEX_REVIEW_TIMEOUT=13 \
-    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$TIMEOUT_OUTPUT" 2>&1
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$TIMEOUT_OUTPUT" 2>&1
 )
 CLEAN_TIMEOUT_EXIT=$?
 set -e
@@ -871,11 +871,11 @@ setup_timeout_repo
 TIMEOUT_BIN="$TEST_DIR/timeout-bin"
 rm -rf "$TIMEOUT_BIN"
 mkdir -p "$TIMEOUT_BIN"
-cat > "$TIMEOUT_BIN/gh" <<'EOF'
+cat >"$TIMEOUT_BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 echo "main"
 EOF
-cat > "$TIMEOUT_BIN/conductor" <<'CXEOF'
+cat >"$TIMEOUT_BIN/conductor" <<'CXEOF'
 #!/usr/bin/env bash
 if [ "${1:-}" = "doctor" ]; then printf '{"providers":[{"configured":true}]}\n'; exit 0; fi
 sleep 999 &
@@ -896,7 +896,7 @@ set +e
     CODEX_REVIEW_BASE="HEAD~1" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
     CODEX_REVIEW_TIMEOUT=2 \
-    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$TIMEOUT_OUTPUT" 2>&1
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$TIMEOUT_OUTPUT" 2>&1
 )
 TIMEOUT_EXIT=$?
 set -e
@@ -933,11 +933,11 @@ echo "==> Test: on_error=fail-closed blocks push on reviewer crash"
 setup_timeout_repo
 rm -rf "$TIMEOUT_BIN"
 mkdir -p "$TIMEOUT_BIN"
-cat > "$TIMEOUT_BIN/gh" <<'EOF'
+cat >"$TIMEOUT_BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 echo "main"
 EOF
-cat > "$TIMEOUT_BIN/conductor" <<'CXEOF'
+cat >"$TIMEOUT_BIN/conductor" <<'CXEOF'
 #!/usr/bin/env bash
 if [ "${1:-}" = "doctor" ]; then printf '{"providers":[{"configured":true}]}\n'; exit 0; fi
 exit 1
@@ -951,7 +951,7 @@ set +e
     CODEX_REVIEW_BASE="HEAD~1" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
     CODEX_REVIEW_ON_ERROR=fail-closed \
-    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$TIMEOUT_OUTPUT" 2>&1
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$TIMEOUT_OUTPUT" 2>&1
 )
 CLOSED_EXIT=$?
 set -e
@@ -973,7 +973,7 @@ set +e
   PATH="$TIMEOUT_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
     CODEX_REVIEW_BASE="HEAD~1" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
-    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$TIMEOUT_OUTPUT" 2>&1
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$TIMEOUT_OUTPUT" 2>&1
 )
 OPEN_EXIT=$?
 set -e
@@ -992,11 +992,11 @@ echo "==> Test: on_error=fail-closed blocks on malformed output"
 setup_timeout_repo
 rm -rf "$TIMEOUT_BIN"
 mkdir -p "$TIMEOUT_BIN"
-cat > "$TIMEOUT_BIN/gh" <<'EOF'
+cat >"$TIMEOUT_BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 echo "main"
 EOF
-cat > "$TIMEOUT_BIN/conductor" <<'CXEOF'
+cat >"$TIMEOUT_BIN/conductor" <<'CXEOF'
 #!/usr/bin/env bash
 if [ "${1:-}" = "doctor" ]; then printf '{"providers":[{"configured":true}]}\n'; exit 0; fi
 echo "no sentinel here"
@@ -1010,7 +1010,7 @@ set +e
     CODEX_REVIEW_BASE="HEAD~1" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
     CODEX_REVIEW_ON_ERROR=fail-closed \
-    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$TIMEOUT_OUTPUT" 2>&1
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$TIMEOUT_OUTPUT" 2>&1
 )
 MALFORMED_EXIT=$?
 set -e
@@ -1035,10 +1035,10 @@ CTX_PROMPT="$TEST_DIR/ctx-prompt.txt"
 setup_ctx_repo() {
   rm -rf "$CTX_REPO"
   setup_test_repo "$CTX_REPO"
-  printf 'base\n' > "$CTX_REPO/example.txt"
+  printf 'base\n' >"$CTX_REPO/example.txt"
   git -C "$CTX_REPO" add example.txt
   git -C "$CTX_REPO" commit -m "base" >/dev/null 2>&1
-  printf 'changed\n' >> "$CTX_REPO/example.txt"
+  printf 'changed\n' >>"$CTX_REPO/example.txt"
   git -C "$CTX_REPO" add example.txt
   git -C "$CTX_REPO" commit -m "change" >/dev/null 2>&1
 }
@@ -1048,11 +1048,11 @@ CTX_BIN="$TEST_DIR/ctx-bin"
 setup_ctx_bin() {
   rm -rf "$CTX_BIN"
   mkdir -p "$CTX_BIN"
-  cat > "$CTX_BIN/gh" <<'EOF'
+  cat >"$CTX_BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 echo "main"
 EOF
-  cat > "$CTX_BIN/conductor" <<'CXEOF'
+  cat >"$CTX_BIN/conductor" <<'CXEOF'
 #!/usr/bin/env bash
 if [ "${1:-}" = "doctor" ]; then printf '{"providers":[{"configured":true}]}\n'; exit 0; fi
 prompt="$(cat)"
@@ -1065,7 +1065,7 @@ CXEOF
 echo "==> Test: context file at repo root is appended to prompt"
 setup_ctx_repo
 setup_ctx_bin
-printf 'UNIQUE_CTX_MARKER_12345\n' > "$CTX_REPO/.codex-review-context.md"
+printf 'UNIQUE_CTX_MARKER_12345\n' >"$CTX_REPO/.codex-review-context.md"
 git -C "$CTX_REPO" add .codex-review-context.md
 git -C "$CTX_REPO" commit -m "add context" >/dev/null 2>&1
 
@@ -1075,7 +1075,7 @@ git -C "$CTX_REPO" commit -m "add context" >/dev/null 2>&1
     CTX_PROMPT="$CTX_PROMPT" \
     CODEX_REVIEW_BASE="HEAD~1" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
-    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$CTX_OUTPUT" 2>&1
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$CTX_OUTPUT" 2>&1
 )
 
 if grep -q 'UNIQUE_CTX_MARKER_12345' "$CTX_PROMPT" \
@@ -1090,7 +1090,7 @@ echo "==> Test: context file under .github/ is discovered"
 setup_ctx_repo
 setup_ctx_bin
 mkdir -p "$CTX_REPO/.github"
-printf 'GITHUB_CTX_MARKER_67890\n' > "$CTX_REPO/.github/codex-review-context.md"
+printf 'GITHUB_CTX_MARKER_67890\n' >"$CTX_REPO/.github/codex-review-context.md"
 git -C "$CTX_REPO" add .github/codex-review-context.md
 git -C "$CTX_REPO" commit -m "add github context" >/dev/null 2>&1
 
@@ -1100,7 +1100,7 @@ git -C "$CTX_REPO" commit -m "add github context" >/dev/null 2>&1
     CTX_PROMPT="$CTX_PROMPT" \
     CODEX_REVIEW_BASE="HEAD~1" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
-    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$CTX_OUTPUT" 2>&1
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$CTX_OUTPUT" 2>&1
 )
 
 if grep -q 'GITHUB_CTX_MARKER_67890' "$CTX_PROMPT"; then
@@ -1119,7 +1119,7 @@ setup_ctx_bin
     CTX_PROMPT="$CTX_PROMPT" \
     CODEX_REVIEW_BASE="HEAD~1" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
-    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$CTX_OUTPUT" 2>&1
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$CTX_OUTPUT" 2>&1
 )
 
 if ! grep -q 'Review context' "$CTX_OUTPUT" \
@@ -1133,11 +1133,11 @@ fi
 echo "==> Test: small/simple diffs use bounded prompt context"
 setup_ctx_repo
 setup_ctx_bin
-printf 'AGENTS_FULL_CONTEXT_MARKER\n' > "$CTX_REPO/AGENTS.md"
-printf 'CLAUDE_FULL_CONTEXT_MARKER\n' > "$CTX_REPO/CLAUDE.md"
+printf 'AGENTS_FULL_CONTEXT_MARKER\n' >"$CTX_REPO/AGENTS.md"
+printf 'CLAUDE_FULL_CONTEXT_MARKER\n' >"$CTX_REPO/CLAUDE.md"
 git -C "$CTX_REPO" add AGENTS.md CLAUDE.md
 git -C "$CTX_REPO" commit -m "add steering files" >/dev/null 2>&1
-printf 'small prompt context change\n' >> "$CTX_REPO/example.txt"
+printf 'small prompt context change\n' >>"$CTX_REPO/example.txt"
 git -C "$CTX_REPO" add example.txt
 git -C "$CTX_REPO" commit -m "small prompt context change" >/dev/null 2>&1
 
@@ -1147,7 +1147,7 @@ git -C "$CTX_REPO" commit -m "small prompt context change" >/dev/null 2>&1
     CTX_PROMPT="$CTX_PROMPT" \
     CODEX_REVIEW_BASE="HEAD~1" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
-    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$CTX_OUTPUT" 2>&1
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$CTX_OUTPUT" 2>&1
 )
 
 if grep -q 'Full AGENTS.md and CLAUDE.md context was intentionally omitted' "$CTX_PROMPT" \
@@ -1172,7 +1172,7 @@ setup_ctx_bin
     CODEX_REVIEW_BASE="HEAD~1" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
     CODEX_REVIEW_CONTEXT_SMALL_MAX_DIFF_LINES=1 \
-    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$CTX_OUTPUT" 2>&1
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$CTX_OUTPUT" 2>&1
 )
 
 if grep -q 'Full project context is required because large diff' "$CTX_PROMPT" \
@@ -1189,7 +1189,7 @@ fi
 echo "==> Test: architectural files keep full AGENTS/CLAUDE context"
 setup_ctx_repo
 setup_ctx_bin
-printf 'architectural review guidance\n' > "$CTX_REPO/AGENTS.md"
+printf 'architectural review guidance\n' >"$CTX_REPO/AGENTS.md"
 git -C "$CTX_REPO" add AGENTS.md
 git -C "$CTX_REPO" commit -m "touch agents" >/dev/null 2>&1
 
@@ -1199,7 +1199,7 @@ git -C "$CTX_REPO" commit -m "touch agents" >/dev/null 2>&1
     CTX_PROMPT="$CTX_PROMPT" \
     CODEX_REVIEW_BASE="HEAD~1" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
-    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$CTX_OUTPUT" 2>&1
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$CTX_OUTPUT" 2>&1
 )
 
 if grep -q 'Full project context is required because architectural path AGENTS.md' "$CTX_PROMPT" \
@@ -1217,11 +1217,11 @@ setup_ctx_bin
 {
   printf '[codex_review]\n'
   printf 'unsafe_paths = ["sensitive/"]\n'
-} > "$CTX_REPO/.codex-review.toml"
+} >"$CTX_REPO/.codex-review.toml"
 git -C "$CTX_REPO" add .codex-review.toml
 git -C "$CTX_REPO" commit -m "configure unsafe path" >/dev/null 2>&1
 mkdir -p "$CTX_REPO/sensitive"
-printf 'secret change\n' > "$CTX_REPO/sensitive/config.txt"
+printf 'secret change\n' >"$CTX_REPO/sensitive/config.txt"
 git -C "$CTX_REPO" add sensitive/config.txt
 git -C "$CTX_REPO" commit -m "touch sensitive config" >/dev/null 2>&1
 
@@ -1231,7 +1231,7 @@ git -C "$CTX_REPO" commit -m "touch sensitive config" >/dev/null 2>&1
     CTX_PROMPT="$CTX_PROMPT" \
     CODEX_REVIEW_BASE="HEAD~1" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
-    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$CTX_OUTPUT" 2>&1
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$CTX_OUTPUT" 2>&1
 )
 
 if grep -q 'Full project context is required because high-risk path sensitive/config.txt' "$CTX_PROMPT" \
@@ -1249,11 +1249,11 @@ setup_ctx_bin
 {
   printf '[review.context]\n'
   printf 'full_context_paths = ["docs/"]\n'
-} > "$CTX_REPO/.codex-review.toml"
+} >"$CTX_REPO/.codex-review.toml"
 git -C "$CTX_REPO" add .codex-review.toml
 git -C "$CTX_REPO" commit -m "configure full context path" >/dev/null 2>&1
 mkdir -p "$CTX_REPO/docs"
-printf 'doc change\n' > "$CTX_REPO/docs/note.md"
+printf 'doc change\n' >"$CTX_REPO/docs/note.md"
 git -C "$CTX_REPO" add docs/note.md
 git -C "$CTX_REPO" commit -m "touch docs" >/dev/null 2>&1
 
@@ -1263,7 +1263,7 @@ git -C "$CTX_REPO" commit -m "touch docs" >/dev/null 2>&1
     CTX_PROMPT="$CTX_PROMPT" \
     CODEX_REVIEW_BASE="HEAD~1" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
-    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$CTX_OUTPUT" 2>&1
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$CTX_OUTPUT" 2>&1
 )
 
 if grep -q 'Full project context is required because configured full-context path docs/note.md' "$CTX_PROMPT" \
@@ -1288,7 +1288,7 @@ setup_ctx_bin
     CTX_PROMPT="$CTX_PROMPT" \
     CODEX_REVIEW_BASE="HEAD~1" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
-    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$CTX_OUTPUT" 2>&1
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$CTX_OUTPUT" 2>&1
 )
 
 if grep -q 'loading diff' "$CTX_OUTPUT" \
@@ -1318,7 +1318,7 @@ echo "==> Test: conductor route-log surfaces in transcript"
 # contain the `[conductor]` header line plus the wrapped cost/token line.
 # Uses ASCII (-> and .) intentionally — the print_route_log filter must
 # tolerate any wrap-line punctuation since it's whitespace-anchored.
-cat > "$CTX_BIN/conductor" <<'CXEOF'
+cat >"$CTX_BIN/conductor" <<'CXEOF'
 #!/usr/bin/env bash
 if [ "${1:-}" = "doctor" ]; then printf '{"providers":[{"configured":true}]}\n'; exit 0; fi
 cat >/dev/null
@@ -1327,7 +1327,7 @@ printf '            . 4.2s . 1284 tok in . 420 tok out . sandbox=read-only\n' >&
 printf 'CODEX_REVIEW_CLEAN\n'
 CXEOF
 chmod +x "$CTX_BIN/conductor"
-printf 'route log test\n' >> "$CTX_REPO/example.txt"
+printf 'route log test\n' >>"$CTX_REPO/example.txt"
 git -C "$CTX_REPO" add example.txt
 git -C "$CTX_REPO" commit -m "route log" >/dev/null 2>&1
 (
@@ -1336,7 +1336,7 @@ git -C "$CTX_REPO" commit -m "route log" >/dev/null 2>&1
     CTX_PROMPT="$CTX_PROMPT" \
     CODEX_REVIEW_BASE="HEAD~1" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
-    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$CTX_OUTPUT" 2>&1
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$CTX_OUTPUT" 2>&1
 )
 
 # Header line + the wrapped cost/token line must both reach the transcript.
@@ -1355,7 +1355,7 @@ echo "==> Test: peer review fires when [review.assist].enabled = true"
 # (peer). The primary emits a route-log to stderr naming itself, which
 # touchstone parses out to set --exclude on the peer call. The peer
 # prints distinctive text so we can assert it surfaces in the transcript.
-cat > "$CTX_BIN/conductor" <<'CXEOF'
+cat >"$CTX_BIN/conductor" <<'CXEOF'
 #!/usr/bin/env bash
 if [ "${1:-}" = "doctor" ]; then printf '{"providers":[{"configured":true}]}\n'; exit 0; fi
 subcmd="$1"; shift
@@ -1378,24 +1378,24 @@ esac
 CXEOF
 chmod +x "$CTX_BIN/conductor"
 # New commit → defeats the cache, and lets us diff vs HEAD~1.
-printf 'peer-review test\n' >> "$CTX_REPO/example.txt"
+printf 'peer-review test\n' >>"$CTX_REPO/example.txt"
 git -C "$CTX_REPO" add example.txt && git -C "$CTX_REPO" commit -m "peer review" >/dev/null 2>&1
 # Enable peer review in the project config.
 {
   cat "$CTX_REPO/.codex-review.toml"
   printf '\n[review.assist]\nenabled = true\nmax_rounds = 1\n'
-} > "$CTX_REPO/.codex-review.toml.tmp" && mv "$CTX_REPO/.codex-review.toml.tmp" "$CTX_REPO/.codex-review.toml"
+} >"$CTX_REPO/.codex-review.toml.tmp" && mv "$CTX_REPO/.codex-review.toml.tmp" "$CTX_REPO/.codex-review.toml"
 git -C "$CTX_REPO" add .codex-review.toml && git -C "$CTX_REPO" commit -m "enable assist" >/dev/null 2>&1
 
 CONDUCTOR_ARGS_LOG="$TEST_DIR/conductor-args.log"
-: > "$CONDUCTOR_ARGS_LOG"
+: >"$CONDUCTOR_ARGS_LOG"
 (
   cd "$CTX_REPO"
   PATH="$CTX_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
     CONDUCTOR_ARGS_LOG="$CONDUCTOR_ARGS_LOG" \
     CODEX_REVIEW_BASE="HEAD~2" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
-    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$CTX_OUTPUT" 2>&1
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$CTX_OUTPUT" 2>&1
 )
 
 if grep -q 'peer review' "$CTX_OUTPUT" \
@@ -1415,17 +1415,17 @@ echo "==> Test: peer review silent when [review.assist].enabled = false"
 # Reset config (strip the assist block) and rerun; peer should NOT fire.
 sed -i.bak '/\[review.assist\]/,$d' "$CTX_REPO/.codex-review.toml" && rm -f "$CTX_REPO/.codex-review.toml.bak"
 git -C "$CTX_REPO" add .codex-review.toml && git -C "$CTX_REPO" commit -m "disable assist" >/dev/null 2>&1
-printf 'another change\n' >> "$CTX_REPO/example.txt"
+printf 'another change\n' >>"$CTX_REPO/example.txt"
 git -C "$CTX_REPO" add example.txt && git -C "$CTX_REPO" commit -m "change" >/dev/null 2>&1
 
-: > "$CONDUCTOR_ARGS_LOG"
+: >"$CONDUCTOR_ARGS_LOG"
 (
   cd "$CTX_REPO"
   PATH="$CTX_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
     CONDUCTOR_ARGS_LOG="$CONDUCTOR_ARGS_LOG" \
     CODEX_REVIEW_BASE="HEAD~2" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
-    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$CTX_OUTPUT" 2>&1
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$CTX_OUTPUT" 2>&1
 )
 
 if ! grep -q '^call ' "$CONDUCTOR_ARGS_LOG" && ! grep -q 'AGREE' "$CTX_OUTPUT"; then
@@ -1448,7 +1448,7 @@ rm -f "$JSON_SUMMARY"
     CODEX_REVIEW_BASE="HEAD~1" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
     CODEX_REVIEW_SUMMARY_FILE="$JSON_SUMMARY" \
-    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$CTX_OUTPUT" 2>&1
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$CTX_OUTPUT" 2>&1
 )
 
 if [ -f "$JSON_SUMMARY" ] \
@@ -1476,12 +1476,13 @@ fi
 
 setup_skiplog_repo() {
   # setup_skiplog_repo <dir> [--with-config-toml]
-  local dir="$1"; shift || true
+  local dir="$1"
+  shift || true
   rm -rf "$dir"
   setup_test_repo "$dir"
-  printf 'base\n' > "$dir/file.txt"
+  printf 'base\n' >"$dir/file.txt"
   if [ "${1:-}" = "--with-config-toml" ]; then
-    cat > "$dir/.codex-review.toml" <<'EOF'
+    cat >"$dir/.codex-review.toml" <<'EOF'
 [review]
 enabled = true
 reviewer = "conductor"
@@ -1491,18 +1492,18 @@ effort = "max"
 EOF
   fi
   git -C "$dir" add . && git -C "$dir" commit -qm init
-  printf 'change\n' >> "$dir/file.txt"
+  printf 'change\n' >>"$dir/file.txt"
   git -C "$dir" add . && git -C "$dir" commit -qm change
 }
 
 make_skiplog_bin_with_conductor() {
   local dir="$1"
   mkdir -p "$dir"
-  cat > "$dir/gh" <<'EOF'
+  cat >"$dir/gh" <<'EOF'
 #!/usr/bin/env bash
 echo main
 EOF
-  cat > "$dir/conductor" <<'EOF'
+  cat >"$dir/conductor" <<'EOF'
 #!/usr/bin/env bash
 if [ "${1:-}" = "doctor" ]; then
   printf '{"providers":[{"configured":true}]}\n'; exit 0
@@ -1515,7 +1516,7 @@ EOF
 make_skiplog_bin_without_conductor() {
   local dir="$1"
   mkdir -p "$dir"
-  cat > "$dir/gh" <<'EOF'
+  cat >"$dir/gh" <<'EOF'
 #!/usr/bin/env bash
 echo main
 EOF
@@ -1523,11 +1524,13 @@ EOF
 }
 
 run_skiplog_hook() {
-  local repo="$1"; shift
-  local sink="$1"; shift
+  local repo="$1"
+  shift
+  local sink="$1"
+  shift
   (
     cd "$repo"
-    "$@" bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" > "$sink" 2>&1
+    "$@" bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$sink" 2>&1
   )
 }
 
@@ -1576,9 +1579,9 @@ make_skiplog_bin_without_conductor "$SKIPLOG_BIN1"
 
 run_skiplog_hook "$SKIPLOG_REPO1" "$TEST_DIR/skiplog-out1.txt" \
   env PATH="$SKIPLOG_BIN1:/usr/bin:/bin:/usr/sbin:/sbin" \
-      TOUCHSTONE_REVIEW_LOG="$SKIPLOG_LOG1" \
-      CODEX_REVIEW_BASE="HEAD~1" \
-      CODEX_REVIEW_DISABLE_CACHE=1 \
+  TOUCHSTONE_REVIEW_LOG="$SKIPLOG_LOG1" \
+  CODEX_REVIEW_BASE="HEAD~1" \
+  CODEX_REVIEW_DISABLE_CACHE=1 \
   || true
 assert_skiplog_last_reason "conductor-missing" "$SKIPLOG_LOG1" "FAIL_OPEN_DEPENDENCY_MISSING"
 
@@ -1591,22 +1594,22 @@ SKIPLOG_BIN2="$TEST_DIR/skiplog-bin2"
 SKIPLOG_LOG2="$TEST_DIR/skiplog-log2.tsv"
 rm -rf "$SKIPLOG_REPO2"
 setup_test_repo "$SKIPLOG_REPO2"
-cat > "$SKIPLOG_REPO2/.codex-review.toml" <<'EOF'
+cat >"$SKIPLOG_REPO2/.codex-review.toml" <<'EOF'
 [review]
 enabled = false
 reviewer = "conductor"
 EOF
-printf 'a\n' > "$SKIPLOG_REPO2/f.txt"
+printf 'a\n' >"$SKIPLOG_REPO2/f.txt"
 git -C "$SKIPLOG_REPO2" add . && git -C "$SKIPLOG_REPO2" commit -qm init
-printf 'b\n' >> "$SKIPLOG_REPO2/f.txt"
+printf 'b\n' >>"$SKIPLOG_REPO2/f.txt"
 git -C "$SKIPLOG_REPO2" add . && git -C "$SKIPLOG_REPO2" commit -qm change
 make_skiplog_bin_with_conductor "$SKIPLOG_BIN2"
 
 run_skiplog_hook "$SKIPLOG_REPO2" "$TEST_DIR/skiplog-out2.txt" \
   env PATH="$SKIPLOG_BIN2:/usr/bin:/bin:/usr/sbin:/sbin" \
-      TOUCHSTONE_REVIEW_LOG="$SKIPLOG_LOG2" \
-      CODEX_REVIEW_BASE="HEAD~1" \
-      CODEX_REVIEW_DISABLE_CACHE=1 \
+  TOUCHSTONE_REVIEW_LOG="$SKIPLOG_LOG2" \
+  CODEX_REVIEW_BASE="HEAD~1" \
+  CODEX_REVIEW_DISABLE_CACHE=1 \
   || true
 assert_skiplog_last_reason "config-disabled" "$SKIPLOG_LOG2" "config-disabled"
 
@@ -1625,10 +1628,10 @@ make_skiplog_bin_with_conductor "$SKIPLOG_BIN3"
 
 run_skiplog_hook "$SKIPLOG_REPO3" "$TEST_DIR/skiplog-out3.txt" \
   env PATH="$SKIPLOG_BIN3:/usr/bin:/bin:/usr/sbin:/sbin" \
-      TOUCHSTONE_REVIEW_LOG="$SKIPLOG_LOG3" \
-      CODEX_REVIEW_ENABLED=false \
-      CODEX_REVIEW_BASE="HEAD~1" \
-      CODEX_REVIEW_DISABLE_CACHE=1 \
+  TOUCHSTONE_REVIEW_LOG="$SKIPLOG_LOG3" \
+  CODEX_REVIEW_ENABLED=false \
+  CODEX_REVIEW_BASE="HEAD~1" \
+  CODEX_REVIEW_DISABLE_CACHE=1 \
   || true
 assert_skiplog_last_reason "review-disabled-by-user" "$SKIPLOG_LOG3" "review-disabled-by-user"
 
@@ -1646,10 +1649,14 @@ make_skiplog_bin_with_conductor "$SKIPLOG_BIN4"
 
 run_skiplog_hook "$SKIPLOG_REPO4" "$TEST_DIR/skiplog-out4.txt" \
   env PATH="$SKIPLOG_BIN4:/usr/bin:/bin:/usr/sbin:/sbin" \
-      TOUCHSTONE_REVIEW_LOG="$SKIPLOG_LOG4" \
-      CODEX_REVIEW_BASE="HEAD~1" \
-      CODEX_REVIEW_DISABLE_CACHE=1 \
-  || { echo "FAIL: hook exited non-zero on a clean review" >&2; cat "$TEST_DIR/skiplog-out4.txt" >&2; ERRORS=$((ERRORS + 1)); }
+  TOUCHSTONE_REVIEW_LOG="$SKIPLOG_LOG4" \
+  CODEX_REVIEW_BASE="HEAD~1" \
+  CODEX_REVIEW_DISABLE_CACHE=1 \
+  || {
+    echo "FAIL: hook exited non-zero on a clean review" >&2
+    cat "$TEST_DIR/skiplog-out4.txt" >&2
+    ERRORS=$((ERRORS + 1))
+  }
 assert_skiplog_last_reason "ran" "$SKIPLOG_LOG4" "ran"
 
 # ---------------------------------------------------------------------------
@@ -1666,22 +1673,22 @@ SKIPLOG_BIN5="$TEST_DIR/skiplog-bin5"
 SKIPLOG_LOG5="$TEST_DIR/skiplog-log5.tsv"
 rm -rf "$SKIPLOG_REPO5"
 setup_test_repo "$SKIPLOG_REPO5"
-cat > "$SKIPLOG_REPO5/.codex-review.toml" <<'EOF'
+cat >"$SKIPLOG_REPO5/.codex-review.toml" <<'EOF'
 [review
 this-is = not = valid =
 === no key here ===
 EOF
-printf 'a\n' > "$SKIPLOG_REPO5/f.txt"
+printf 'a\n' >"$SKIPLOG_REPO5/f.txt"
 git -C "$SKIPLOG_REPO5" add . && git -C "$SKIPLOG_REPO5" commit -qm init
-printf 'b\n' >> "$SKIPLOG_REPO5/f.txt"
+printf 'b\n' >>"$SKIPLOG_REPO5/f.txt"
 git -C "$SKIPLOG_REPO5" add . && git -C "$SKIPLOG_REPO5" commit -qm change
 make_skiplog_bin_with_conductor "$SKIPLOG_BIN5"
 
 run_skiplog_hook "$SKIPLOG_REPO5" "$TEST_DIR/skiplog-out5.txt" \
   env PATH="$SKIPLOG_BIN5:/usr/bin:/bin:/usr/sbin:/sbin" \
-      TOUCHSTONE_REVIEW_LOG="$SKIPLOG_LOG5" \
-      CODEX_REVIEW_BASE="HEAD~1" \
-      CODEX_REVIEW_DISABLE_CACHE=1 \
+  TOUCHSTONE_REVIEW_LOG="$SKIPLOG_LOG5" \
+  CODEX_REVIEW_BASE="HEAD~1" \
+  CODEX_REVIEW_DISABLE_CACHE=1 \
   || true
 if [ -s "$SKIPLOG_LOG5" ]; then
   echo "==> PASS: malformed TOML still produced a log entry"
@@ -1701,14 +1708,14 @@ SKIPLOG_LOG6="$TEST_DIR/skiplog-log6.tsv"
 setup_skiplog_repo "$SKIPLOG_REPO6" --with-config-toml
 make_skiplog_bin_with_conductor "$SKIPLOG_BIN6"
 
-: > "$SKIPLOG_LOG6"
+: >"$SKIPLOG_LOG6"
 i=0
 while [ "$i" -lt 1000 ]; do
-  printf 'seed-ts\trepo\tbranch\tsha\tseed\trow-%s\n' "$i" >> "$SKIPLOG_LOG6"
+  printf 'seed-ts\trepo\tbranch\tsha\tseed\trow-%s\n' "$i" >>"$SKIPLOG_LOG6"
   i=$((i + 1))
 done
 
-seeded_count="$(wc -l < "$SKIPLOG_LOG6" | tr -d ' ')"
+seeded_count="$(wc -l <"$SKIPLOG_LOG6" | tr -d ' ')"
 if [ "$seeded_count" != "1000" ]; then
   echo "FAIL: seeding sanity check — expected 1000 lines, got $seeded_count" >&2
   ERRORS=$((ERRORS + 1))
@@ -1716,12 +1723,16 @@ fi
 
 run_skiplog_hook "$SKIPLOG_REPO6" "$TEST_DIR/skiplog-out6.txt" \
   env PATH="$SKIPLOG_BIN6:/usr/bin:/bin:/usr/sbin:/sbin" \
-      TOUCHSTONE_REVIEW_LOG="$SKIPLOG_LOG6" \
-      CODEX_REVIEW_BASE="HEAD~1" \
-      CODEX_REVIEW_DISABLE_CACHE=1 \
-  || { echo "FAIL: hook exited non-zero in rollover test" >&2; cat "$TEST_DIR/skiplog-out6.txt" >&2; ERRORS=$((ERRORS + 1)); }
+  TOUCHSTONE_REVIEW_LOG="$SKIPLOG_LOG6" \
+  CODEX_REVIEW_BASE="HEAD~1" \
+  CODEX_REVIEW_DISABLE_CACHE=1 \
+  || {
+    echo "FAIL: hook exited non-zero in rollover test" >&2
+    cat "$TEST_DIR/skiplog-out6.txt" >&2
+    ERRORS=$((ERRORS + 1))
+  }
 
-final_count="$(wc -l < "$SKIPLOG_LOG6" | tr -d ' ')"
+final_count="$(wc -l <"$SKIPLOG_LOG6" | tr -d ' ')"
 if [ "$final_count" = "1000" ]; then
   echo "==> PASS: log capped at 1000 entries after rollover"
 else
@@ -1772,15 +1783,19 @@ make_skiplog_bin_with_conductor "$SKIPLOG_BIN7"
 
 # Pre-create the would-be sentinel path. If the hook tried to log to a
 # non-/dev/null target by mistake, the file's mtime would advance.
-: > "$SKIPLOG_PROBE7"
+: >"$SKIPLOG_PROBE7"
 SKIPLOG_PROBE7_MTIME_BEFORE="$(stat -f %m "$SKIPLOG_PROBE7" 2>/dev/null || stat -c %Y "$SKIPLOG_PROBE7")"
 
 run_skiplog_hook "$SKIPLOG_REPO7" "$TEST_DIR/skiplog-out7.txt" \
   env PATH="$SKIPLOG_BIN7:/usr/bin:/bin:/usr/sbin:/sbin" \
-      TOUCHSTONE_REVIEW_LOG=/dev/null \
-      CODEX_REVIEW_BASE="HEAD~1" \
-      CODEX_REVIEW_DISABLE_CACHE=1 \
-  || { echo "FAIL: hook exited non-zero with TOUCHSTONE_REVIEW_LOG=/dev/null" >&2; cat "$TEST_DIR/skiplog-out7.txt" >&2; ERRORS=$((ERRORS + 1)); }
+  TOUCHSTONE_REVIEW_LOG=/dev/null \
+  CODEX_REVIEW_BASE="HEAD~1" \
+  CODEX_REVIEW_DISABLE_CACHE=1 \
+  || {
+    echo "FAIL: hook exited non-zero with TOUCHSTONE_REVIEW_LOG=/dev/null" >&2
+    cat "$TEST_DIR/skiplog-out7.txt" >&2
+    ERRORS=$((ERRORS + 1))
+  }
 
 SKIPLOG_PROBE7_MTIME_AFTER="$(stat -f %m "$SKIPLOG_PROBE7" 2>/dev/null || stat -c %Y "$SKIPLOG_PROBE7")"
 if [ "$SKIPLOG_PROBE7_MTIME_BEFORE" = "$SKIPLOG_PROBE7_MTIME_AFTER" ]; then
@@ -1805,11 +1820,15 @@ make_skiplog_bin_with_conductor "$SKIPLOG_BIN8"
 
 run_skiplog_hook "$SKIPLOG_REPO8" "$TEST_DIR/skiplog-out8.txt" \
   env PATH="$SKIPLOG_BIN8:/usr/bin:/bin:/usr/sbin:/sbin" \
-      HOME="$SKIPLOG_FAKEHOME8" \
-      TOUCHSTONE_REVIEW_LOG="" \
-      CODEX_REVIEW_BASE="HEAD~1" \
-      CODEX_REVIEW_DISABLE_CACHE=1 \
-  || { echo "FAIL: hook exited non-zero with TOUCHSTONE_REVIEW_LOG=''" >&2; cat "$TEST_DIR/skiplog-out8.txt" >&2; ERRORS=$((ERRORS + 1)); }
+  HOME="$SKIPLOG_FAKEHOME8" \
+  TOUCHSTONE_REVIEW_LOG="" \
+  CODEX_REVIEW_BASE="HEAD~1" \
+  CODEX_REVIEW_DISABLE_CACHE=1 \
+  || {
+    echo "FAIL: hook exited non-zero with TOUCHSTONE_REVIEW_LOG=''" >&2
+    cat "$TEST_DIR/skiplog-out8.txt" >&2
+    ERRORS=$((ERRORS + 1))
+  }
 
 # Negative invariant — no log file should exist anywhere under the
 # fake $HOME. The bug surfaces here: a `:-` expansion would substitute

--- a/tests/test-reviewer-sentinel-context.sh
+++ b/tests/test-reviewer-sentinel-context.sh
@@ -54,7 +54,7 @@ new_repo() {
   git -C "$repo" init -q
   git -C "$repo" config user.email t@t
   git -C "$repo" config user.name t
-  printf 'init\n' > "$repo/README.md"
+  printf 'init\n' >"$repo/README.md"
   git -C "$repo" add README.md
   git -C "$repo" commit -qm init
 }
@@ -77,8 +77,8 @@ echo "==> Test: detects_and_injects_journal"
 REPO_DETECT="$TEST_DIR/repo-detect"
 new_repo "$REPO_DETECT"
 mkdir -p "$REPO_DETECT/.sentinel/runs" "$REPO_DETECT/.cortex/journal"
-printf -- '---\ncycle-id: foo\n---\n' > "$REPO_DETECT/.sentinel/runs/run.md"
-cat > "$REPO_DETECT/.cortex/journal/20260428-sentinel-cycle-foo.md" <<'EOF'
+printf -- '---\ncycle-id: foo\n---\n' >"$REPO_DETECT/.sentinel/runs/run.md"
+cat >"$REPO_DETECT/.cortex/journal/20260428-sentinel-cycle-foo.md" <<'EOF'
 ---
 title: Sentinel Cycle Foo
 ---
@@ -103,7 +103,7 @@ echo "==> Test: sentinel_but_no_cortex"
 REPO_NO_CORTEX="$TEST_DIR/repo-no-cortex"
 new_repo "$REPO_NO_CORTEX"
 mkdir -p "$REPO_NO_CORTEX/.sentinel/runs"
-printf 'sentinel run\n' > "$REPO_NO_CORTEX/.sentinel/runs/run.md"
+printf 'sentinel run\n' >"$REPO_NO_CORTEX/.sentinel/runs/run.md"
 run_context_helper "$REPO_NO_CORTEX"
 assert_empty "$CONTEXT_STDOUT" "sentinel_but_no_cortex stdout"
 assert_contains "$CONTEXT_STDERR" "no cycle journal entry found" "sentinel_but_no_cortex stderr"
@@ -112,9 +112,9 @@ echo "==> Test: cycle_id_match_preferred_over_recency"
 REPO_CYCLE="$TEST_DIR/repo-cycle"
 new_repo "$REPO_CYCLE"
 mkdir -p "$REPO_CYCLE/.sentinel/runs" "$REPO_CYCLE/.cortex/journal"
-printf -- '---\ncycle-id: B\n---\n' > "$REPO_CYCLE/.sentinel/runs/run.md"
-printf 'journal A newer\n' > "$REPO_CYCLE/.cortex/journal/20260428-sentinel-cycle-A.md"
-printf 'journal B matched\n' > "$REPO_CYCLE/.cortex/journal/20260427-sentinel-cycle-B.md"
+printf -- '---\ncycle-id: B\n---\n' >"$REPO_CYCLE/.sentinel/runs/run.md"
+printf 'journal A newer\n' >"$REPO_CYCLE/.cortex/journal/20260428-sentinel-cycle-A.md"
+printf 'journal B matched\n' >"$REPO_CYCLE/.cortex/journal/20260427-sentinel-cycle-B.md"
 touch -t 202604281200 "$REPO_CYCLE/.cortex/journal/20260428-sentinel-cycle-A.md"
 touch -t 202604271200 "$REPO_CYCLE/.cortex/journal/20260427-sentinel-cycle-B.md"
 run_context_helper "$REPO_CYCLE"
@@ -125,8 +125,8 @@ echo "==> Test: malformed_journal_falls_back"
 REPO_MALFORMED="$TEST_DIR/repo-malformed"
 new_repo "$REPO_MALFORMED"
 mkdir -p "$REPO_MALFORMED/.sentinel/runs" "$REPO_MALFORMED/.cortex/journal"
-printf 'sentinel run\n' > "$REPO_MALFORMED/.sentinel/runs/run.md"
-printf 'unreadable journal\n' > "$REPO_MALFORMED/.cortex/journal/20260428-sentinel-cycle-bad.md"
+printf 'sentinel run\n' >"$REPO_MALFORMED/.sentinel/runs/run.md"
+printf 'unreadable journal\n' >"$REPO_MALFORMED/.cortex/journal/20260428-sentinel-cycle-bad.md"
 chmod 000 "$REPO_MALFORMED/.cortex/journal/20260428-sentinel-cycle-bad.md"
 run_context_helper "$REPO_MALFORMED"
 chmod 644 "$REPO_MALFORMED/.cortex/journal/20260428-sentinel-cycle-bad.md"
@@ -137,13 +137,13 @@ echo "==> Test: smoke prompt sent to conductor includes sentinel context"
 REPO_SMOKE="$TEST_DIR/repo-smoke"
 new_repo "$REPO_SMOKE"
 mkdir -p "$REPO_SMOKE/.sentinel/runs" "$REPO_SMOKE/.cortex/journal" "$TEST_DIR/bin"
-printf -- '---\ncycle-id: smoke\n---\n' > "$REPO_SMOKE/.sentinel/runs/run.md"
-printf 'smoke journal context\n' > "$REPO_SMOKE/.cortex/journal/20260428-sentinel-cycle-smoke.md"
-printf 'change\n' >> "$REPO_SMOKE/README.md"
+printf -- '---\ncycle-id: smoke\n---\n' >"$REPO_SMOKE/.sentinel/runs/run.md"
+printf 'smoke journal context\n' >"$REPO_SMOKE/.cortex/journal/20260428-sentinel-cycle-smoke.md"
+printf 'change\n' >>"$REPO_SMOKE/README.md"
 git -C "$REPO_SMOKE" add README.md
 git -C "$REPO_SMOKE" commit -qm change
 PROMPT_CAPTURE="$TEST_DIR/prompt.capture"
-cat > "$TEST_DIR/bin/conductor" <<'EOF'
+cat >"$TEST_DIR/bin/conductor" <<'EOF'
 #!/usr/bin/env bash
 case "$1" in
   doctor)

--- a/tests/test-run-script.sh
+++ b/tests/test-run-script.sh
@@ -35,27 +35,27 @@ mkdir -p "$PROJECT"
 git -C "$PROJECT" init -q
 
 CURRENT_ID="$(git -C "$TOUCHSTONE_ROOT" rev-parse HEAD)"
-CURRENT_VERSION="$(tr -d '[:space:]' < "$TOUCHSTONE_ROOT/VERSION")"
-printf '%s\n' "$CURRENT_ID" > "$PROJECT/.touchstone-version"
+CURRENT_VERSION="$(tr -d '[:space:]' <"$TOUCHSTONE_ROOT/VERSION")"
+printf '%s\n' "$CURRENT_ID" >"$PROJECT/.touchstone-version"
 
 echo "==> Test: run-script accepts the reviewed current id"
 
 SUCCESS_OUT="$TEST_DIR/success.out"
-( cd "$PROJECT" && run_touchstone run-script touchstone-run --project-version "$CURRENT_ID" -- detect ) >"$SUCCESS_OUT" 2>&1
+(cd "$PROJECT" && run_touchstone run-script touchstone-run --project-version "$CURRENT_ID" -- detect) >"$SUCCESS_OUT" 2>&1
 assert_contains "$SUCCESS_OUT" '^project_type=generic$'
 assert_contains "$SUCCESS_OUT" '^monorepo=false$'
 
 echo "==> Test: run-script accepts the installed VERSION string"
 
 VERSION_OUT="$TEST_DIR/version.out"
-( cd "$PROJECT" && run_touchstone run-script touchstone-run --project-version "$CURRENT_VERSION" -- detect ) >"$VERSION_OUT" 2>&1
+(cd "$PROJECT" && run_touchstone run-script touchstone-run --project-version "$CURRENT_VERSION" -- detect) >"$VERSION_OUT" 2>&1
 assert_contains "$VERSION_OUT" '^project_type=generic$'
 
 echo "==> Test: run-script accepts an older release-version contract"
 
 OLDER_VERSION="v0.0.0"
 OLDER_VERSION_OUT="$TEST_DIR/older-version.out"
-( cd "$PROJECT" && run_touchstone run-script touchstone-run --project-version "$OLDER_VERSION" -- detect ) >"$OLDER_VERSION_OUT" 2>&1
+(cd "$PROJECT" && run_touchstone run-script touchstone-run --project-version "$OLDER_VERSION" -- detect) >"$OLDER_VERSION_OUT" 2>&1
 assert_contains "$OLDER_VERSION_OUT" '^project_type=generic$'
 
 echo "==> Test: run-script rejects a newer release-version contract"
@@ -63,7 +63,7 @@ echo "==> Test: run-script rejects a newer release-version contract"
 FUTURE_VERSION="$(printf '%s\n' "$CURRENT_VERSION" | awk -F. '{ printf "%d.0.0\n", $1 + 1 }')"
 FUTURE_VERSION_OUT="$TEST_DIR/future-version.out"
 set +e
-( cd "$PROJECT" && run_touchstone run-script touchstone-run --project-version "$FUTURE_VERSION" -- detect ) >"$FUTURE_VERSION_OUT" 2>&1
+(cd "$PROJECT" && run_touchstone run-script touchstone-run --project-version "$FUTURE_VERSION" -- detect) >"$FUTURE_VERSION_OUT" 2>&1
 FUTURE_VERSION_EXIT=$?
 set -e
 
@@ -98,8 +98,8 @@ echo "==> Test: --project controls the delegated script working directory"
 NODE_PROJECT="$TEST_DIR/node-project"
 mkdir -p "$NODE_PROJECT"
 git -C "$NODE_PROJECT" init -q
-printf '%s\n' "$CURRENT_ID" > "$NODE_PROJECT/.touchstone-version"
-printf '{"scripts":{},"packageManager":"pnpm@9.0.0"}\n' > "$NODE_PROJECT/package.json"
+printf '%s\n' "$CURRENT_ID" >"$NODE_PROJECT/.touchstone-version"
+printf '{"scripts":{},"packageManager":"pnpm@9.0.0"}\n' >"$NODE_PROJECT/package.json"
 PROJECT_CONTEXT_OUT="$TEST_DIR/project-context.out"
 (
   cd "$PROJECT"
@@ -131,7 +131,7 @@ echo "==> Test: run-script rejects a project version contract the CLI cannot sat
 
 MISMATCH_OUT="$TEST_DIR/mismatch.out"
 set +e
-( cd "$PROJECT" && run_touchstone run-script touchstone-run --project-version 0000000000000000000000000000000000000000 -- detect ) >"$MISMATCH_OUT" 2>&1
+(cd "$PROJECT" && run_touchstone run-script touchstone-run --project-version 0000000000000000000000000000000000000000 -- detect) >"$MISMATCH_OUT" 2>&1
 MISMATCH_EXIT=$?
 set -e
 
@@ -170,7 +170,7 @@ echo "==> Test: run-script rejects unknown script names"
 
 UNKNOWN_OUT="$TEST_DIR/unknown.out"
 set +e
-( cd "$PROJECT" && run_touchstone run-script not-a-script --project-version "$CURRENT_ID" ) >"$UNKNOWN_OUT" 2>&1
+(cd "$PROJECT" && run_touchstone run-script not-a-script --project-version "$CURRENT_ID") >"$UNKNOWN_OUT" 2>&1
 UNKNOWN_EXIT=$?
 set -e
 
@@ -185,7 +185,7 @@ echo "==> Test: run-script keeps high-risk PR scripts out of the prototype allow
 
 HIGH_RISK_OUT="$TEST_DIR/high-risk.out"
 set +e
-( cd "$PROJECT" && run_touchstone run-script open-pr --project-version "$CURRENT_ID" -- --help ) >"$HIGH_RISK_OUT" 2>&1
+(cd "$PROJECT" && run_touchstone run-script open-pr --project-version "$CURRENT_ID" -- --help) >"$HIGH_RISK_OUT" 2>&1
 HIGH_RISK_EXIT=$?
 set -e
 

--- a/tests/test-run-script.sh
+++ b/tests/test-run-script.sh
@@ -127,6 +127,8 @@ VALIDATE_ENV_OUT="$TEST_DIR/validate-env.out"
   cd "$VALIDATE_PROJECT"
   GIT_DIR="$VALIDATE_PROJECT/.git" \
     GIT_WORK_TREE="$VALIDATE_PROJECT" \
+    PRE_COMMIT=1 \
+    PRE_COMMIT_REMOTE_BRANCH=refs/heads/feature/test \
     bash "$TOUCHSTONE_ROOT/scripts/touchstone-run.sh" validate
 ) >"$VALIDATE_ENV_OUT" 2>&1
 assert_contains "$VALIDATE_ENV_OUT" 'validate.sh'

--- a/tests/test-run-script.sh
+++ b/tests/test-run-script.sh
@@ -35,27 +35,27 @@ mkdir -p "$PROJECT"
 git -C "$PROJECT" init -q
 
 CURRENT_ID="$(git -C "$TOUCHSTONE_ROOT" rev-parse HEAD)"
-CURRENT_VERSION="$(tr -d '[:space:]' <"$TOUCHSTONE_ROOT/VERSION")"
-printf '%s\n' "$CURRENT_ID" >"$PROJECT/.touchstone-version"
+CURRENT_VERSION="$(tr -d '[:space:]' < "$TOUCHSTONE_ROOT/VERSION")"
+printf '%s\n' "$CURRENT_ID" > "$PROJECT/.touchstone-version"
 
 echo "==> Test: run-script accepts the reviewed current id"
 
 SUCCESS_OUT="$TEST_DIR/success.out"
-(cd "$PROJECT" && run_touchstone run-script touchstone-run --project-version "$CURRENT_ID" -- detect) >"$SUCCESS_OUT" 2>&1
+( cd "$PROJECT" && run_touchstone run-script touchstone-run --project-version "$CURRENT_ID" -- detect ) >"$SUCCESS_OUT" 2>&1
 assert_contains "$SUCCESS_OUT" '^project_type=generic$'
 assert_contains "$SUCCESS_OUT" '^monorepo=false$'
 
 echo "==> Test: run-script accepts the installed VERSION string"
 
 VERSION_OUT="$TEST_DIR/version.out"
-(cd "$PROJECT" && run_touchstone run-script touchstone-run --project-version "$CURRENT_VERSION" -- detect) >"$VERSION_OUT" 2>&1
+( cd "$PROJECT" && run_touchstone run-script touchstone-run --project-version "$CURRENT_VERSION" -- detect ) >"$VERSION_OUT" 2>&1
 assert_contains "$VERSION_OUT" '^project_type=generic$'
 
 echo "==> Test: run-script accepts an older release-version contract"
 
 OLDER_VERSION="v0.0.0"
 OLDER_VERSION_OUT="$TEST_DIR/older-version.out"
-(cd "$PROJECT" && run_touchstone run-script touchstone-run --project-version "$OLDER_VERSION" -- detect) >"$OLDER_VERSION_OUT" 2>&1
+( cd "$PROJECT" && run_touchstone run-script touchstone-run --project-version "$OLDER_VERSION" -- detect ) >"$OLDER_VERSION_OUT" 2>&1
 assert_contains "$OLDER_VERSION_OUT" '^project_type=generic$'
 
 echo "==> Test: run-script rejects a newer release-version contract"
@@ -63,7 +63,7 @@ echo "==> Test: run-script rejects a newer release-version contract"
 FUTURE_VERSION="$(printf '%s\n' "$CURRENT_VERSION" | awk -F. '{ printf "%d.0.0\n", $1 + 1 }')"
 FUTURE_VERSION_OUT="$TEST_DIR/future-version.out"
 set +e
-(cd "$PROJECT" && run_touchstone run-script touchstone-run --project-version "$FUTURE_VERSION" -- detect) >"$FUTURE_VERSION_OUT" 2>&1
+( cd "$PROJECT" && run_touchstone run-script touchstone-run --project-version "$FUTURE_VERSION" -- detect ) >"$FUTURE_VERSION_OUT" 2>&1
 FUTURE_VERSION_EXIT=$?
 set -e
 
@@ -98,8 +98,8 @@ echo "==> Test: --project controls the delegated script working directory"
 NODE_PROJECT="$TEST_DIR/node-project"
 mkdir -p "$NODE_PROJECT"
 git -C "$NODE_PROJECT" init -q
-printf '%s\n' "$CURRENT_ID" >"$NODE_PROJECT/.touchstone-version"
-printf '{"scripts":{},"packageManager":"pnpm@9.0.0"}\n' >"$NODE_PROJECT/package.json"
+printf '%s\n' "$CURRENT_ID" > "$NODE_PROJECT/.touchstone-version"
+printf '{"scripts":{},"packageManager":"pnpm@9.0.0"}\n' > "$NODE_PROJECT/package.json"
 PROJECT_CONTEXT_OUT="$TEST_DIR/project-context.out"
 (
   cd "$PROJECT"
@@ -131,7 +131,7 @@ echo "==> Test: run-script rejects a project version contract the CLI cannot sat
 
 MISMATCH_OUT="$TEST_DIR/mismatch.out"
 set +e
-(cd "$PROJECT" && run_touchstone run-script touchstone-run --project-version 0000000000000000000000000000000000000000 -- detect) >"$MISMATCH_OUT" 2>&1
+( cd "$PROJECT" && run_touchstone run-script touchstone-run --project-version 0000000000000000000000000000000000000000 -- detect ) >"$MISMATCH_OUT" 2>&1
 MISMATCH_EXIT=$?
 set -e
 
@@ -170,7 +170,7 @@ echo "==> Test: run-script rejects unknown script names"
 
 UNKNOWN_OUT="$TEST_DIR/unknown.out"
 set +e
-(cd "$PROJECT" && run_touchstone run-script not-a-script --project-version "$CURRENT_ID") >"$UNKNOWN_OUT" 2>&1
+( cd "$PROJECT" && run_touchstone run-script not-a-script --project-version "$CURRENT_ID" ) >"$UNKNOWN_OUT" 2>&1
 UNKNOWN_EXIT=$?
 set -e
 
@@ -185,7 +185,7 @@ echo "==> Test: run-script keeps high-risk PR scripts out of the prototype allow
 
 HIGH_RISK_OUT="$TEST_DIR/high-risk.out"
 set +e
-(cd "$PROJECT" && run_touchstone run-script open-pr --project-version "$CURRENT_ID" -- --help) >"$HIGH_RISK_OUT" 2>&1
+( cd "$PROJECT" && run_touchstone run-script open-pr --project-version "$CURRENT_ID" -- --help ) >"$HIGH_RISK_OUT" 2>&1
 HIGH_RISK_EXIT=$?
 set -e
 

--- a/tests/test-run-script.sh
+++ b/tests/test-run-script.sh
@@ -35,27 +35,27 @@ mkdir -p "$PROJECT"
 git -C "$PROJECT" init -q
 
 CURRENT_ID="$(git -C "$TOUCHSTONE_ROOT" rev-parse HEAD)"
-CURRENT_VERSION="$(tr -d '[:space:]' < "$TOUCHSTONE_ROOT/VERSION")"
-printf '%s\n' "$CURRENT_ID" > "$PROJECT/.touchstone-version"
+CURRENT_VERSION="$(tr -d '[:space:]' <"$TOUCHSTONE_ROOT/VERSION")"
+printf '%s\n' "$CURRENT_ID" >"$PROJECT/.touchstone-version"
 
 echo "==> Test: run-script accepts the reviewed current id"
 
 SUCCESS_OUT="$TEST_DIR/success.out"
-( cd "$PROJECT" && run_touchstone run-script touchstone-run --project-version "$CURRENT_ID" -- detect ) >"$SUCCESS_OUT" 2>&1
+(cd "$PROJECT" && run_touchstone run-script touchstone-run --project-version "$CURRENT_ID" -- detect) >"$SUCCESS_OUT" 2>&1
 assert_contains "$SUCCESS_OUT" '^project_type=generic$'
 assert_contains "$SUCCESS_OUT" '^monorepo=false$'
 
 echo "==> Test: run-script accepts the installed VERSION string"
 
 VERSION_OUT="$TEST_DIR/version.out"
-( cd "$PROJECT" && run_touchstone run-script touchstone-run --project-version "$CURRENT_VERSION" -- detect ) >"$VERSION_OUT" 2>&1
+(cd "$PROJECT" && run_touchstone run-script touchstone-run --project-version "$CURRENT_VERSION" -- detect) >"$VERSION_OUT" 2>&1
 assert_contains "$VERSION_OUT" '^project_type=generic$'
 
 echo "==> Test: run-script accepts an older release-version contract"
 
 OLDER_VERSION="v0.0.0"
 OLDER_VERSION_OUT="$TEST_DIR/older-version.out"
-( cd "$PROJECT" && run_touchstone run-script touchstone-run --project-version "$OLDER_VERSION" -- detect ) >"$OLDER_VERSION_OUT" 2>&1
+(cd "$PROJECT" && run_touchstone run-script touchstone-run --project-version "$OLDER_VERSION" -- detect) >"$OLDER_VERSION_OUT" 2>&1
 assert_contains "$OLDER_VERSION_OUT" '^project_type=generic$'
 
 echo "==> Test: run-script rejects a newer release-version contract"
@@ -63,7 +63,7 @@ echo "==> Test: run-script rejects a newer release-version contract"
 FUTURE_VERSION="$(printf '%s\n' "$CURRENT_VERSION" | awk -F. '{ printf "%d.0.0\n", $1 + 1 }')"
 FUTURE_VERSION_OUT="$TEST_DIR/future-version.out"
 set +e
-( cd "$PROJECT" && run_touchstone run-script touchstone-run --project-version "$FUTURE_VERSION" -- detect ) >"$FUTURE_VERSION_OUT" 2>&1
+(cd "$PROJECT" && run_touchstone run-script touchstone-run --project-version "$FUTURE_VERSION" -- detect) >"$FUTURE_VERSION_OUT" 2>&1
 FUTURE_VERSION_EXIT=$?
 set -e
 
@@ -98,8 +98,8 @@ echo "==> Test: --project controls the delegated script working directory"
 NODE_PROJECT="$TEST_DIR/node-project"
 mkdir -p "$NODE_PROJECT"
 git -C "$NODE_PROJECT" init -q
-printf '%s\n' "$CURRENT_ID" > "$NODE_PROJECT/.touchstone-version"
-printf '{"scripts":{},"packageManager":"pnpm@9.0.0"}\n' > "$NODE_PROJECT/package.json"
+printf '%s\n' "$CURRENT_ID" >"$NODE_PROJECT/.touchstone-version"
+printf '{"scripts":{},"packageManager":"pnpm@9.0.0"}\n' >"$NODE_PROJECT/package.json"
 PROJECT_CONTEXT_OUT="$TEST_DIR/project-context.out"
 (
   cd "$PROJECT"
@@ -107,6 +107,29 @@ PROJECT_CONTEXT_OUT="$TEST_DIR/project-context.out"
 ) >"$PROJECT_CONTEXT_OUT" 2>&1
 assert_contains "$PROJECT_CONTEXT_OUT" '^project_type=node$'
 assert_contains "$PROJECT_CONTEXT_OUT" '^package_manager=pnpm$'
+
+echo "==> Test: configured validate commands do not inherit hook Git env"
+
+VALIDATE_PROJECT="$TEST_DIR/validate-project"
+mkdir -p "$VALIDATE_PROJECT"
+git -C "$VALIDATE_PROJECT" init -q
+cat >"$VALIDATE_PROJECT/.touchstone-config" <<EOF_CONFIG
+validate_command=bash validate.sh
+EOF_CONFIG
+cat >"$VALIDATE_PROJECT/validate.sh" <<'EOF_VALIDATE'
+set -e
+git init nested >/dev/null
+test -d nested/.git
+test "$(git -C nested rev-parse --is-bare-repository)" = "false"
+EOF_VALIDATE
+VALIDATE_ENV_OUT="$TEST_DIR/validate-env.out"
+(
+  cd "$VALIDATE_PROJECT"
+  GIT_DIR="$VALIDATE_PROJECT/.git" \
+    GIT_WORK_TREE="$VALIDATE_PROJECT" \
+    bash "$TOUCHSTONE_ROOT/scripts/touchstone-run.sh" validate
+) >"$VALIDATE_ENV_OUT" 2>&1
+assert_contains "$VALIDATE_ENV_OUT" 'validate.sh'
 
 echo "==> Test: run-script rejects projects without a version contract"
 
@@ -131,7 +154,7 @@ echo "==> Test: run-script rejects a project version contract the CLI cannot sat
 
 MISMATCH_OUT="$TEST_DIR/mismatch.out"
 set +e
-( cd "$PROJECT" && run_touchstone run-script touchstone-run --project-version 0000000000000000000000000000000000000000 -- detect ) >"$MISMATCH_OUT" 2>&1
+(cd "$PROJECT" && run_touchstone run-script touchstone-run --project-version 0000000000000000000000000000000000000000 -- detect) >"$MISMATCH_OUT" 2>&1
 MISMATCH_EXIT=$?
 set -e
 
@@ -170,7 +193,7 @@ echo "==> Test: run-script rejects unknown script names"
 
 UNKNOWN_OUT="$TEST_DIR/unknown.out"
 set +e
-( cd "$PROJECT" && run_touchstone run-script not-a-script --project-version "$CURRENT_ID" ) >"$UNKNOWN_OUT" 2>&1
+(cd "$PROJECT" && run_touchstone run-script not-a-script --project-version "$CURRENT_ID") >"$UNKNOWN_OUT" 2>&1
 UNKNOWN_EXIT=$?
 set -e
 
@@ -185,7 +208,7 @@ echo "==> Test: run-script keeps high-risk PR scripts out of the prototype allow
 
 HIGH_RISK_OUT="$TEST_DIR/high-risk.out"
 set +e
-( cd "$PROJECT" && run_touchstone run-script open-pr --project-version "$CURRENT_ID" -- --help ) >"$HIGH_RISK_OUT" 2>&1
+(cd "$PROJECT" && run_touchstone run-script open-pr --project-version "$CURRENT_ID" -- --help) >"$HIGH_RISK_OUT" 2>&1
 HIGH_RISK_EXIT=$?
 set -e
 

--- a/tests/test-spawn-worktree.sh
+++ b/tests/test-spawn-worktree.sh
@@ -39,8 +39,8 @@ git -C "$REPO" config user.email "test@example.com"
 git -C "$REPO" config user.name "Test"
 git -C "$REPO" remote add origin "$REMOTE"
 
-echo "tracked" > "$REPO/tracked.txt"
-cat > "$REPO/.gitignore" <<'EOF'
+echo "tracked" >"$REPO/tracked.txt"
+cat >"$REPO/.gitignore" <<'EOF'
 .env.test
 local/*.json
 node_modules/
@@ -50,13 +50,13 @@ git -C "$REPO" commit -qm "initial"
 git -C "$REPO" push -q -u origin main
 git -C "$REPO" remote set-head origin main
 
-printf 'TOKEN=fake\n' > "$REPO/.env.test"
+printf 'TOKEN=fake\n' >"$REPO/.env.test"
 mkdir -p "$REPO/local" "$REPO/local/secrets" "$REPO/node_modules/pkg"
-printf '{"debug":true}\n' > "$REPO/local/dev.json"
-printf '{"prod":true}\n' > "$REPO/local/secrets/prod.json"
-printf 'cached\n' > "$REPO/node_modules/pkg/cache.txt"
-printf 'not ignored\n' > "$REPO/not-ignored.txt"
-cat > "$REPO/.worktreeinclude" <<'EOF'
+printf '{"debug":true}\n' >"$REPO/local/dev.json"
+printf '{"prod":true}\n' >"$REPO/local/secrets/prod.json"
+printf 'cached\n' >"$REPO/node_modules/pkg/cache.txt"
+printf 'not ignored\n' >"$REPO/not-ignored.txt"
+cat >"$REPO/.worktreeinclude" <<'EOF'
 # explicit local test config
 .env.test
 local/*.json
@@ -105,10 +105,10 @@ BAD_WT="$TEST_DIR/bad-include-wt"
 git init -q -b main "$BAD_INCLUDE_REPO"
 git -C "$BAD_INCLUDE_REPO" config user.email "test@example.com"
 git -C "$BAD_INCLUDE_REPO" config user.name "Test"
-echo "tracked" > "$BAD_INCLUDE_REPO/tracked.txt"
+echo "tracked" >"$BAD_INCLUDE_REPO/tracked.txt"
 git -C "$BAD_INCLUDE_REPO" add tracked.txt
 git -C "$BAD_INCLUDE_REPO" commit -qm "initial"
-printf '!negated\n' > "$BAD_INCLUDE_REPO/.worktreeinclude"
+printf '!negated\n' >"$BAD_INCLUDE_REPO/.worktreeinclude"
 if (cd "$BAD_INCLUDE_REPO" && bash "$TOUCHSTONE_ROOT/scripts/spawn-worktree.sh" feat/will-fail "$BAD_WT") >"$TEST_DIR/bad-include-output.txt" 2>&1; then
   fail "negated .worktreeinclude pattern should fail"
 fi

--- a/tests/test-status.sh
+++ b/tests/test-status.sh
@@ -41,14 +41,15 @@ assert_not_contains() {
 # Run touchstone with HOME pointed at a tempdir registry. NO_COLOR keeps the
 # output ANSI-free so grep assertions don't trip over escapes.
 run_touchstone() {
-  local fake_home="$1"; shift
+  local fake_home="$1"
+  shift
   HOME="$fake_home" \
     NO_COLOR=1 \
     TOUCHSTONE_NO_AUTO_UPDATE=1 \
     bash "$TOUCHSTONE_BIN" "$@"
 }
 
-CURRENT_VERSION="$(tr -d '[:space:]' < "$TOUCHSTONE_ROOT/VERSION")"
+CURRENT_VERSION="$(tr -d '[:space:]' <"$TOUCHSTONE_ROOT/VERSION")"
 
 echo "==> Test: touchstone status / status --all"
 echo "    Test dir: $TEST_DIR"
@@ -63,18 +64,18 @@ mkdir -p "$FAKE_HOME"
 CURRENT_PROJECT="$TEST_DIR/proj-current"
 BEHIND_PROJECT="$TEST_DIR/proj-behind"
 NO_MANIFEST_PROJECT="$TEST_DIR/proj-no-manifest"
-MISSING_PROJECT="$TEST_DIR/proj-missing"  # never created
+MISSING_PROJECT="$TEST_DIR/proj-missing" # never created
 
 mkdir -p "$CURRENT_PROJECT" "$BEHIND_PROJECT" "$NO_MANIFEST_PROJECT"
 
 # proj-current: version matches the touchstone HEAD (VERSION string, since
 # the brew-install path uses that as the id when there's no .git directory —
 # which is also the worktree path we're running from).
-printf '%s\n' "$CURRENT_VERSION" > "$CURRENT_PROJECT/.touchstone-version"
+printf '%s\n' "$CURRENT_VERSION" >"$CURRENT_PROJECT/.touchstone-version"
 
 # proj-behind: arbitrary GC'd-style id that isn't reachable in touchstone's
 # git history. The behind computation must report "?" rather than crash.
-printf '%s\n' "0000000000000000000000000000000000000abc" > "$BEHIND_PROJECT/.touchstone-version"
+printf '%s\n' "0000000000000000000000000000000000000abc" >"$BEHIND_PROJECT/.touchstone-version"
 
 # proj-no-manifest: directory exists but has no .touchstone-version. The
 # table must render "(no manifest)" without aborting the walk.
@@ -86,7 +87,7 @@ printf '%s\n' "0000000000000000000000000000000000000abc" > "$BEHIND_PROJECT/.tou
   printf '%s\n' "$BEHIND_PROJECT"
   printf '%s\n' "$NO_MANIFEST_PROJECT"
   printf '%s\n' "$MISSING_PROJECT"
-} > "$FAKE_HOME/.touchstone-projects"
+} >"$FAKE_HOME/.touchstone-projects"
 
 # --------------------------------------------------------------------------
 # Test 1: `touchstone status --all` renders a row per registry entry
@@ -132,7 +133,7 @@ echo ""
 echo "--- Test 2: status from inside a project ---"
 
 PROJECT_OUT="$TEST_DIR/project.out"
-( cd "$CURRENT_PROJECT" && run_touchstone "$FAKE_HOME" status ) >"$PROJECT_OUT" 2>&1
+(cd "$CURRENT_PROJECT" && run_touchstone "$FAKE_HOME" status) >"$PROJECT_OUT" 2>&1
 
 assert_contains "$PROJECT_OUT" "^project: *${CURRENT_PROJECT}"
 assert_contains "$PROJECT_OUT" "^touchstone: *${CURRENT_VERSION}"
@@ -152,7 +153,7 @@ mkdir -p "$NON_PROJECT"
 NOT_OUT="$TEST_DIR/not.out"
 
 set +e
-( cd "$NON_PROJECT" && run_touchstone "$FAKE_HOME" status ) >"$NOT_OUT" 2>&1
+(cd "$NON_PROJECT" && run_touchstone "$FAKE_HOME" status) >"$NOT_OUT" 2>&1
 NOT_EXIT=$?
 set -e
 
@@ -192,7 +193,7 @@ echo "--- Test 5: status --all with zero-byte registry ---"
 
 EMPTY_FILE_HOME="$TEST_DIR/empty-file-home"
 mkdir -p "$EMPTY_FILE_HOME"
-: > "$EMPTY_FILE_HOME/.touchstone-projects"
+: >"$EMPTY_FILE_HOME/.touchstone-projects"
 
 EMPTY_FILE_OUT="$TEST_DIR/empty-file.out"
 set +e
@@ -220,7 +221,7 @@ mkdir -p "$COMMENT_HOME"
   printf '%s\n' "$CURRENT_PROJECT"
   printf '   \n'
   printf '# trailing comment\n'
-} > "$COMMENT_HOME/.touchstone-projects"
+} >"$COMMENT_HOME/.touchstone-projects"
 
 COMMENT_OUT="$TEST_DIR/comment.out"
 run_touchstone "$COMMENT_HOME" status --all >"$COMMENT_OUT" 2>&1
@@ -236,7 +237,7 @@ echo ""
 echo "--- Test 7: status --json project capability state ---"
 
 CURRENT_JSON_OUT="$TEST_DIR/current-json.out"
-( cd "$CURRENT_PROJECT" && run_touchstone "$FAKE_HOME" status --json ) >"$CURRENT_JSON_OUT" 2>&1
+(cd "$CURRENT_PROJECT" && run_touchstone "$FAKE_HOME" status --json) >"$CURRENT_JSON_OUT" 2>&1
 
 assert_contains "$CURRENT_JSON_OUT" '"installed_touchstone"'
 assert_contains "$CURRENT_JSON_OUT" '"project_touchstone"'
@@ -252,10 +253,10 @@ assert_contains "$CURRENT_JSON_OUT" '"project_state": "available"'
 OLD_CAPABILITY_PROJECT="$TEST_DIR/proj-old-capability"
 mkdir -p "$OLD_CAPABILITY_PROJECT"
 OLD_WORKTREE_BOUNDARY_ID="$(git -C "$TOUCHSTONE_ROOT" rev-parse d596930^)"
-printf '%s\n' "$OLD_WORKTREE_BOUNDARY_ID" > "$OLD_CAPABILITY_PROJECT/.touchstone-version"
+printf '%s\n' "$OLD_WORKTREE_BOUNDARY_ID" >"$OLD_CAPABILITY_PROJECT/.touchstone-version"
 
 OLD_JSON_OUT="$TEST_DIR/old-json.out"
-( cd "$OLD_CAPABILITY_PROJECT" && run_touchstone "$FAKE_HOME" status --json ) >"$OLD_JSON_OUT" 2>&1
+(cd "$OLD_CAPABILITY_PROJECT" && run_touchstone "$FAKE_HOME" status --json) >"$OLD_JSON_OUT" 2>&1
 
 assert_contains "$OLD_JSON_OUT" '"state": "project_files_outdated"'
 assert_contains "$OLD_JSON_OUT" '"name": "worktree-lifecycle"'
@@ -270,7 +271,7 @@ echo "--- Test 8: doctor required capability gates old project files ---"
 
 REQUIRE_OUT="$TEST_DIR/require-capability.out"
 set +e
-( cd "$OLD_CAPABILITY_PROJECT" && run_touchstone "$FAKE_HOME" doctor --project --require-capability worktree-lifecycle ) >"$REQUIRE_OUT" 2>&1
+(cd "$OLD_CAPABILITY_PROJECT" && run_touchstone "$FAKE_HOME" doctor --project --require-capability worktree-lifecycle) >"$REQUIRE_OUT" 2>&1
 REQUIRE_EXIT=$?
 set -e
 

--- a/tests/test-sync-smoke.sh
+++ b/tests/test-sync-smoke.sh
@@ -42,8 +42,8 @@ cleanup() {
 
   # This test may run on a shared machine, so assert the invariant we own:
   # no project path from this isolated TEST_DIR may leak into the real registry.
-  if [ -n "$REAL_REGISTRY_FILE" ] && [ -f "$REAL_REGISTRY_FILE" ] && \
-     grep -F "$TEST_DIR" "$REAL_REGISTRY_FILE" >/dev/null 2>&1; then
+  if [ -n "$REAL_REGISTRY_FILE" ] && [ -f "$REAL_REGISTRY_FILE" ] \
+    && grep -F "$TEST_DIR" "$REAL_REGISTRY_FILE" >/dev/null 2>&1; then
     echo "FAIL: test wrote isolated temp paths to real registry at $REAL_REGISTRY_FILE" >&2
     registry_changed=true
   fi
@@ -71,9 +71,9 @@ else
   REGISTRY_FILE="$TEST_DIR/.touchstone-projects"
   SMOKE_PROJECT="$TEST_DIR/smoke-project"
   if bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$SMOKE_PROJECT" \
-      --no-register --no-with-cortex --no-with-sentinel --no-github \
-      >"$TEST_DIR/bootstrap-smoke-project.txt" 2>&1; then
-    printf '%s\n' "$SMOKE_PROJECT" > "$REGISTRY_FILE"
+    --no-register --no-with-cortex --no-with-sentinel --no-github \
+    >"$TEST_DIR/bootstrap-smoke-project.txt" 2>&1; then
+    printf '%s\n' "$SMOKE_PROJECT" >"$REGISTRY_FILE"
   else
     echo "FAIL: could not bootstrap isolated smoke project" >&2
     cat "$TEST_DIR/bootstrap-smoke-project.txt" >&2
@@ -101,7 +101,7 @@ while IFS= read -r line || [ -n "$line" ]; do
     \#*) continue ;;
   esac
   PROJECTS+=("$trimmed")
-done < "$REGISTRY_FILE"
+done <"$REGISTRY_FILE"
 
 if [ "${#PROJECTS[@]}" -eq 0 ]; then
   echo "==> Registry is empty, skipping smoke test."
@@ -141,8 +141,8 @@ for project in "${PROJECTS[@]}"; do
   # Run --dry-run and capture combined stdout+stderr and exit code.
   output_file="$(mktemp -t touchstone-smoke.XXXXXX)"
   set +e
-  ( cd "$project" && bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh" --dry-run ) \
-    > "$output_file" 2>&1
+  (cd "$project" && bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh" --dry-run) \
+    >"$output_file" 2>&1
   rc=$?
   set -e
 

--- a/tests/test-toml.sh
+++ b/tests/test-toml.sh
@@ -32,25 +32,25 @@ assert_eq() {
 }
 
 # Case 1: Simple keys
-printf 'a = 1\nb = "two"' > test.toml
+printf 'a = 1\nb = "two"' >test.toml
 test_results=""
 toml_parse test.toml test_callback
 assert_eq ":a=1|:b=two|" "$test_results" "Simple keys"
 
 # Case 2: Sections
-printf '[sec]\nkey = "val"' > test.toml
+printf '[sec]\nkey = "val"' >test.toml
 test_results=""
 toml_parse test.toml test_callback
 assert_eq "sec:key=val|" "$test_results" "Sections"
 
 # Case 3: Arrays
-printf 'arr = ["a", "b"]' > test.toml
+printf 'arr = ["a", "b"]' >test.toml
 test_results=""
 toml_parse test.toml test_callback
 assert_eq ":arr=a,b|" "$test_results" "Single-line array"
 
 # Case 4: Multiline arrays
-printf 'arr = [\n"a",\n"b"\n]' > test.toml
+printf 'arr = [\n"a",\n"b"\n]' >test.toml
 test_results=""
 toml_parse test.toml test_callback
 assert_eq ":arr=a,b|" "$test_results" "Multiline array"

--- a/tests/test-update-migrate-reviewer-config.sh
+++ b/tests/test-update-migrate-reviewer-config.sh
@@ -26,7 +26,10 @@ TEST_DIR="$(mktemp -d -t touchstone-test-update-migrate.XXXXXX)"
 trap 'rm -rf "$TEST_DIR"' EXIT
 
 ERRORS=0
-fail() { echo "FAIL: $*" >&2; ERRORS=$((ERRORS + 1)); }
+fail() {
+  echo "FAIL: $*" >&2
+  ERRORS=$((ERRORS + 1))
+}
 
 bootstrap_project() {
   local dir="$1"
@@ -44,9 +47,9 @@ commit_file() {
 
 run_update() {
   local dir="$1"
-  ( cd "$dir" \
+  (cd "$dir" \
     && bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh" --in-place \
-       </dev/null ) >"$TEST_DIR/update.out" 2>&1
+      </dev/null) >"$TEST_DIR/update.out" 2>&1
 }
 
 # ---------------------------------------------------------------------------
@@ -55,7 +58,7 @@ run_update() {
 echo "==> Case 1: v1.x reviewers cascade migrates to v2.x conductor shape"
 P1="$TEST_DIR/p1"
 bootstrap_project "$P1"
-cat > "$P1/.codex-review.toml" <<'EOF'
+cat >"$P1/.codex-review.toml" <<'EOF'
 [review]
 enabled = true
 reviewers = ["codex", "claude"]
@@ -94,7 +97,7 @@ fi
 echo "==> Case 2: [review.local] block triggers migration"
 P2="$TEST_DIR/p2"
 bootstrap_project "$P2"
-cat > "$P2/.codex-review.toml" <<'EOF'
+cat >"$P2/.codex-review.toml" <<'EOF'
 [review]
 enabled = true
 reviewer = "conductor"
@@ -121,7 +124,7 @@ fi
 echo "==> Case 3: already-v2.x config is unchanged"
 P3="$TEST_DIR/p3"
 bootstrap_project "$P3"
-cat > "$P3/.codex-review.toml" <<'EOF'
+cat >"$P3/.codex-review.toml" <<'EOF'
 [review]
 enabled = true
 reviewer = "conductor"

--- a/tests/test-update.sh
+++ b/tests/test-update.sh
@@ -57,8 +57,8 @@ commit_all() {
   # Skip the commit when there's nothing staged — new-project.sh now creates an
   # initial commit during bootstrap, so the test helper must not error out when
   # the tree is already clean.
-  if [ -n "$(git -C "$repo" status --porcelain)" ] || \
-     ! git -C "$repo" rev-parse --verify HEAD >/dev/null 2>&1; then
+  if [ -n "$(git -C "$repo" status --porcelain)" ] \
+    || ! git -C "$repo" rev-parse --verify HEAD >/dev/null 2>&1; then
     git -C "$repo" commit --no-verify -m "$message" >/dev/null
   fi
 }
@@ -103,10 +103,10 @@ fi
 echo ""
 echo "--- Step 3: Modify a Touchstone-owned file, then update ---"
 
-echo "# locally modified" >> "$PROJECT/principles/engineering-principles.md"
+echo "# locally modified" >>"$PROJECT/principles/engineering-principles.md"
 rm "$PROJECT/scripts/touchstone-run.sh"
-printf '{"custom": true}\n' > "$PROJECT/.claude/settings.json"
-echo "0000000000000000000000000000000000000000" > "$PROJECT/.touchstone-version"
+printf '{"custom": true}\n' >"$PROJECT/.claude/settings.json"
+echo "0000000000000000000000000000000000000000" >"$PROJECT/.touchstone-version"
 commit_all "$PROJECT" "simulate old touchstone state"
 
 (cd "$PROJECT" && bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh") 2>&1 | tee "$TEST_DIR/update-output-2.txt"
@@ -181,8 +181,8 @@ configure_git "$IN_PLACE_PROJECT"
 commit_all "$IN_PLACE_PROJECT" "initial in-place test project"
 git -C "$IN_PLACE_PROJECT" checkout -q -b feature/in-place-update
 rm "$IN_PLACE_PROJECT/scripts/touchstone-run.sh"
-printf '{"custom": true}\n' > "$IN_PLACE_PROJECT/.claude/settings.json"
-echo "0000000000000000000000000000000000000004" > "$IN_PLACE_PROJECT/.touchstone-version"
+printf '{"custom": true}\n' >"$IN_PLACE_PROJECT/.claude/settings.json"
+echo "0000000000000000000000000000000000000004" >"$IN_PLACE_PROJECT/.touchstone-version"
 commit_all "$IN_PLACE_PROJECT" "simulate old in-place touchstone state"
 IN_PLACE_BASE="$(git -C "$IN_PLACE_PROJECT" rev-parse HEAD)"
 
@@ -227,8 +227,8 @@ fi
 echo ""
 echo "--- Step 4: Verify project-owned files are untouched ---"
 
-echo "# my project context" >> "$PROJECT/CLAUDE.md"
-echo "0000000000000000000000000000000000000001" > "$PROJECT/.touchstone-version"
+echo "# my project context" >>"$PROJECT/CLAUDE.md"
+echo "0000000000000000000000000000000000000001" >"$PROJECT/.touchstone-version"
 commit_all "$PROJECT" "simulate project-owned customization"
 CLAUDE_CHECKSUM="$(md5 -q "$PROJECT/CLAUDE.md" 2>/dev/null || md5sum "$PROJECT/CLAUDE.md" | awk '{print $1}')"
 
@@ -248,7 +248,7 @@ assert_not_exists "$PROJECT/CLAUDE.md.bak"
 # Existing projects from before Gemini support should receive GEMINI.md once,
 # but the file remains project-owned after that.
 rm -f "$PROJECT/GEMINI.md"
-echo "0000000000000000000000000000000000000001" > "$PROJECT/.touchstone-version"
+echo "0000000000000000000000000000000000000001" >"$PROJECT/.touchstone-version"
 commit_all "$PROJECT" "simulate pre-gemini project"
 
 (cd "$PROJECT" && bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh") >/dev/null 2>&1
@@ -272,7 +272,7 @@ fi
 echo ""
 echo "--- Step 4b: AGENTS.md without principles block gets backfilled on update ---"
 
-cat > "$PROJECT/AGENTS.md" <<'EOF'
+cat >"$PROJECT/AGENTS.md" <<'EOF'
 # AGENTS.md — AI Reviewer Guide for Test Project
 
 You are reviewing PRs for Test Project.
@@ -281,7 +281,7 @@ You are reviewing PRs for Test Project.
 
 - Project-specific rule that must survive the update.
 EOF
-echo "0000000000000000000000000000000000000002" > "$PROJECT/.touchstone-version"
+echo "0000000000000000000000000000000000000002" >"$PROJECT/.touchstone-version"
 commit_all "$PROJECT" "simulate pre-block AGENTS.md state"
 
 (cd "$PROJECT" && bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh") >/dev/null 2>&1
@@ -316,10 +316,10 @@ DIRTY_PROJECT="$TEST_DIR/dirty-project"
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$DIRTY_PROJECT" --no-register >/dev/null
 configure_git "$DIRTY_PROJECT"
 commit_all "$DIRTY_PROJECT" "initial dirty test project"
-echo "0000000000000000000000000000000000000002" > "$DIRTY_PROJECT/.touchstone-version"
+echo "0000000000000000000000000000000000000002" >"$DIRTY_PROJECT/.touchstone-version"
 commit_all "$DIRTY_PROJECT" "simulate old dirty test project"
 DIRTY_BRANCH="$(git -C "$DIRTY_PROJECT" rev-parse --abbrev-ref HEAD)"
-echo "# uncommitted change" >> "$DIRTY_PROJECT/scripts/open-pr.sh"
+echo "# uncommitted change" >>"$DIRTY_PROJECT/scripts/open-pr.sh"
 
 if (cd "$DIRTY_PROJECT" && bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh") >"$TEST_DIR/dirty-output.txt" 2>&1; then
   echo "FAIL: expected dirty update to fail" >&2
@@ -343,10 +343,10 @@ ROLLBACK_PROJECT="$TEST_DIR/rollback-project"
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$ROLLBACK_PROJECT" --no-register >/dev/null
 configure_git "$ROLLBACK_PROJECT"
 commit_all "$ROLLBACK_PROJECT" "initial rollback test project"
-printf '\n.touchstone-version\n.touchstone-manifest\n' >> "$ROLLBACK_PROJECT/.gitignore"
+printf '\n.touchstone-version\n.touchstone-manifest\n' >>"$ROLLBACK_PROJECT/.gitignore"
 git -C "$ROLLBACK_PROJECT" rm --cached .touchstone-version .touchstone-manifest >/dev/null
 commit_all "$ROLLBACK_PROJECT" "simulate legacy ignored touchstone metadata"
-echo "legacy-old-version" > "$ROLLBACK_PROJECT/.touchstone-version"
+echo "legacy-old-version" >"$ROLLBACK_PROJECT/.touchstone-version"
 rm "$ROLLBACK_PROJECT/.touchstone-manifest"
 mkdir "$ROLLBACK_PROJECT/.touchstone-manifest"
 ROLLBACK_BRANCH="$(git -C "$ROLLBACK_PROJECT" rev-parse --abbrev-ref HEAD)"
@@ -390,7 +390,7 @@ commit_all "$SWIFT_UPDATE_PROJECT" "initial swift touchstone project"
 # Simulate a stale touchstone version + a project that pre-existed the swiftlint
 # template (so .swiftlint.yml was never created at bootstrap time).
 rm -f "$SWIFT_UPDATE_PROJECT/.swiftlint.yml"
-echo "0000000000000000000000000000000000000010" > "$SWIFT_UPDATE_PROJECT/.touchstone-version"
+echo "0000000000000000000000000000000000000010" >"$SWIFT_UPDATE_PROJECT/.touchstone-version"
 commit_all "$SWIFT_UPDATE_PROJECT" "simulate pre-swiftlint-template swift project"
 
 (cd "$SWIFT_UPDATE_PROJECT" && bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh") >"$TEST_DIR/swift-update-output.txt" 2>&1
@@ -422,9 +422,9 @@ fi
 SWIFT_HAND_EDITED_PROJECT="$TEST_DIR/swift-hand-edited-update"
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$SWIFT_HAND_EDITED_PROJECT" --no-register --type swift >/dev/null
 configure_git "$SWIFT_HAND_EDITED_PROJECT"
-printf 'SENTINEL_HAND_EDITED_SWIFTLINT\n' > "$SWIFT_HAND_EDITED_PROJECT/.swiftlint.yml"
+printf 'SENTINEL_HAND_EDITED_SWIFTLINT\n' >"$SWIFT_HAND_EDITED_PROJECT/.swiftlint.yml"
 commit_all "$SWIFT_HAND_EDITED_PROJECT" "initial swift project with hand-edited swiftlint"
-echo "0000000000000000000000000000000000000011" > "$SWIFT_HAND_EDITED_PROJECT/.touchstone-version"
+echo "0000000000000000000000000000000000000011" >"$SWIFT_HAND_EDITED_PROJECT/.touchstone-version"
 commit_all "$SWIFT_HAND_EDITED_PROJECT" "simulate stale touchstone state"
 
 (cd "$SWIFT_HAND_EDITED_PROJECT" && bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh") >/dev/null 2>&1
@@ -437,7 +437,7 @@ NON_SWIFT_UPDATE_PROJECT="$TEST_DIR/non-swift-update-project"
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$NON_SWIFT_UPDATE_PROJECT" --no-register --type python >/dev/null
 configure_git "$NON_SWIFT_UPDATE_PROJECT"
 commit_all "$NON_SWIFT_UPDATE_PROJECT" "initial python project"
-echo "0000000000000000000000000000000000000012" > "$NON_SWIFT_UPDATE_PROJECT/.touchstone-version"
+echo "0000000000000000000000000000000000000012" >"$NON_SWIFT_UPDATE_PROJECT/.touchstone-version"
 commit_all "$NON_SWIFT_UPDATE_PROJECT" "simulate stale python touchstone state"
 
 (cd "$NON_SWIFT_UPDATE_PROJECT" && bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh") >/dev/null 2>&1
@@ -454,7 +454,7 @@ CHECK_PROJECT="$TEST_DIR/check-project"
 bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$CHECK_PROJECT" --no-register >/dev/null
 configure_git "$CHECK_PROJECT"
 commit_all "$CHECK_PROJECT" "initial check project"
-echo "0000000000000000000000000000000000000003" > "$CHECK_PROJECT/.touchstone-version"
+echo "0000000000000000000000000000000000000003" >"$CHECK_PROJECT/.touchstone-version"
 commit_all "$CHECK_PROJECT" "simulate old check project"
 CHECK_BRANCH="$(git -C "$CHECK_PROJECT" rev-parse --abbrev-ref HEAD)"
 

--- a/tests/test-worker.sh
+++ b/tests/test-worker.sh
@@ -37,7 +37,7 @@ setup_repo_with_origin() {
   git -C "$repo" init -b main >/dev/null 2>&1
   git -C "$repo" config user.name "Touchstone Test"
   git -C "$repo" config user.email "touchstone@example.com"
-  printf 'base\n' > "$repo/file.txt"
+  printf 'base\n' >"$repo/file.txt"
   git -C "$repo" add file.txt
   git -C "$repo" commit -m "base commit" >/dev/null 2>&1
   git init --bare "$origin" >/dev/null 2>&1
@@ -48,7 +48,7 @@ setup_repo_with_origin() {
 make_fake_gh() {
   local bin_dir="$1"
   mkdir -p "$bin_dir"
-  cat > "$bin_dir/gh" <<'EOF'
+  cat >"$bin_dir/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -89,9 +89,9 @@ SPAWN_JSON="$TEST_DIR/spawn.json"
   cd "$REPO"
   TOUCHSTONE_EVENTS_FILE="$SPAWN_EVENTS" \
     "$TOUCHSTONE_ROOT/bin/touchstone" worker spawn \
-      --task "Fix Worker Lifecycle!" \
-      --type fix \
-      --json >"$SPAWN_JSON"
+    --task "Fix Worker Lifecycle!" \
+    --type fix \
+    --json >"$SPAWN_JSON"
 )
 WORKTREE_PATH="$(sed -n 's/.*"worktree_path":"\([^"]*\)".*/\1/p' "$SPAWN_JSON")"
 if [ ! -d "$WORKTREE_PATH" ]; then
@@ -110,7 +110,7 @@ STATUS_JSON="$TEST_DIR/status.json"
 )
 assert_json_value "$STATUS_JSON" state "spawned"
 
-printf 'change\n' >> "$WORKTREE_PATH/file.txt"
+printf 'change\n' >>"$WORKTREE_PATH/file.txt"
 git -C "$WORKTREE_PATH" add file.txt
 git -C "$WORKTREE_PATH" commit -m "worker change" >/dev/null 2>&1
 (
@@ -119,7 +119,7 @@ git -C "$WORKTREE_PATH" commit -m "worker change" >/dev/null 2>&1
 )
 assert_json_value "$STATUS_JSON" state "working"
 
-printf 'dirty\n' >> "$WORKTREE_PATH/file.txt"
+printf 'dirty\n' >>"$WORKTREE_PATH/file.txt"
 (
   cd "$REPO"
   "$TOUCHSTONE_ROOT/bin/touchstone" worker status --worktree "$WORKTREE_PATH" --json >"$STATUS_JSON"
@@ -130,54 +130,54 @@ git -C "$WORKTREE_PATH" checkout -- file.txt
 FAKE_GH="$TEST_DIR/fake-gh"
 make_fake_gh "$FAKE_GH"
 PATH="$FAKE_GH:/usr/bin:/bin:/usr/sbin:/sbin" \
-GH_PR_NUMBER=138 \
-GH_PR_URL="https://example.test/autumngarage/touchstone/pull/138" \
-GH_PR_STATE=OPEN \
+  GH_PR_NUMBER=138 \
+  GH_PR_URL="https://example.test/autumngarage/touchstone/pull/138" \
+  GH_PR_STATE=OPEN \
   "$TOUCHSTONE_ROOT/bin/touchstone" worker status --worktree "$WORKTREE_PATH" --json >"$STATUS_JSON"
 assert_json_value "$STATUS_JSON" state "pr_opened"
 assert_contains "$STATUS_JSON" '"pr_number":138'
 
 COMMON_DIR="$(git -C "$WORKTREE_PATH" rev-parse --git-common-dir)"
 mkdir -p "$COMMON_DIR/touchstone/reviewer-clean"
-cat > "$COMMON_DIR/touchstone/reviewer-clean/fix_fix-worker-lifecycle.clean" <<'EOF'
+cat >"$COMMON_DIR/touchstone/reviewer-clean/fix_fix-worker-lifecycle.clean" <<'EOF'
 result=CODEX_REVIEW_CLEAN
 branch=fix/fix-worker-lifecycle
 EOF
 PATH="$FAKE_GH:/usr/bin:/bin:/usr/sbin:/sbin" \
-GH_PR_STATE=OPEN \
+  GH_PR_STATE=OPEN \
   "$TOUCHSTONE_ROOT/bin/touchstone" worker status --worktree "$WORKTREE_PATH" --json >"$STATUS_JSON"
 assert_json_value "$STATUS_JSON" state "reviewing"
 
 PATH="$FAKE_GH:/usr/bin:/bin:/usr/sbin:/sbin" \
-GH_PR_STATE=MERGED \
-GH_PR_MERGED_AT=2026-05-06T12:00:00Z \
+  GH_PR_STATE=MERGED \
+  GH_PR_MERGED_AT=2026-05-06T12:00:00Z \
   "$TOUCHSTONE_ROOT/bin/touchstone" worker status --worktree "$WORKTREE_PATH" --json >"$STATUS_JSON"
 assert_json_value "$STATUS_JSON" state "cleanup_failed"
 assert_json_value "$STATUS_JSON" merged_at "2026-05-06T12:00:00Z"
 
 PATH="$FAKE_GH:/usr/bin:/bin:/usr/sbin:/sbin" \
-GH_PR_STATE=CLOSED \
+  GH_PR_STATE=CLOSED \
   "$TOUCHSTONE_ROOT/bin/touchstone" worker status --worktree "$WORKTREE_PATH" --json >"$STATUS_JSON"
 assert_json_value "$STATUS_JSON" state "abandoned"
 
 mkdir -p "$COMMON_DIR/touchstone/reviewer-blocked"
-: > "$COMMON_DIR/touchstone/reviewer-blocked/fix_fix-worker-lifecycle.blocked"
+: >"$COMMON_DIR/touchstone/reviewer-blocked/fix_fix-worker-lifecycle.blocked"
 PATH="$FAKE_GH:/usr/bin:/bin:/usr/sbin:/sbin" \
-GH_PR_STATE=CLOSED \
+  GH_PR_STATE=CLOSED \
   "$TOUCHSTONE_ROOT/bin/touchstone" worker status --worktree "$WORKTREE_PATH" --json >"$STATUS_JSON"
 assert_json_value "$STATUS_JSON" state "review_blocked"
 
 echo "==> Case c: worker list filters lifecycle branches"
 LIST_JSON="$TEST_DIR/list.json"
 PATH="$FAKE_GH:/usr/bin:/bin:/usr/sbin:/sbin" \
-GH_PR_STATE=OPEN \
+  GH_PR_STATE=OPEN \
   "$TOUCHSTONE_ROOT/bin/touchstone" worker list --repo "$REPO" --json >"$LIST_JSON"
 assert_contains "$LIST_JSON" '"branch":"fix/fix-worker-lifecycle"'
 
 echo "==> Case d: worker ship delegates to project-local open-pr with cleanup and events env"
 SHIP_WT="$TEST_DIR/ship-worktree"
 mkdir -p "$SHIP_WT/scripts"
-cat > "$SHIP_WT/scripts/open-pr.sh" <<'EOF'
+cat >"$SHIP_WT/scripts/open-pr.sh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" > "$SHIP_ARGS_FILE"
@@ -185,11 +185,11 @@ printf '%s\n' "${TOUCHSTONE_EVENTS_FILE:-}" > "$SHIP_EVENTS_FILE"
 EOF
 chmod +x "$SHIP_WT/scripts/open-pr.sh"
 SHIP_ARGS_FILE="$TEST_DIR/ship-args" \
-SHIP_EVENTS_FILE="$TEST_DIR/ship-events-env" \
+  SHIP_EVENTS_FILE="$TEST_DIR/ship-events-env" \
   "$TOUCHSTONE_ROOT/bin/touchstone" worker ship \
-    --worktree "$SHIP_WT" \
-    --cleanup \
-    --events-json "$TEST_DIR/ship-events.ndjson"
+  --worktree "$SHIP_WT" \
+  --cleanup \
+  --events-json "$TEST_DIR/ship-events.ndjson"
 if ! grep -q -- '--auto-merge --cleanup-worktree' "$TEST_DIR/ship-args"; then
   fail "worker ship did not pass expected open-pr args"
   cat "$TEST_DIR/ship-args" >&2
@@ -210,9 +210,9 @@ SAFE_EVENTS="$TEST_DIR/safe-events.ndjson"
   cd "$REPO"
   TOUCHSTONE_EVENTS_FILE="$SAFE_EVENTS" \
     "$TOUCHSTONE_ROOT/bin/touchstone" worker spawn \
-      --task "Docs noop" \
-      --type docs \
-      --json >"$SAFE_JSON"
+    --task "Docs noop" \
+    --type docs \
+    --json >"$SAFE_JSON"
 )
 SAFE_WORKTREE="$(sed -n 's/.*"worktree_path":"\([^"]*\)".*/\1/p' "$SAFE_JSON")"
 ABANDON_EVENTS="$TEST_DIR/abandon-events.ndjson"


### PR DESCRIPTION
## Linked Issues

Closes #195
Closes #194
Closes #193

Ensure Touchstone validation launched from a pre-push hook does not leak pre-commit branch metadata into nested review-hook tests, while preserving the same cleanup for configured validation commands.

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
