### PR TITLE
fix(validate): unset GIT_DIR/GIT_INDEX_FILE before running bootstrap tests

### DIFF
--- a/scripts/touchstone-run.sh
+++ b/scripts/touchstone-run.sh
@@ -14,6 +14,17 @@ set -euo pipefail
 
 ACTION="${1:-validate}"
 
+clear_git_hook_env() {
+  unset GIT_DIR
+  unset GIT_WORK_TREE
+  unset GIT_INDEX_FILE
+  unset GIT_OBJECT_DIRECTORY
+  unset GIT_COMMON_DIR
+  unset GIT_NAMESPACE
+  unset GIT_PREFIX
+  unset GIT_INTERNAL_GETTEXT_SH_SCHEME
+}
+
 # tests/test-find-python-bin.sh sources this script with
 # TOUCHSTONE_RUN_SOURCE_ONLY=1 to call helpers directly without running the
 # action dispatcher at the bottom. Tests pass TOUCHSTONE_RUN_TEST_REPO_ROOT
@@ -22,6 +33,7 @@ ACTION="${1:-validate}"
 if [ "${TOUCHSTONE_RUN_SOURCE_ONLY:-0}" = "1" ]; then
   REPO_ROOT="${TOUCHSTONE_RUN_TEST_REPO_ROOT:-$(pwd)}"
 else
+  clear_git_hook_env
   REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
   cd "$REPO_ROOT"
 fi
@@ -170,6 +182,8 @@ run_shell_command() {
   info "$command"
   env \
     -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE \
+    -u GIT_OBJECT_DIRECTORY -u GIT_COMMON_DIR -u GIT_NAMESPACE \
+    -u GIT_PREFIX -u GIT_INTERNAL_GETTEXT_SH_SCHEME \
     -u PRE_COMMIT -u PRE_COMMIT_FROM_REF -u PRE_COMMIT_TO_REF \
     -u PRE_COMMIT_LOCAL_BRANCH -u PRE_COMMIT_REMOTE_BRANCH \
     -u PRE_COMMIT_REMOTE_NAME -u PRE_COMMIT_REMOTE_URL \

--- a/tests/test-validate-env-isolation.sh
+++ b/tests/test-validate-env-isolation.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# tests/test-validate-env-isolation.sh — pre-push Git env must not steer validate.
+#
+set -euo pipefail
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_DIR="$(mktemp -d -t touchstone-test-validate-env.XXXXXX)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+ERRORS=0
+
+assert_contains() {
+  local file="$1" needle="$2"
+  if ! grep -q -- "$needle" "$file" 2>/dev/null; then
+    echo "FAIL: expected '$file' to contain '$needle'" >&2
+    echo "  ---- file content ----" >&2
+    sed 's/^/    /' "$file" >&2 || true
+    echo "  ----------------------" >&2
+    ERRORS=$((ERRORS + 1))
+  fi
+}
+
+assert_not_exists() {
+  if [ -e "$1" ]; then
+    echo "FAIL: expected '$1' to not exist" >&2
+    ERRORS=$((ERRORS + 1))
+  fi
+}
+
+OUTER_REPO="$TEST_DIR/outer-repo"
+VALIDATE_PROJECT="$TEST_DIR/validate-project"
+mkdir -p "$OUTER_REPO" "$VALIDATE_PROJECT"
+git -C "$OUTER_REPO" init -q
+git -C "$VALIDATE_PROJECT" init -q
+
+cat >"$VALIDATE_PROJECT/.touchstone-config" <<EOF_CONFIG
+validate_command=bash validate.sh
+EOF_CONFIG
+
+cat >"$VALIDATE_PROJECT/validate.sh" <<'EOF_VALIDATE'
+set -e
+printf 'validate-project-pwd=%s\n' "$PWD"
+git init nested >/dev/null
+test -d nested/.git
+test "$(git -C nested rev-parse --is-bare-repository)" = "false"
+EOF_VALIDATE
+
+echo "==> Test: validate ignores Git hook environment from another repo"
+
+VALIDATE_OUT="$TEST_DIR/validate.out"
+(
+  cd "$VALIDATE_PROJECT"
+  GIT_DIR="$OUTER_REPO/.git" \
+    GIT_WORK_TREE="$OUTER_REPO" \
+    GIT_INDEX_FILE="$OUTER_REPO/.git/index" \
+    GIT_OBJECT_DIRECTORY="$OUTER_REPO/.git/objects" \
+    GIT_COMMON_DIR="$OUTER_REPO/.git" \
+    GIT_NAMESPACE=touchstone-test \
+    GIT_PREFIX=from-hook/ \
+    GIT_INTERNAL_GETTEXT_SH_SCHEME=fallthrough \
+    bash "$TOUCHSTONE_ROOT/scripts/touchstone-run.sh" validate
+) >"$VALIDATE_OUT" 2>&1
+
+assert_contains "$VALIDATE_OUT" 'validate.sh'
+assert_contains "$VALIDATE_OUT" "validate-project-pwd=$VALIDATE_PROJECT"
+assert_not_exists "$OUTER_REPO/nested"
+
+if [ "$ERRORS" -ne 0 ]; then
+  exit 1
+fi
+
+echo "PASS: validate clears hook Git environment before dispatch"

--- a/tests/test-validate-env-isolation.sh
+++ b/tests/test-validate-env-isolation.sh
@@ -33,6 +33,7 @@ VALIDATE_PROJECT="$TEST_DIR/validate-project"
 mkdir -p "$OUTER_REPO" "$VALIDATE_PROJECT"
 git -C "$OUTER_REPO" init -q
 git -C "$VALIDATE_PROJECT" init -q
+VALIDATE_PROJECT_PWD="$(cd "$VALIDATE_PROJECT" && pwd -P)"
 
 cat >"$VALIDATE_PROJECT/.touchstone-config" <<EOF_CONFIG
 validate_command=bash validate.sh
@@ -63,7 +64,7 @@ VALIDATE_OUT="$TEST_DIR/validate.out"
 ) >"$VALIDATE_OUT" 2>&1
 
 assert_contains "$VALIDATE_OUT" 'validate.sh'
-assert_contains "$VALIDATE_OUT" "validate-project-pwd=$VALIDATE_PROJECT"
+assert_contains "$VALIDATE_OUT" "validate-project-pwd=$VALIDATE_PROJECT_PWD"
 assert_not_exists "$OUTER_REPO/nested"
 
 if [ "$ERRORS" -ne 0 ]; then


### PR DESCRIPTION
## Linked Issues

Closes #206

Clear hook-local Git repository variables before touchstone-run.sh resolves the repo root, and keep the same isolation at the configured-command boundary. This prevents pre-push validation from redirecting nested bootstrap git commands into the hook source worktree.

Closes-issue: #206

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
