### PR TITLE
fix(merge-pr): invalidate clean-review marker when branch HEAD advances

### DIFF
--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -157,15 +157,23 @@ branch_has_clean_review_marker() {
   local branch="$1"
   local head_oid="$2"
   local merge_base="$3"
-  local marker marker_branch marker_head marker_merge_base
+  local marker marker_branch marker_head marker_merge_base live_branch_head
   marker="$(review_clean_marker_file "$branch")"
   [ -f "$marker" ] || return 1
   grep -q '^result=CODEX_REVIEW_CLEAN$' "$marker" || return 1
   marker_branch="$(marker_field branch "$marker")"
   marker_head="$(marker_field head "$marker")"
   marker_merge_base="$(marker_field merge_base "$marker")"
+
+  if ! live_branch_head="$(git rev-parse "$branch" 2>/dev/null)"; then
+    live_branch_head="$(git rev-parse HEAD 2>/dev/null || echo "")"
+  fi
+
+  # Invariant: A clean-review marker is valid only when its `head` field equals the current branch HEAD.
   [ "$marker_branch" = "$branch" ] \
-    && [ "$marker_head" = "$head_oid" ] \
+    && [ -n "$live_branch_head" ] \
+    && [ "$live_branch_head" = "$head_oid" ] \
+    && [ "$marker_head" = "$live_branch_head" ] \
     && [ "$marker_merge_base" = "$merge_base" ]
 }
 

--- a/tests/test-merge-pr.sh
+++ b/tests/test-merge-pr.sh
@@ -321,6 +321,30 @@ else
   exit 1
 fi
 
+echo "==> Test: auto-bypass rejects clean marker when live branch HEAD advanced (#211)"
+reset_case_files
+# Reproduce the safety regression: the branch has a clean marker for the
+# earlier PR head, then the local branch advances before the final merge
+# review fails. The stale marker must not auto-promote that failed review
+# to a bypass, because the live branch HEAD has never reviewed cleanly.
+mkdir -p "$GIT_PATH_ROOT/touchstone/reviewer-clean"
+printf 'result=CODEX_REVIEW_CLEAN\nbranch=feature/test\nbase=origin/main\nmerge_base=base-oid\nhead=pr-head-oid\n' \
+  >"$GIT_PATH_ROOT/touchstone/reviewer-clean/feature_test.clean"
+if CODEX_REVIEW_EXIT=124 GIT_LOCAL_BRANCH_HEAD="advanced-head-oid" \
+  run_merge_pr "$TEST_DIR/output-advanced-head.txt" 123; then
+  echo "FAIL: merge-pr.sh auto-bypassed with a clean marker for an earlier HEAD" >&2
+  cat "$TEST_DIR/output-advanced-head.txt" >&2
+  exit 1
+fi
+if [ ! -f "$TEST_DIR/gh-merge-head" ] \
+  && ! grep -q 'Auto-promoting to reviewer bypass' "$TEST_DIR/output-advanced-head.txt"; then
+  echo "==> PASS: clean marker for earlier HEAD does not auto-bypass advanced branch"
+else
+  echo "FAIL: advanced-head case should not merge or auto-bypass" >&2
+  cat "$TEST_DIR/output-advanced-head.txt" >&2
+  exit 1
+fi
+
 echo "==> Test: sibling worktree owning main is fast-forwarded without false merge failure"
 reset_case_files
 MAIN_WORKTREE="$TEST_DIR/main-worktree"


### PR DESCRIPTION
## Linked Issues

Closes #211

Invariant: A clean-review marker is valid only when its `head` field equals the current branch HEAD.

The regression test failed before this fix because merge-pr.sh auto-bypassed a failed review when the branch had advanced beyond the marker's recorded head.

Closes-issue: #211

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
