### PR TITLE
fix(review): exclude ollama from default conductor review routing

### DIFF
--- a/.codex-review.toml
+++ b/.codex-review.toml
@@ -26,3 +26,8 @@ unsafe_paths = [
   "hooks/codex-review.sh",
   "templates/",
 ]
+
+[review.conductor]
+# Local ollama providers frequently time out during merge-gate code review on
+# substantial diffs unless the machine has a review-capable model loaded.
+exclude = ["ollama"]

--- a/hooks/codex-review.config.example.toml
+++ b/hooks/codex-review.config.example.toml
@@ -71,10 +71,18 @@ unsafe_paths = [
 # Conductor routing (optional)
 # --------------------------------------------------------------------------
 # Fine-tune what Conductor picks and how hard it thinks. By default,
-# Touchstone applies size-aware routing below; set these only when you want a
-# global fallback or a pinned provider.
+# Touchstone applies size-aware routing below and excludes ollama from review
+# auto-routing. Local ollama providers are useful for cheap background help,
+# but the merge gate needs predictable review output; during Wave 2 on
+# 2026-05-07, PRs #214, #215, and #216 all needed manual
+# TOUCHSTONE_CONDUCTOR_EXCLUDE=ollama or --with claude because the local
+# provider timed out or returned malformed review output on substantial diffs.
+#
+# Projects with a code-review-capable model loaded locally can re-enable
+# ollama with a one-line override:
+#   exclude = []
 
-# [review.conductor]
+[review.conductor]
 # # Which provider wins auto-routing. One of:
 # #   "best"     — highest-quality-tier (frontier > strong > standard > local)
 # #   "cheapest" — minimize $/tok (good for throwaway branches)
@@ -93,8 +101,8 @@ unsafe_paths = [
 # # Pin a specific provider (bypasses auto-routing). Rarely needed.
 # # with = "claude"
 #
-# # Exclude providers from auto-routing (degraded, rate-limited, too expensive).
-# # exclude = "gemini"
+# Exclude providers from auto-routing (degraded, rate-limited, too expensive).
+exclude = ["ollama"]
 
 # --------------------------------------------------------------------------
 # Routing by diff size (default)

--- a/tests/test-review-dry-run.sh
+++ b/tests/test-review-dry-run.sh
@@ -190,6 +190,30 @@ else
 fi
 
 # ----------------------------------------------------------------------------
+echo "==> Test: conductor exclude config reaches route preview"
+REPO_EXCLUDE="$TEST_DIR/repo-exclude"
+new_repo "$REPO_EXCLUDE"
+cat >"$REPO_EXCLUDE/.codex-review.toml" <<'EOF'
+[review.conductor]
+exclude = ["ollama"]
+EOF
+git -C "$REPO_EXCLUDE" add . && git -C "$REPO_EXCLUDE" commit -qm cfg
+echo c >>"$REPO_EXCLUDE/README.md" && git -C "$REPO_EXCLUDE" add . && git -C "$REPO_EXCLUDE" commit -qm change
+
+: >"$ARGS_FILE"
+out="$(run_review "$REPO_EXCLUDE" --dry-run --base HEAD~1 2>&1)"
+
+if grep -q '\-\-exclude ollama' "$ARGS_FILE" \
+  && echo "$out" | grep -q 'would pick: claude'; then
+  echo "==> PASS: [review.conductor].exclude reached conductor route"
+else
+  echo "FAIL: conductor exclude config should pass --exclude to route preview" >&2
+  echo "args: $(cat "$ARGS_FILE")" >&2
+  echo "out: $out" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ----------------------------------------------------------------------------
 echo '==> Test: --dry-run with `with =` pinned config skips route preview'
 REPO_PIN="$TEST_DIR/repo-pin"
 new_repo "$REPO_PIN"


### PR DESCRIPTION
## Linked Issues

Closes #218

Wave 2 PRs #214, #215, and #216 all needed manual provider intervention via TOUCHSTONE_CONDUCTOR_EXCLUDE=ollama, --with claude, or a documented bypass after local ollama review routing timed out or returned malformed output.

Closes-issue: #218

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
