### PR TITLE
feat(auto-update): auto-sync projects on touchstone version drift

### DIFF
--- a/bin/touchstone
+++ b/bin/touchstone
@@ -19,6 +19,7 @@
 #   touchstone status [--json]            Show status of the current project
 #   touchstone status --all               Show version distribution across registered projects
 #   touchstone version                    Show installed version
+#   touchstone --version                  Show installed version
 #   touchstone doctor                     Report conductor-review fail-open trends
 #   touchstone help                       Show this help
 #
@@ -1615,6 +1616,10 @@ cmd_help() {
   printf "    ${BOLD}touchstone release${RESET} [--patch]      Cut a new touchstone release\n"
   printf "    ${BOLD}touchstone help${RESET}                   Show this help\n"
   echo ""
+  echo "  ${BOLD}Environment:${RESET}"
+  printf "    ${BOLD}TOUCHSTONE_NO_AUTO_UPDATE=1${RESET}        Disable CLI auto-update and project auto-sync\n"
+  printf "    ${BOLD}TOUCHSTONE_NO_AUTO_PROJECT_SYNC=1${RESET}  Disable project auto-sync only\n"
+  echo ""
   printf "  Install: ${DIM}brew tap autumngarage/touchstone && brew install touchstone${RESET}\n"
   echo ""
 }
@@ -1625,6 +1630,10 @@ cmd_help() {
 
 COMMAND="${1:-help}"
 shift 2>/dev/null || true
+
+# Auto-project-sync runs after command parsing so read-only commands can skip
+# it and before dispatch so write-capable commands see current Touchstone files.
+touchstone_auto_project_sync "$COMMAND" "$@" || true
 
 case "$COMMAND" in
   new)          cmd_new "$@" ;;
@@ -1646,7 +1655,7 @@ case "$COMMAND" in
   skills)       cmd_skills "$@" ;;
   changelog)    cmd_changelog "$@" ;;
   release)      cmd_release "$@" ;;
-  version)      cmd_version ;;
+  version|--version) cmd_version ;;
   doctor)       cmd_doctor "$@" ;;
   help|-h|--help) cmd_help ;;
   *)

--- a/lib/auto-update.sh
+++ b/lib/auto-update.sh
@@ -9,7 +9,8 @@
 # once per hour to avoid slowing down every command.
 #
 # Env overrides:
-#   TOUCHSTONE_NO_AUTO_UPDATE=1  — disable auto-update entirely
+#   TOUCHSTONE_NO_AUTO_UPDATE=1  — disable auto-update and auto-project-sync entirely
+#   TOUCHSTONE_NO_AUTO_PROJECT_SYNC=1 — disable per-project file sync only
 #   TOUCHSTONE_UPDATE_INTERVAL   — seconds between checks (default: 3600 = 1 hour)
 #
 
