### PR TITLE
[alchemist] fix: Dogfood B: extend the README "tools" section to mention Alchemist as the 5th sibling (#210)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 > *Scaffolding + pre-push AI review for AI-assisted projects.*
 >
-> by **[Autumn Garage](https://github.com/autumngarage/autumn-garage)** · alongside [Cortex](https://github.com/autumngarage/cortex) · [Sentinel](https://github.com/autumngarage/sentinel) · [Conductor](https://github.com/autumngarage/conductor)
+> by **[Autumn Garage](https://github.com/autumngarage/autumn-garage)** · alongside [Cortex](https://github.com/autumngarage/cortex) · [Sentinel](https://github.com/autumngarage/sentinel) · [Conductor](https://github.com/autumngarage/conductor) · [Alchemist](https://github.com/autumngarage/alchemist) — issue-driven transmuter — open issue in, reviewed PR out.
 
 # Touchstone
 


### PR DESCRIPTION
Closes https://github.com/autumngarage/touchstone/issues/210

> Dogfood B: extend the README "tools" section to mention Alchemist as the 5th sibling

---

🤖 Transmuted by [Alchemist](https://github.com/autumngarage/alchemist) ·
brief template v1 · provider `openrouter`

Touchstone runs the review and merge gate after this PR opens. Watch for its
review comment + auto-merge.
