### PR TITLE
docs(workflow): require claiming issues before agent dispatch

### DIFF
--- a/.cortex/journal/2026-05-06-pr-merged-2328.md
+++ b/.cortex/journal/2026-05-06-pr-merged-2328.md
@@ -1,0 +1,45 @@
+# PR #208 merged — fix(doctor): document capability help
+
+**Date:** 2026-05-06
+**Type:** pr-merged
+**Trigger:** T1.9
+**Cites:** journal/2026-05-06-pr-merged-2116
+**Merge-commit:** c3fc02e5990391ec8001d028488781041b959408
+**Branch:** fix/doctor-help-require-capability
+
+> fix(doctor): document capability help.
+
+## What shipped
+
+- [ ] Tests pass locally
+- [ ] No new silent failures (no `except: pass`, no swallowed errors)
+- [ ] No new code paths that diverge between environments
+- [ ] Low risk — isolated change, no shared state affected
+- [ ] Medium risk — touches shared infrastructure or data paths
+- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)
+
+## Closes / advances
+
+- **Plans:** _(none recorded — fill on edit)_
+- **Doctrine:** _(none recorded — fill on edit)_
+- **Journal linkage:** _(none recorded — fill on edit)_
+
+## Follow-ups (deferred to future work)
+
+_None._
+
+(Per SPEC § 4.2, deferred items must resolve to another Plan, Journal entry, or Doctrine entry in the same commit as the merge note.)
+
+
+<!--
+Context auto-pulled at draft time. Remove this block before saving.
+
+Recent commits:
+- c3fc02e fix(doctor): document capability help (#208)
+- 6b9032f feat(doctor): add tests and completions (#207)
+- 350d254 docs(journal): auto-draft pr-merged entry for #191
+- 41d7204 Refresh conductor integrations to v0.10.1 (#191)
+- 038ad85 v2.7.0
+
+Active-branch PR: (no open PR for this branch)
+-->

--- a/.cortex/state.md
+++ b/.cortex/state.md
@@ -1,10 +1,10 @@
 ---
-Generated: 2026-05-06T21:16:28-04:00
+Generated: 2026-05-06T23:28:43-04:00
 Generator: cortex refresh-state v1.2.0
 Sources:
-  - HEAD sha: 41d7204352d2af3dbc8a237b2e2027fed8badebf
+  - HEAD sha: c3fc02e5990391ec8001d028488781041b959408
   - .cortex/plans/*.md (2 files)
-  - .cortex/journal/*.md (3 entries, 2026-05-05..2026-05-06)
+  - .cortex/journal/*.md (4 entries, 2026-05-05..2026-05-06)
   - .cortex/doctrine/*.md (1 entries)
   - .cortex/templates/**/*.md (12 templates)
   - docs/case-studies/*.md (0 case studies)
@@ -15,6 +15,7 @@ Sources-hash:
   .cortex/journal/2026-05-05-cortex-install-baseline.md: dcc1ddd566c02c618277309b6daebf1334d477994b154a0f87a615642bd32829
   .cortex/journal/2026-05-05-touchstone-conductor-plan-shipped.md: 908d0fc7ddd56257d9b8d29036e3d2462a2ea176b8572a229212d586d9393e13
   .cortex/journal/2026-05-06-pr-merged-2116.md: 68bb4383122d55ce6bcdc5bcb25978d917fb84db13d1e7515263e32fc2934cf4
+  .cortex/journal/2026-05-06-pr-merged-2328.md: 5e07e37df12b8e19e7102271706fa2f28d4e4e55a1d4d00f73888f1c861e43a5
   .cortex/plans/touchstone-conductor-integration.md: be3f8211b7c19e32e0c4c858c35678c1d85418fe12c5d22b29cc0a7831f8a54c
   .cortex/plans/touchstone-cortex-metadata.md: 0e23c4e06b91c1e8da358b3928750798975eed88815502fb8e7ddfbdbd0187f5
   .cortex/templates/README.md: 695aa2e623bd7f4e698dae471bded0cde354da0c1d8589266660ceb1be8efad1
@@ -29,7 +30,7 @@ Sources-hash:
   .cortex/templates/journal/release.md: 9a6bc59219156e48b419fb170c7c50ff557767def8672ef20568df3e14eadbd0
   .cortex/templates/journal/sentinel-cycle.md: 2945e2d94af4ec9848584b4b3e9cea7060d2968dd42e78faf21fb6f859137476
   .cortex/templates/plans/template.md: d8156cfa3b86acd2a1fbb36cff07cae37d99f3adee7f72b14b7b16e645c51b44
-Corpus: 3 Journal entries, 2 Plans, 1 Doctrine entries, 12 Templates, 0 Case studies
+Corpus: 4 Journal entries, 2 Plans, 1 Doctrine entries, 12 Templates, 0 Case studies
 Omitted:
   []
 Incomplete:
@@ -48,6 +49,7 @@ Spec: 0.5.0
 
 - **2026-05-05** — Touchstone Conductor integration plan — active -> shipped (`.cortex/journal/2026-05-05-touchstone-conductor-plan-shipped.md`, Type: plan-transition)
 - **2026-05-06** — PR #191 merged — Refresh conductor integrations to v0.10.1 (`.cortex/journal/2026-05-06-pr-merged-2116.md`, Type: pr-merged)
+- **2026-05-06** — PR #208 merged — fix(doctor): document capability help (`.cortex/journal/2026-05-06-pr-merged-2328.md`, Type: pr-merged)
 
 ## Stale-now / handle-later
 

--- a/principles/git-workflow.md
+++ b/principles/git-workflow.md
@@ -120,6 +120,42 @@ A stacked PR is a PR whose base branch is another open PR's branch instead of th
 - **If you must stack:** drop `--auto-merge` on the whole chain. Merge each PR by hand in order, using **merge commit** or **rebase merge** (never squash) for the parent so the child's branch still traces to something on main. `open-pr.sh` will warn if you pass `--base <branch>` + `--auto-merge` together — take the warning seriously.
 - **Recover an orphaned child**: re-open the work as a fresh PR against current `main` (the lineage is lost but the diff usually still applies). If the parent's squashed content is already on main, the child's diff is just the child-only changes — which is usually what you wanted anyway.
 
+## Claiming issues before agent dispatch
+
+Before spawning a coding agent — Claude Code subagent, Conductor `exec` worker, Codex CLI, or any other — to work on a GitHub issue, **claim it first**. Set the assignee, post a one-line dispatch comment, then spawn the agent. The cost is ten seconds per issue; the cost of skipping it is two agents picking up the same issue and shipping competing PRs.
+
+**The mechanical steps.**
+
+```bash
+gh issue edit <n> --add-assignee @me
+gh issue comment <n> --body "Wave N Lane X dispatched. Branch \`<branch>\`, worktree at \`<path>\`. <agent type> implementing. PR will land via \`open-pr.sh --auto-merge\`."
+```
+
+Then start the agent. Not after.
+
+**Why this is a rule.**
+
+Without it, three failure modes recur in agent-driven workflows:
+
+1. **Duplicate work.** Two agents (or two collaborators, or a future you in another session) pick up the same issue from the open queue and ship competing PRs. The first to merge wins; the second rebases into conflict or closes orphaned. Both burned budget.
+2. **No in-progress signal.** A reader scanning open issues can't tell which are actively being worked vs which are dormant. Triage decays — a two-week-old "open" issue might be thirty seconds from a PR or completely abandoned, with no way to tell from outside the thread.
+3. **Lost lineage on bypass.** If the PR that closes the issue ends up using `merge-pr.sh --bypass-with-disclosure` or hits review-tooling drama, the dispatch comment is the only record on the issue thread that ties the work back to a specific lane, agent, branch, and worktree. That breadcrumb matters when something goes wrong months later.
+
+The discipline is small. The recovery from skipping it is large.
+
+**When to unassign.**
+
+If you decide not to ship — the work turns out to be wrong, the approach pivots, the agent stalls and you stand it down — unassign with `gh issue edit <n> --remove-assignee @me` and post a "stood down — <reason>" comment. Leaving stale assignments is worse than no assignment at all; readers will assume the issue is being worked when it isn't.
+
+**When this rule does NOT apply.**
+
+- **Issues you're proposing or analyzing, not implementing.** You're researching whether something is even worth doing — no claim. Claim only when an agent (or you) is actively starting implementation.
+- **Drive-by fixes during unrelated work.** A one-line typo fix on the way to something else doesn't need a claim — but if it warrants its own commit, it warrants a `Closes-issue:` trailer at minimum.
+
+**For multi-issue bundles.**
+
+When one lane closes multiple issues (e.g., Wave 1's Lane A bundling shfmt + markdownlint + actionlint into one branch), claim and comment on all of them with the same lane / branch reference. The dispatch comment becomes the per-issue audit thread; the bundling is visible from any of them.
+
 ## Parallel work with worktrees
 
 File-writing subagents must use isolated worktrees unless explicitly waived. The default is isolation; flat shared-checkout fan-out is the exception.


### PR DESCRIPTION
Adds a "Claiming issues before agent dispatch" section to the canonical
git-workflow principle. The rule: assign and post a one-line dispatch
comment on a GitHub issue *before* spawning a coding agent (subagent,
Conductor exec worker, Codex CLI) on it; unassign with a "stood down"
comment if you decide not to ship.

Why: during the Wave 2 swarm dispatch on the conductor-review-improvements
batch, three issues had no assignee and no in-progress signal — exactly
the failure mode that produces duplicate work, dormant-vs-active triage
ambiguity, and lost lineage when a PR ends up using
--bypass-with-disclosure. CLAUDE.md already imports
@principles/git-workflow.md, so the rule reaches every Touchstone-aware
session and propagates to bootstrapped projects via update-project.sh
without further wiring.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