@@ -77,4 +78,105 @@ touchstone_auto_update() {
   else
     echo "==> Update available: v${latest_version}. Run: brew upgrade touchstone" >&2
   fi
+}
+
+touchstone_installed_id() {
+  local current_version
+  current_version="$(cat "$TOUCHSTONE_ROOT/VERSION" 2>/dev/null | tr -d '[:space:]' || true)"
+
+  # Mirror bootstrap/update-project.sh exactly: regular source checkouts record
+  # the Touchstone git SHA, while brew installs and git-worktree checkouts
+  # record VERSION. Comparing any other field would re-sync forever.
+  if [ -d "$TOUCHSTONE_ROOT/.git" ]; then
+    git -C "$TOUCHSTONE_ROOT" rev-parse HEAD
+  else
+    printf '%s\n' "$current_version"
+  fi
+}
+
+touchstone_find_project_root() {
+  local dir
+  dir="$(pwd)"
+
+  while [ "$dir" != "/" ]; do
+    if [ -f "$dir/.touchstone-version" ]; then
+      printf '%s\n' "$dir"
+      return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+
+  return 1
+}
+
+touchstone_auto_project_sync_command_skips() {
+  local command="${1:-}" subcommand="${2:-}"
+
+  case "$command" in
+    ""|help|-h|--help|version|--version|status|list|ls|diff|changelog|doctor|detect|skills|update|sync|new|init|migrate-from-toolkit|migrate-review-config|release)
+      return 0
+      ;;
+  esac
+
+  case "$command:$subcommand" in
+    adr:list|worker:status|worker:list|review:--dry-run|review:-n)
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
+touchstone_auto_project_sync() {
+  local command="${1:-}"
+  shift 2>/dev/null || true
+
+  if [ "${TOUCHSTONE_NO_AUTO_UPDATE:-}" = "1" ] \
+    || [ "${TOUCHSTONE_NO_AUTO_PROJECT_SYNC:-}" = "1" ]; then
+    return 0
+  fi
+
+  if touchstone_auto_project_sync_command_skips "$command" "$@"; then
+    return 0
+  fi
+
+  local project_dir
+  if ! project_dir="$(touchstone_find_project_root)"; then
+    return 0
+  fi
+
+  local project_id installed_id
+  project_id="$(tr -d '[:space:]' <"$project_dir/.touchstone-version" 2>/dev/null || true)"
+  installed_id="$(touchstone_installed_id)"
+  [ -n "$project_id" ] || return 0
+  [ -n "$installed_id" ] || return 0
+
+  if [ "$project_id" = "$installed_id" ]; then
+    return 0
+  fi
+
+  if ! git -C "$project_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "WARNING: touchstone auto-sync skipped for $project_dir (not a git repository)." >&2
+    return 0
+  fi
+
+  if [ -n "$(git -C "$project_dir" status --porcelain)" ]; then
+    echo "WARNING: touchstone auto-sync skipped for $project_dir (working tree is dirty)." >&2
+    return 0
+  fi
+
+  local log_file
+  log_file="$(mktemp -t touchstone-auto-project-sync.XXXXXX)"
+
+  # Invariant: after any non-readonly `touchstone <subcmd>` in a
+  # touchstone-aware project, the project's principles/hooks/scripts match the
+  # installed Touchstone id, or the user opted out, or the tree was dirty.
+  if (cd "$project_dir" && bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh") >"$log_file" 2>&1; then
+    rm -f "$log_file"
+    echo "==> auto-synced touchstone $project_id -> $installed_id" >&2
+    return 0
+  fi
+
+  echo "WARNING: touchstone auto-sync failed for $project_dir; continuing. Log: $log_file" >&2
+  return 0
 }

--- a/principles/git-workflow.md
+++ b/principles/git-workflow.md
@@ -31,6 +31,14 @@ The three layers are complementary — the local hook catches the honest mistake
 5. **Ship.** `scripts/open-pr.sh --auto-merge` pushes, creates the PR, runs the final read-only Conductor merge review, squash-merges after a clean review, deletes the remote branch, and pulls the updated default branch — all in one command. Use `scripts/open-pr.sh` (without `--auto-merge`) if you want to open the PR without merging.
 6. **Clean up.** Delete the local feature branch. Run `scripts/cleanup-branches.sh` periodically for batch hygiene.
 
+### Touchstone CLI auto-sync
+
+When a brew-installed `touchstone` CLI runs a write-capable command inside a Touchstone-aware project, it compares the project's recorded `.touchstone-version` with the installed Touchstone version. If they differ and the project worktree is clean, the CLI runs the same `touchstone update` path before the requested command so `principles/`, `hooks/`, and `scripts/` stay current.
+
+If the project worktree is dirty, auto-sync prints a one-line warning and skips; the user's pending work is never stashed, overwritten, or committed. `touchstone version`, help, status, diff, doctor, list, changelog, and other read-only commands do not trigger auto-sync.
+
+Set `TOUCHSTONE_NO_AUTO_UPDATE=1` to disable both CLI self-update and project auto-sync. Set `TOUCHSTONE_NO_AUTO_PROJECT_SYNC=1` to keep CLI self-update enabled but disable only the per-project sync.
+
 ## Commit discipline
 
 **One concern per commit.** A commit should describe a single logical change — a feature, a fix, a refactor, a doc update — not a multi-day grab bag. The diff might span many files, but it should be one coherent thought. This is the "atomic commit" principle: every commit is a self-contained unit of intent.

--- a/tests/test-auto-project-sync.sh
+++ b/tests/test-auto-project-sync.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+#
+# tests/test-auto-project-sync.sh — touchstone CLI per-project auto-sync.
+#
+set -euo pipefail
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TOUCHSTONE_BIN="$TOUCHSTONE_ROOT/bin/touchstone"
+TEST_DIR="$(mktemp -d -t touchstone-test-auto-project-sync.XXXXXX)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+ERRORS=0
+if [ -d "$TOUCHSTONE_ROOT/.git" ]; then
+  CURRENT_ID="$(git -C "$TOUCHSTONE_ROOT" rev-parse HEAD)"
+else
+  CURRENT_ID="$(tr -d '[:space:]' <"$TOUCHSTONE_ROOT/VERSION")"
+fi
+
+assert_contains() {
+  local file="$1" needle="$2"
+  if ! grep -q -- "$needle" "$file" 2>/dev/null; then
+    echo "FAIL: expected '$file' to contain '$needle'" >&2
+    echo "  ---- file content ----" >&2
+    sed 's/^/    /' "$file" >&2 || true
+    echo "  ----------------------" >&2
+    ERRORS=$((ERRORS + 1))
+  fi
+}
+
+assert_not_contains() {
+  local file="$1" needle="$2"
+  if grep -q -- "$needle" "$file" 2>/dev/null; then
+    echo "FAIL: expected '$file' to NOT contain '$needle'" >&2
+    echo "  ---- file content ----" >&2
+    sed 's/^/    /' "$file" >&2 || true
+    echo "  ----------------------" >&2
+    ERRORS=$((ERRORS + 1))
+  fi
+}
+
+assert_version_equals() {
+  local project="$1" expected="$2"
+  local actual
+  actual="$(tr -d '[:space:]' <"$project/.touchstone-version")"
+  if [ "$actual" != "$expected" ]; then
+    echo "FAIL: expected $project/.touchstone-version to be '$expected', got '$actual'" >&2
+    ERRORS=$((ERRORS + 1))
+  fi
+}
+
+run_touchstone() {
+  local fake_home="$1"
+  shift
+  mkdir -p "$fake_home/.touchstone-state"
+  date +%s >"$fake_home/.touchstone-state/last-update-check"
+  HOME="$fake_home" \
+    NO_COLOR=1 \
+    TOUCHSTONE_STATE_DIR="$fake_home/.touchstone-state" \
+    bash "$TOUCHSTONE_BIN" "$@"
+}
+
+make_project() {
+  local project="$1" version="$2"
+  mkdir -p "$project"
+  git -C "$project" init -q
+  git -C "$project" config user.name "Touchstone Test"
+  git -C "$project" config user.email "touchstone@example.invalid"
+  printf '%s\n' "$version" >"$project/.touchstone-version"
+  printf 'test project\n' >"$project/README.md"
+  git -C "$project" add README.md .touchstone-version
+  git -C "$project" commit -q -m "test fixture"
+}
+
+echo "==> Test: auto-project-sync"
+echo "    Test dir: $TEST_DIR"
+
+echo ""
+echo "--- drift + clean tree: sync runs, then subcommand proceeds ---"
+CLEAN_HOME="$TEST_DIR/home-clean"
+CLEAN_PROJECT="$TEST_DIR/project-clean"
+make_project "$CLEAN_PROJECT" "0000000000000000000000000000000000000001"
+CLEAN_OUT="$TEST_DIR/clean.out"
+(cd "$CLEAN_PROJECT" && run_touchstone "$CLEAN_HOME" run validate) >"$CLEAN_OUT" 2>&1
+assert_contains "$CLEAN_OUT" "auto-synced touchstone 0000000000000000000000000000000000000001 -> $CURRENT_ID"
+assert_contains "$CLEAN_OUT" "generic project has no default 'lint' command"
+assert_version_equals "$CLEAN_PROJECT" "$CURRENT_ID"
+if ! git -C "$CLEAN_PROJECT" branch --show-current | grep -q '^chore/touchstone-'; then
+  echo "FAIL: expected auto-sync to leave project on a chore/touchstone-* update branch" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo ""
+echo "--- drift + dirty tree: warning, no sync, subcommand proceeds ---"
+DIRTY_HOME="$TEST_DIR/home-dirty"
+DIRTY_PROJECT="$TEST_DIR/project-dirty"
+DIRTY_OLD="0000000000000000000000000000000000000002"
+make_project "$DIRTY_PROJECT" "$DIRTY_OLD"
+printf 'dirty\n' >>"$DIRTY_PROJECT/README.md"
+DIRTY_OUT="$TEST_DIR/dirty.out"
+(cd "$DIRTY_PROJECT" && run_touchstone "$DIRTY_HOME" run validate) >"$DIRTY_OUT" 2>&1
+assert_contains "$DIRTY_OUT" "WARNING: touchstone auto-sync skipped for $DIRTY_PROJECT (working tree is dirty)."
+assert_contains "$DIRTY_OUT" "generic project has no default 'lint' command"
+assert_version_equals "$DIRTY_PROJECT" "$DIRTY_OLD"
+
+echo ""
+echo "--- no drift: no-op, subcommand proceeds ---"
+CURRENT_HOME="$TEST_DIR/home-current"
+CURRENT_PROJECT="$TEST_DIR/project-current"
+make_project "$CURRENT_PROJECT" "$CURRENT_ID"
+CURRENT_OUT="$TEST_DIR/current.out"
+(cd "$CURRENT_PROJECT" && run_touchstone "$CURRENT_HOME" run validate) >"$CURRENT_OUT" 2>&1
+assert_not_contains "$CURRENT_OUT" "auto-synced touchstone"
+assert_contains "$CURRENT_OUT" "generic project has no default 'lint' command"
+assert_version_equals "$CURRENT_PROJECT" "$CURRENT_ID"
+
+echo ""
+echo "--- TOUCHSTONE_NO_AUTO_PROJECT_SYNC=1: no-op on drift ---"
+NO_PROJECT_SYNC_HOME="$TEST_DIR/home-no-project-sync"
+NO_PROJECT_SYNC_PROJECT="$TEST_DIR/project-no-project-sync"
+NO_PROJECT_SYNC_OLD="0000000000000000000000000000000000000003"
+make_project "$NO_PROJECT_SYNC_PROJECT" "$NO_PROJECT_SYNC_OLD"
+NO_PROJECT_SYNC_OUT="$TEST_DIR/no-project-sync.out"
+(
+  cd "$NO_PROJECT_SYNC_PROJECT"
+  TOUCHSTONE_NO_AUTO_PROJECT_SYNC=1 run_touchstone "$NO_PROJECT_SYNC_HOME" run validate
+) >"$NO_PROJECT_SYNC_OUT" 2>&1
+assert_not_contains "$NO_PROJECT_SYNC_OUT" "auto-synced touchstone"
+assert_version_equals "$NO_PROJECT_SYNC_PROJECT" "$NO_PROJECT_SYNC_OLD"
+
+echo ""
+echo "--- TOUCHSTONE_NO_AUTO_UPDATE=1: no-op on drift ---"
+NO_AUTO_UPDATE_HOME="$TEST_DIR/home-no-auto-update"
+NO_AUTO_UPDATE_PROJECT="$TEST_DIR/project-no-auto-update"
+NO_AUTO_UPDATE_OLD="0000000000000000000000000000000000000004"
+make_project "$NO_AUTO_UPDATE_PROJECT" "$NO_AUTO_UPDATE_OLD"
+NO_AUTO_UPDATE_OUT="$TEST_DIR/no-auto-update.out"
+(
+  cd "$NO_AUTO_UPDATE_PROJECT"
+  TOUCHSTONE_NO_AUTO_UPDATE=1 run_touchstone "$NO_AUTO_UPDATE_HOME" run validate
+) >"$NO_AUTO_UPDATE_OUT" 2>&1
+assert_not_contains "$NO_AUTO_UPDATE_OUT" "auto-synced touchstone"
+assert_version_equals "$NO_AUTO_UPDATE_PROJECT" "$NO_AUTO_UPDATE_OLD"
+
+echo ""
+echo "--- non-touchstone project: no-op ---"
+PLAIN_HOME="$TEST_DIR/home-plain"
+PLAIN_PROJECT="$TEST_DIR/project-plain"
+mkdir -p "$PLAIN_PROJECT"
+git -C "$PLAIN_PROJECT" init -q
+PLAIN_OUT="$TEST_DIR/plain.out"
+(cd "$PLAIN_PROJECT" && run_touchstone "$PLAIN_HOME" run validate) >"$PLAIN_OUT" 2>&1
+assert_not_contains "$PLAIN_OUT" "auto-synced touchstone"
+assert_contains "$PLAIN_OUT" "generic project has no default 'lint' command"
+
+echo ""
+echo "--- touchstone version/help: read-only commands do not sync ---"
+VERSION_HOME="$TEST_DIR/home-version"
+VERSION_PROJECT="$TEST_DIR/project-version"
+VERSION_OLD="0000000000000000000000000000000000000005"
+make_project "$VERSION_PROJECT" "$VERSION_OLD"
+VERSION_OUT="$TEST_DIR/version.out"
+(cd "$VERSION_PROJECT" && run_touchstone "$VERSION_HOME" version) >"$VERSION_OUT" 2>&1
+assert_not_contains "$VERSION_OUT" "auto-synced touchstone"
+assert_contains "$VERSION_OUT" "touchstone v"
+assert_version_equals "$VERSION_PROJECT" "$VERSION_OLD"
+LONG_VERSION_OUT="$TEST_DIR/long-version.out"
+(cd "$VERSION_PROJECT" && run_touchstone "$VERSION_HOME" --version) >"$LONG_VERSION_OUT" 2>&1
+assert_not_contains "$LONG_VERSION_OUT" "auto-synced touchstone"
+assert_contains "$LONG_VERSION_OUT" "touchstone v"
+assert_version_equals "$VERSION_PROJECT" "$VERSION_OLD"
+HELP_OUT="$TEST_DIR/help.out"
+(cd "$VERSION_PROJECT" && run_touchstone "$VERSION_HOME" --help) >"$HELP_OUT" 2>&1
+assert_not_contains "$HELP_OUT" "auto-synced touchstone"
+assert_contains "$HELP_OUT" "TOUCHSTONE_NO_AUTO_PROJECT_SYNC"
+assert_version_equals "$VERSION_PROJECT" "$VERSION_OLD"
+
+if [ -e "$TEST_DIR/home-clean/.touchstone-projects" ] \
+  || [ -e "$TEST_DIR/home-dirty/.touchstone-projects" ] \
+  || [ -e "$TEST_DIR/home-current/.touchstone-projects" ]; then
+  echo "FAIL: auto-project-sync tests must not touch ~/.touchstone-projects" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+if [ "$ERRORS" -ne 0 ]; then
+  echo ""
+  echo "FAIL: $ERRORS auto-project-sync assertion(s) failed" >&2
+  exit 1
+fi
+
+echo ""
+echo "PASS: auto-project-sync"


### PR DESCRIPTION
## Summary

- add a Touchstone CLI auto-project-sync helper that detects `.touchstone-version` drift and runs the existing project update path on clean worktrees
- wire the helper before write-capable command dispatch while skipping read-only commands and opt-outs
- document auto-sync behavior, dirty-tree skip, and opt-out env vars

## Tests

- `for test in tests/test-*.sh; do echo "==> $test"; bash "$test" || exit 1; done`
- `CODEX_REVIEW_FORCE=1 TOUCHSTONE_CONDUCTOR_EXCLUDE=ollama bash scripts/codex-review.sh`

Closes #221
Closes #222
