### PR TITLE
fix(review): sync review helper libraries to downstream projects

### DIFF
--- a/.codex-review.toml
+++ b/.codex-review.toml
@@ -34,3 +34,4 @@ exclude = ["ollama"]
 
 [review]
 preflight_required = true
+comment_on_clean = true

--- a/.codex-review.toml
+++ b/.codex-review.toml
@@ -31,3 +31,6 @@ unsafe_paths = [
 # Local ollama providers frequently time out during merge-gate code review on
 # substantial diffs unless the machine has a review-capable model loaded.
 exclude = ["ollama"]
+
+[review]
+preflight_required = true

--- a/bin/touchstone
+++ b/bin/touchstone
@@ -7,6 +7,7 @@
 #   touchstone init [--no-setup] [--type node|python|swift|rust|go|generic|auto] [--reviewer conductor|none (or legacy: codex|claude|gemini|local|auto)]
 #                                      Add touchstone to the current project
 #   touchstone run <task>                  Run profile task: lint, test, build, typecheck, validate
+#   touchstone preflight                   Run deterministic review preflight checks
 #   touchstone run-script <name>           Prototype runner for pinned project-local script shims
 #   touchstone worker <command>            Manage worker worktree lifecycle
 #   touchstone update                     Update current project to latest touchstone
@@ -288,6 +289,10 @@ cmd_sync() {
 
 cmd_run() {
   exec bash "$TOUCHSTONE_ROOT/scripts/touchstone-run.sh" "$@"
+}
+
+cmd_preflight() {
+  exec bash "$TOUCHSTONE_ROOT/lib/preflight.sh" "$@"
 }
 
 cmd_worker() {
@@ -1578,6 +1583,7 @@ cmd_help() {
   printf "    ${BOLD}touchstone new${RESET} <dir>              Bootstrap a new project from scratch\n"
   printf "    ${BOLD}touchstone detect${RESET}                 Show detected project profile\n"
   printf "    ${BOLD}touchstone run${RESET} <task>             Run lint, typecheck, build, test, or validate\n"
+  printf "    ${BOLD}touchstone preflight${RESET}              Run deterministic review preflight checks\n"
   printf "    ${BOLD}touchstone run-script${RESET} <name>      Prototype runner for pinned script shims\n"
   printf "    ${BOLD}touchstone worker${RESET} spawn --task ... --type fix|feat|chore|refactor|docs\n"
   printf "    ${BOLD}touchstone worker${RESET} status --worktree <path> [--json]\n"
@@ -1639,6 +1645,7 @@ case "$COMMAND" in
   new)          cmd_new "$@" ;;
   init)         cmd_init "$@" ;;
   run)          cmd_run "$@" ;;
+  preflight)    cmd_preflight "$@" ;;
   run-script)   cmd_run_script "$@" ;;
   worker)      cmd_worker "$@" ;;
   detect)       cmd_detect ;;

--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -1079,6 +1079,8 @@ write_touchstone_manifest() {
     printf 'lib/toml.sh\n'
     printf 'lib/events.sh\n'
     printf 'lib/worker-state.sh\n'
+    printf 'lib/preflight.sh\n'
+    printf 'lib/review-comment.sh\n'
     if [ "$INPUT_TYPE" = "python" ]; then
       printf 'scripts/run-pytest-in-venv.sh\n'
     fi
@@ -1337,6 +1339,8 @@ mkdir -p "$PROJECT_DIR/lib"
 copy_file_force "$TOUCHSTONE_ROOT/lib/toml.sh" "$PROJECT_DIR/lib/toml.sh"
 copy_file_force "$TOUCHSTONE_ROOT/lib/events.sh" "$PROJECT_DIR/lib/events.sh"
 copy_file_force "$TOUCHSTONE_ROOT/lib/worker-state.sh" "$PROJECT_DIR/lib/worker-state.sh"
+copy_file_force "$TOUCHSTONE_ROOT/lib/preflight.sh" "$PROJECT_DIR/lib/preflight.sh"
+copy_file_force "$TOUCHSTONE_ROOT/lib/review-comment.sh" "$PROJECT_DIR/lib/review-comment.sh"
 
 # Claude Code settings — wires the branch-guard and emergency-disclosure
 # PreToolUse hooks shipped above. Touchstone-owned (overwritten on update);

--- a/bootstrap/update-project.sh
+++ b/bootstrap/update-project.sh
@@ -416,6 +416,8 @@ update_file "$TOUCHSTONE_ROOT/scripts/worker.sh" "$PROJECT_DIR/scripts/worker.sh
 update_file "$TOUCHSTONE_ROOT/lib/toml.sh" "$PROJECT_DIR/lib/toml.sh"
 update_file "$TOUCHSTONE_ROOT/lib/events.sh" "$PROJECT_DIR/lib/events.sh"
 update_file "$TOUCHSTONE_ROOT/lib/worker-state.sh" "$PROJECT_DIR/lib/worker-state.sh"
+update_file "$TOUCHSTONE_ROOT/lib/preflight.sh" "$PROJECT_DIR/lib/preflight.sh"
+update_file "$TOUCHSTONE_ROOT/lib/review-comment.sh" "$PROJECT_DIR/lib/review-comment.sh"
 
 if [ "$PROJECT_TYPE" = "python" ] || [ -f "$PROJECT_DIR/scripts/run-pytest-in-venv.sh" ]; then
   update_file "$TOUCHSTONE_ROOT/scripts/run-pytest-in-venv.sh" "$PROJECT_DIR/scripts/run-pytest-in-venv.sh"
@@ -567,6 +569,8 @@ write_touchstone_manifest() {
     printf 'lib/toml.sh\n'
     printf 'lib/events.sh\n'
     printf 'lib/worker-state.sh\n'
+    printf 'lib/preflight.sh\n'
+    printf 'lib/review-comment.sh\n'
     if [ "$PROJECT_TYPE" = "python" ] || [ -f "$PROJECT_DIR/scripts/run-pytest-in-venv.sh" ]; then
       printf 'scripts/run-pytest-in-venv.sh\n'
     fi

--- a/completions/touchstone.bash
+++ b/completions/touchstone.bash
@@ -3,7 +3,7 @@ _touchstone() {
   COMPREPLY=()
   cur="${COMP_WORDS[COMP_CWORD]}"
   prev="${COMP_WORDS[COMP_CWORD-1]}"
-  commands="init new update sync status doctor version list unregister diff adr release help"
+  commands="init new update sync status doctor version list unregister diff adr release preflight help"
 
   case "$prev" in
     touchstone)

--- a/completions/touchstone.zsh
+++ b/completions/touchstone.zsh
@@ -9,6 +9,7 @@ _touchstone() {
     'sync:Update all registered projects'
     'status:Show project status (use --all for the registry view)'
     'doctor:Report conductor-review fail-open trends'
+    'preflight:Run deterministic review preflight checks'
     'version:Show installed version'
     'list:Show registered projects'
     'unregister:Remove a project from the registry'

--- a/hooks/codex-review.config.example.toml
+++ b/hooks/codex-review.config.example.toml
@@ -65,6 +65,7 @@ unsafe_paths = [
 
 # [review]
 # enabled = true
+# preflight_required = true  # Run deterministic lint/test preflight before merge review; skips missing local tools visibly.
 # # reviewer = "conductor"   # single-valued in 2.0+; absent reviewers[]
 
 # --------------------------------------------------------------------------

--- a/hooks/codex-review.config.example.toml
+++ b/hooks/codex-review.config.example.toml
@@ -66,6 +66,7 @@ unsafe_paths = [
 # [review]
 # enabled = true
 # preflight_required = true  # Run deterministic lint/test preflight before merge review; skips missing local tools visibly.
+# comment_on_clean = true    # Leave a one-line PR audit trail after a clean merge review; set false for quiet repos.
 # # reviewer = "conductor"   # single-valued in 2.0+; absent reviewers[]
 
 # --------------------------------------------------------------------------

--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -2339,6 +2339,23 @@ parse_primary_provider() {
   printf '%s' "$line" | sed -nE 's/.*(→|-> ?)([a-zA-Z0-9_.-]+).*/\2/p' | head -1
 }
 
+parse_primary_model() {
+  local stderr_file="${1:-$REVIEW_STDERR_FILE}"
+  [ -f "$stderr_file" ] || {
+    printf ''
+    return
+  }
+  local line
+  line="$(grep -m1 '^\[conductor\]' "$stderr_file" 2>/dev/null || true)"
+  [ -n "$line" ] || {
+    printf ''
+    return
+  }
+  printf '%s' "$line" \
+    | sed -nE 's/.*(model|model_id|model-id)[=:][[:space:]]*([a-zA-Z0-9_.:/@-]+).*/\2/p' \
+    | head -1
+}
+
 conductor_invocation_label() {
   local conductor_path subcommand
   conductor_path="$(command -v conductor 2>/dev/null || printf 'conductor')"
@@ -2464,11 +2481,16 @@ check_worktree_invariants() {
 # --------------------------------------------------------------------------
 
 print_summary() {
-  local elapsed mins secs findings
+  local elapsed mins secs findings provider model peer_provider
   elapsed=$(($(date +%s) - REVIEW_START_TIME))
   mins=$((elapsed / 60))
   secs=$((elapsed % 60))
   findings="${REVIEW_FINDINGS_COUNT:-0}"
+  provider="$(parse_primary_provider)"
+  [ -n "$provider" ] || provider="${CONDUCTOR_WITH:-unknown}"
+  model="$(parse_primary_model)"
+  [ -n "$model" ] || model="unknown"
+  peer_provider="none"
 
   printf "\n  ${C_DIM}─── review summary ────────────────────────${C_RESET}\n"
   printf "  ${C_DIM}reviewer:       %s${C_RESET}\n" "$REVIEWER_LABEL"
@@ -2488,8 +2510,8 @@ print_summary() {
   printf "  ${C_DIM}──────────────────────────────────────────${C_RESET}\n"
 
   if [ -n "${CODEX_REVIEW_SUMMARY_FILE:-}" ]; then
-    printf '{"reviewer":"%s","route":"%s","mode":"%s","files":%d,"diff_lines":%d,"iterations":%d,"fix_commits":%d,"peer_assists":%d,"findings":%d,"exit_reason":"%s","elapsed_seconds":%d}\n' \
-      "$REVIEWER_LABEL" "$ROUTING_DECISION" "$REVIEW_MODE" "$REVIEW_FILES_INSPECTED" "$DIFF_LINE_COUNT" \
+    printf '{"reviewer":"%s","provider":"%s","model":"%s","peer_provider":"%s","route":"%s","mode":"%s","files":%d,"diff_lines":%d,"iterations":%d,"fix_commits":%d,"peer_assists":%d,"findings":%d,"exit_reason":"%s","elapsed_seconds":%d}\n' \
+      "$REVIEWER_LABEL" "$provider" "$model" "$peer_provider" "$ROUTING_DECISION" "$REVIEW_MODE" "$REVIEW_FILES_INSPECTED" "$DIFF_LINE_COUNT" \
       "${iter:-0}" "$FIX_COMMITS" "$ASSIST_ROUNDS" "$findings" "$REVIEW_EXIT_REASON" "$elapsed" \
       >"$CODEX_REVIEW_SUMMARY_FILE" 2>/dev/null || true
   fi

--- a/lib/preflight.sh
+++ b/lib/preflight.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+#
+# lib/preflight.sh — deterministic review preflight checks.
+#
+# Public entrypoint:
+#   touchstone_preflight_main [repo-root]
+#
+# Tooling policy: missing local linters are skipped with a visible line, not
+# treated as failures. Touchstone projects can run on fresh machines where the
+# deterministic gate should still enforce every installed check and the test
+# suite without turning optional dev-tool installation into a merge blocker.
+#
+set -euo pipefail
+
+touchstone_preflight_info() { printf '==> %s\n' "$*"; }
+touchstone_preflight_ok() { printf '  OK %s\n' "$*"; }
+touchstone_preflight_skip() { printf '  SKIP %s\n' "$*"; }
+touchstone_preflight_fail() { printf '  FAIL %s\n' "$*" >&2; }
+
+touchstone_preflight_repo_root() {
+  local requested="${1:-}"
+  if [ -n "$requested" ]; then
+    (cd "$requested" && pwd)
+    return
+  fi
+  git rev-parse --show-toplevel 2>/dev/null || pwd
+}
+
+touchstone_preflight_all_files() {
+  git ls-files 2>/dev/null
+}
+
+touchstone_preflight_changed_files() {
+  local base="${TOUCHSTONE_PREFLIGHT_BASE:-}"
+
+  if [ -z "$base" ]; then
+    base="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+    [ -n "$base" ] || base="origin/main"
+  fi
+
+  if git rev-parse --verify --quiet "$base^{commit}" >/dev/null 2>&1; then
+    {
+      git diff --name-only "$base"...HEAD 2>/dev/null || true
+      git diff --name-only --cached 2>/dev/null || true
+      git diff --name-only 2>/dev/null || true
+    } | sort -u
+    return 0
+  fi
+
+  touchstone_preflight_all_files
+}
+
+touchstone_preflight_shell_files() {
+  touchstone_preflight_changed_files \
+    | awk '
+        /^completions\// { next }
+        /^prototypes\// { next }
+        { print }
+      ' \
+    | while IFS= read -r path; do
+      [ -n "$path" ] || continue
+      [ -f "$path" ] || continue
+      case "$path" in
+        *.sh | bin/touchstone)
+          printf '%s\n' "$path"
+          ;;
+        *)
+          if IFS= read -r first_line <"$path" \
+            && printf '%s\n' "$first_line" | grep -Eq '^#!.*(sh|bash|zsh|ksh)'; then
+            printf '%s\n' "$path"
+          fi
+          ;;
+      esac
+    done
+}
+
+touchstone_preflight_shfmt_files() {
+  touchstone_preflight_shell_files \
+    | awk '
+        $0 == "bin/touchstone" { next }
+        { print }
+      '
+}
+
+touchstone_preflight_markdown_files() {
+  touchstone_preflight_changed_files \
+    | awk '
+        /^\.cortex\// { next }
+        /\.md$/ { print }
+      '
+}
+
+touchstone_preflight_workflow_files() {
+  touchstone_preflight_changed_files \
+    | awk '
+        /^\.github\/workflows\/.*\.ya?ml$/ { print }
+      '
+}
+
+touchstone_preflight_run_list() {
+  local label="$1"
+  local command_name="$2"
+  shift 2
+  local -a args=("$@")
+  local files
+
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    touchstone_preflight_skip "$label ($command_name not installed)"
+    return 0
+  fi
+
+  files="$(cat)"
+  if [ -z "$files" ]; then
+    touchstone_preflight_skip "$label (no matching files)"
+    return 0
+  fi
+
+  touchstone_preflight_info "$label"
+  if printf '%s\n' "$files" | xargs "$command_name" "${args[@]}"; then
+    touchstone_preflight_ok "$label"
+    return 0
+  fi
+
+  touchstone_preflight_fail "$label"
+  return 1
+}
+
+touchstone_preflight_markdownlint() {
+  local files
+  files="$(touchstone_preflight_markdown_files)"
+  if [ -z "$files" ]; then
+    touchstone_preflight_skip "markdownlint (no matching files)"
+    return 0
+  fi
+
+  if command -v markdownlint-cli2 >/dev/null 2>&1; then
+    touchstone_preflight_info "markdownlint-cli2"
+    if printf '%s\n' "$files" | xargs markdownlint-cli2; then
+      touchstone_preflight_ok "markdownlint-cli2"
+      return 0
+    fi
+    touchstone_preflight_fail "markdownlint-cli2"
+    return 1
+  fi
+
+  if command -v markdownlint >/dev/null 2>&1; then
+    touchstone_preflight_info "markdownlint"
+    if printf '%s\n' "$files" | xargs markdownlint --config .markdownlint.json; then
+      touchstone_preflight_ok "markdownlint"
+      return 0
+    fi
+    touchstone_preflight_fail "markdownlint"
+    return 1
+  fi
+
+  touchstone_preflight_skip "markdownlint (markdownlint-cli2/markdownlint not installed)"
+  return 0
+}
+
+touchstone_preflight_validate() {
+  local validate_script="${TOUCHSTONE_PREFLIGHT_VALIDATE_SCRIPT:-scripts/touchstone-run.sh}"
+  local validate_command="${TOUCHSTONE_PREFLIGHT_VALIDATE_COMMAND:-}"
+
+  if [ -n "$validate_command" ]; then
+    touchstone_preflight_info "tests ($validate_command)"
+    if TOUCHSTONE_PREFLIGHT_IN_PROGRESS=1 bash -c "$validate_command"; then
+      touchstone_preflight_ok "tests"
+      return 0
+    fi
+    touchstone_preflight_fail "tests"
+    return 1
+  fi
+
+  if [ ! -f "$validate_script" ]; then
+    touchstone_preflight_skip "tests ($validate_script not found)"
+    return 0
+  fi
+
+  touchstone_preflight_info "tests (touchstone-run validate)"
+  if TOUCHSTONE_PREFLIGHT_IN_PROGRESS=1 bash "$validate_script" validate; then
+    touchstone_preflight_ok "tests"
+    return 0
+  fi
+
+  touchstone_preflight_fail "tests"
+  return 1
+}
+
+touchstone_preflight_run() {
+  local repo_root="$1"
+  local failures=0
+
+  cd "$repo_root"
+  touchstone_preflight_info "preflight in $repo_root"
+
+  touchstone_preflight_shell_files \
+    | touchstone_preflight_run_list "shellcheck" shellcheck --severity=warning \
+    || failures=$((failures + 1))
+  touchstone_preflight_shfmt_files \
+    | touchstone_preflight_run_list "shfmt -d" shfmt -d -i 2 -ci -bn \
+    || failures=$((failures + 1))
+  touchstone_preflight_markdownlint || failures=$((failures + 1))
+  touchstone_preflight_workflow_files \
+    | touchstone_preflight_run_list "actionlint" actionlint \
+    || failures=$((failures + 1))
+  touchstone_preflight_validate || failures=$((failures + 1))
+
+  if [ "$failures" -eq 0 ]; then
+    touchstone_preflight_info "preflight clean"
+    return 0
+  fi
+
+  touchstone_preflight_fail "preflight failed ($failures check group(s))"
+  return 1
+}
+
+touchstone_preflight_main() {
+  local repo_root
+  repo_root="$(touchstone_preflight_repo_root "${1:-}")"
+  touchstone_preflight_run "$repo_root"
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  touchstone_preflight_main "$@"
+fi

--- a/lib/review-comment.sh
+++ b/lib/review-comment.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# lib/review-comment.sh — shared PR comment helpers for review events.
+#
+# Public interface:
+#   format_clean_review_comment <review-summary-json>
+#   post_pr_review_comment <pr-number> <comment-string>
+#   read_latest_review_event <jsonl-path>
+#
+set -euo pipefail
+
+review_comment_json_field() {
+  local json="$1"
+  local key="$2"
+  printf '%s\n' "$json" | sed -nE 's/.*"'"$key"'"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/p' | head -1
+}
+
+review_comment_json_number() {
+  local json="$1"
+  local key="$2"
+  printf '%s\n' "$json" | sed -nE 's/.*"'"$key"'"[[:space:]]*:[[:space:]]*([0-9]+).*/\1/p' | head -1
+}
+
+review_comment_clean_value() {
+  local value="$1"
+  value="$(printf '%s' "${value:-unknown}" | tr '\r\n\t' '   ')"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  [ -n "$value" ] || value="unknown"
+  printf '%s' "$value"
+}
+
+format_clean_review_comment() {
+  local json="$1"
+  local reviewer provider model peer iterations mode findings
+
+  reviewer="$(review_comment_clean_value "$(review_comment_json_field "$json" reviewer)")"
+  provider="$(review_comment_clean_value "$(review_comment_json_field "$json" provider)")"
+  model="$(review_comment_clean_value "$(review_comment_json_field "$json" model)")"
+  peer="$(review_comment_clean_value "$(review_comment_json_field "$json" peer_provider)")"
+  iterations="$(review_comment_clean_value "$(review_comment_json_number "$json" iterations)")"
+  mode="$(review_comment_clean_value "$(review_comment_json_field "$json" mode)")"
+  findings="$(review_comment_clean_value "$(review_comment_json_number "$json" findings)")"
+
+  printf '%s review clean - provider: %s, model: %s, peer: %s, iterations: %s, mode: %s, findings: %s' \
+    "$reviewer" "$provider" "$model" "$peer" "$iterations" "$mode" "$findings"
+}
+
+post_pr_review_comment() {
+  local pr_number="$1"
+  local comment="$2"
+
+  gh pr comment "$pr_number" --body "$comment"
+}
+
+read_latest_review_event() {
+  local log_path="$1"
+  [ -f "$log_path" ] || return 1
+  tail -n 1 "$log_path"
+}

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -2339,6 +2339,23 @@ parse_primary_provider() {
   printf '%s' "$line" | sed -nE 's/.*(→|-> ?)([a-zA-Z0-9_.-]+).*/\2/p' | head -1
 }
 
+parse_primary_model() {
+  local stderr_file="${1:-$REVIEW_STDERR_FILE}"
+  [ -f "$stderr_file" ] || {
+    printf ''
+    return
+  }
+  local line
+  line="$(grep -m1 '^\[conductor\]' "$stderr_file" 2>/dev/null || true)"
+  [ -n "$line" ] || {
+    printf ''
+    return
+  }
+  printf '%s' "$line" \
+    | sed -nE 's/.*(model|model_id|model-id)[=:][[:space:]]*([a-zA-Z0-9_.:/@-]+).*/\2/p' \
+    | head -1
+}
+
 conductor_invocation_label() {
   local conductor_path subcommand
   conductor_path="$(command -v conductor 2>/dev/null || printf 'conductor')"
@@ -2464,11 +2481,16 @@ check_worktree_invariants() {
 # --------------------------------------------------------------------------
 
 print_summary() {
-  local elapsed mins secs findings
+  local elapsed mins secs findings provider model peer_provider
   elapsed=$(($(date +%s) - REVIEW_START_TIME))
   mins=$((elapsed / 60))
   secs=$((elapsed % 60))
   findings="${REVIEW_FINDINGS_COUNT:-0}"
+  provider="$(parse_primary_provider)"
+  [ -n "$provider" ] || provider="${CONDUCTOR_WITH:-unknown}"
+  model="$(parse_primary_model)"
+  [ -n "$model" ] || model="unknown"
+  peer_provider="none"
 
   printf "\n  ${C_DIM}─── review summary ────────────────────────${C_RESET}\n"
   printf "  ${C_DIM}reviewer:       %s${C_RESET}\n" "$REVIEWER_LABEL"
@@ -2488,8 +2510,8 @@ print_summary() {
   printf "  ${C_DIM}──────────────────────────────────────────${C_RESET}\n"
 
   if [ -n "${CODEX_REVIEW_SUMMARY_FILE:-}" ]; then
-    printf '{"reviewer":"%s","route":"%s","mode":"%s","files":%d,"diff_lines":%d,"iterations":%d,"fix_commits":%d,"peer_assists":%d,"findings":%d,"exit_reason":"%s","elapsed_seconds":%d}\n' \
-      "$REVIEWER_LABEL" "$ROUTING_DECISION" "$REVIEW_MODE" "$REVIEW_FILES_INSPECTED" "$DIFF_LINE_COUNT" \
+    printf '{"reviewer":"%s","provider":"%s","model":"%s","peer_provider":"%s","route":"%s","mode":"%s","files":%d,"diff_lines":%d,"iterations":%d,"fix_commits":%d,"peer_assists":%d,"findings":%d,"exit_reason":"%s","elapsed_seconds":%d}\n' \
+      "$REVIEWER_LABEL" "$provider" "$model" "$peer_provider" "$ROUTING_DECISION" "$REVIEW_MODE" "$REVIEW_FILES_INSPECTED" "$DIFF_LINE_COUNT" \
       "${iter:-0}" "$FIX_COMMITS" "$ASSIST_ROUNDS" "$findings" "$REVIEW_EXIT_REASON" "$elapsed" \
       >"$CODEX_REVIEW_SUMMARY_FILE" 2>/dev/null || true
   fi

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -25,6 +25,7 @@ BYPASS_REASON=""
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REVIEW_SCRIPT="$SCRIPT_DIR/codex-review.sh"
 PREFLIGHT_SCRIPT="$SCRIPT_DIR/../lib/preflight.sh"
+REVIEW_COMMENT_SCRIPT="$SCRIPT_DIR/../lib/review-comment.sh"
 if [ -f "$SCRIPT_DIR/../lib/events.sh" ]; then
   # shellcheck source=../lib/events.sh
   source "$SCRIPT_DIR/../lib/events.sh"
@@ -35,11 +36,17 @@ if [ -f "$PREFLIGHT_SCRIPT" ]; then
   # shellcheck source=../lib/preflight.sh
   source "$PREFLIGHT_SCRIPT"
 fi
+if [ -f "$REVIEW_COMMENT_SCRIPT" ]; then
+  # shellcheck source=../lib/review-comment.sh
+  source "$REVIEW_COMMENT_SCRIPT"
+fi
 REVIEWED_HEAD_OID=""
 PR_HEAD_BRANCH=""
 BYPASS_REVIEW=false
 TOUCHSTONE_MERGE_FAILURE_REASON="nonzero-exit"
 PREFLIGHT_REQUIRED=true
+COMMENT_ON_CLEAN=true
+REVIEW_SUMMARY_FILE=""
 
 on_merge_exit() {
   local rc="$?"
@@ -134,6 +141,8 @@ load_merge_review_config() {
 
     if [ "$section" = "review" ] && [ "$key" = "preflight_required" ]; then
       PREFLIGHT_REQUIRED="$(normalize_bool "$value")"
+    elif [ "$section" = "review" ] && [ "$key" = "comment_on_clean" ]; then
+      COMMENT_ON_CLEAN="$(normalize_bool "$value")"
     fi
   }
 
@@ -419,6 +428,43 @@ record_bypass_comment() {
   gh pr comment "$PR_NUMBER" --body "Reviewer bypassed via \`--bypass-with-disclosure\`. Reason: $BYPASS_REASON"
 }
 
+post_clean_review_comment() {
+  local summary_file="$1"
+  local summary_json comment
+
+  if ! truthy "$COMMENT_ON_CLEAN"; then
+    echo "==> Clean-review PR comment disabled by [review].comment_on_clean=false."
+    return 0
+  fi
+  if [ "$BYPASS_REVIEW" = true ]; then
+    return 0
+  fi
+  if ! declare -F format_clean_review_comment >/dev/null 2>&1 \
+    || ! declare -F post_pr_review_comment >/dev/null 2>&1; then
+    echo "WARNING: review comment helper not found at $REVIEW_COMMENT_SCRIPT; skipping clean-review comment." >&2
+    return 0
+  fi
+  if [ -z "$summary_file" ] || [ ! -f "$summary_file" ]; then
+    echo "WARNING: clean review summary file missing; skipping clean-review comment." >&2
+    return 0
+  fi
+
+  summary_json="$(tail -n 1 "$summary_file" 2>/dev/null || true)"
+  if [ -z "$summary_json" ]; then
+    echo "WARNING: clean review summary file is empty; skipping clean-review comment." >&2
+    return 0
+  fi
+
+  comment="$(format_clean_review_comment "$summary_json")"
+  if post_pr_review_comment "$PR_NUMBER" "$comment"; then
+    echo "==> Posted clean-review PR comment."
+    return 0
+  fi
+
+  echo "WARNING: failed to post clean-review PR comment for PR #$PR_NUMBER." >&2
+  return 0
+}
+
 run_preflight_gate() {
   if ! truthy "$PREFLIGHT_REQUIRED"; then
     echo "==> Preflight disabled by [review].preflight_required=false."
@@ -582,11 +628,17 @@ run_merge_review() {
 
   echo "==> Running merge review ..."
   local review_rc=0
+  REVIEW_SUMMARY_FILE="$(git rev-parse --git-path "touchstone/review-summary-pr-${PR_NUMBER}.json" 2>/dev/null || echo "")"
+  if [ -n "$REVIEW_SUMMARY_FILE" ]; then
+    mkdir -p "$(dirname "$REVIEW_SUMMARY_FILE")" 2>/dev/null || true
+    rm -f "$REVIEW_SUMMARY_FILE" 2>/dev/null || true
+  fi
   touchstone_emit_event review_started pr_number="$PR_NUMBER" mode=review-only
   CODEX_REVIEW_BASE="$default_base_ref" \
     CODEX_REVIEW_BRANCH_NAME="$pr_head_branch" \
     CODEX_REVIEW_FORCE=1 \
     CODEX_REVIEW_MODE=review-only \
+    CODEX_REVIEW_SUMMARY_FILE="$REVIEW_SUMMARY_FILE" \
     bash "$REVIEW_SCRIPT" || review_rc=$?
 
   if [ "$review_rc" -eq 0 ]; then
@@ -718,6 +770,7 @@ fi
 
 MERGED_AT="$(gh pr view "$PR_NUMBER" --json mergedAt --jq '.mergedAt // empty' 2>/dev/null || echo "")"
 touchstone_emit_event merged pr_number="$PR_NUMBER" merged_at="$MERGED_AT" head_sha="$REVIEWED_HEAD_OID"
+post_clean_review_comment "$REVIEW_SUMMARY_FILE"
 
 # Record squash-merge metadata for cleanup-branches.sh. The merge has
 # succeeded on GitHub; this is best-effort persistence for later cleanup.

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -24,16 +24,22 @@ PR_NUMBER=""
 BYPASS_REASON=""
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REVIEW_SCRIPT="$SCRIPT_DIR/codex-review.sh"
+PREFLIGHT_SCRIPT="$SCRIPT_DIR/../lib/preflight.sh"
 if [ -f "$SCRIPT_DIR/../lib/events.sh" ]; then
   # shellcheck source=../lib/events.sh
   source "$SCRIPT_DIR/../lib/events.sh"
 else
   touchstone_emit_event() { :; }
 fi
+if [ -f "$PREFLIGHT_SCRIPT" ]; then
+  # shellcheck source=../lib/preflight.sh
+  source "$PREFLIGHT_SCRIPT"
+fi
 REVIEWED_HEAD_OID=""
 PR_HEAD_BRANCH=""
 BYPASS_REVIEW=false
 TOUCHSTONE_MERGE_FAILURE_REASON="nonzero-exit"
+PREFLIGHT_REQUIRED=true
 
 on_merge_exit() {
   local rc="$?"
@@ -102,6 +108,36 @@ truthy() {
     true | 1 | yes | on) return 0 ;;
     *) return 1 ;;
   esac
+}
+
+normalize_bool() {
+  case "$(printf '%s' "${1:-false}" | tr '[:upper:]' '[:lower:]')" in
+    true | 1 | yes | on) printf 'true' ;;
+    false | 0 | no | off) printf 'false' ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
+
+load_merge_review_config() {
+  local config_file
+  config_file="$(git rev-parse --show-toplevel 2>/dev/null)/.codex-review.toml"
+  [ -f "$config_file" ] || return 0
+  [ -f "$SCRIPT_DIR/../lib/toml.sh" ] || return 0
+
+  # shellcheck source=../lib/toml.sh
+  source "$SCRIPT_DIR/../lib/toml.sh"
+
+  merge_pr_toml_callback() {
+    local section="$1"
+    local key="$2"
+    local value="$3"
+
+    if [ "$section" = "review" ] && [ "$key" = "preflight_required" ]; then
+      PREFLIGHT_REQUIRED="$(normalize_bool "$value")"
+    fi
+  }
+
+  toml_parse "$config_file" merge_pr_toml_callback
 }
 
 review_clean_marker_key() {
@@ -383,6 +419,34 @@ record_bypass_comment() {
   gh pr comment "$PR_NUMBER" --body "Reviewer bypassed via \`--bypass-with-disclosure\`. Reason: $BYPASS_REASON"
 }
 
+run_preflight_gate() {
+  if ! truthy "$PREFLIGHT_REQUIRED"; then
+    echo "==> Preflight disabled by [review].preflight_required=false."
+    return 0
+  fi
+  if truthy "${TOUCHSTONE_NO_PREFLIGHT:-false}"; then
+    echo "==> Skipping preflight because TOUCHSTONE_NO_PREFLIGHT=1."
+    return 0
+  fi
+  if ! declare -F touchstone_preflight_main >/dev/null 2>&1; then
+    echo "==> Preflight helper not found at $PREFLIGHT_SCRIPT — skipping preflight."
+    return 0
+  fi
+
+  echo "==> Running deterministic preflight before merge review ..."
+  touchstone_emit_event preflight_started pr_number="$PR_NUMBER" mode=merge
+  if touchstone_preflight_main "$(git rev-parse --show-toplevel)"; then
+    touchstone_emit_event preflight_clean pr_number="$PR_NUMBER" head_sha="$pr_head_oid"
+    return 0
+  fi
+
+  echo "ERROR: Deterministic preflight failed; refusing to spend provider tokens on review." >&2
+  echo "       Fix the preflight failure or set TOUCHSTONE_NO_PREFLIGHT=1 for an emergency bypass." >&2
+  touchstone_emit_event preflight_blocked pr_number="$PR_NUMBER" head_sha="$pr_head_oid"
+  TOUCHSTONE_MERGE_FAILURE_REASON="preflight-blocked"
+  return 1
+}
+
 run_merge_review() {
   local current_branch default_base_ref local_head pr_head_branch pr_head_oid
 
@@ -514,6 +578,8 @@ run_merge_review() {
     exit 1
   fi
 
+  run_preflight_gate || return $?
+
   echo "==> Running merge review ..."
   local review_rc=0
   touchstone_emit_event review_started pr_number="$PR_NUMBER" mode=review-only
@@ -555,6 +621,8 @@ run_merge_review() {
   TOUCHSTONE_MERGE_FAILURE_REASON="review-blocked"
   return "$review_rc"
 }
+
+load_merge_review_config
 
 # 1. Sanity check the PR exists and is open.
 if ! PR_STATE="$(gh pr view "$PR_NUMBER" --json state --jq '.state')"; then

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -160,6 +160,8 @@ assert_exists "$PROJECT/principles/README.md"
 # Scripts
 assert_exists "$PROJECT/scripts/codex-review.sh"
 assert_exists "$PROJECT/lib/toml.sh"
+assert_exists "$PROJECT/lib/preflight.sh"
+assert_exists "$PROJECT/lib/review-comment.sh"
 assert_exists "$PROJECT/scripts/touchstone-run.sh"
 assert_exists "$PROJECT/scripts/open-pr.sh"
 assert_exists "$PROJECT/scripts/merge-pr.sh"
@@ -193,6 +195,8 @@ assert_contains "$PROJECT/.touchstone-manifest" '^scripts/open-pr.sh$'
 assert_contains "$PROJECT/.touchstone-manifest" '^scripts/spawn-worktree.sh$'
 assert_contains "$PROJECT/.touchstone-manifest" '^scripts/cleanup-worktrees.sh$'
 assert_contains "$PROJECT/.touchstone-manifest" '^lib/toml\.sh$'
+assert_contains "$PROJECT/.touchstone-manifest" '^lib/preflight\.sh$'
+assert_contains "$PROJECT/.touchstone-manifest" '^lib/review-comment\.sh$'
 if grep -q '^\.touchstone-config$' "$PROJECT/.gitignore"; then
   echo "FAIL: expected .touchstone-config to be commit-friendly, not ignored" >&2
   ERRORS=$((ERRORS + 1))

--- a/tests/test-preflight.sh
+++ b/tests/test-preflight.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+#
+# tests/test-preflight.sh — deterministic preflight gate and merge short-circuit.
+#
+set -euo pipefail
+
+if [ "${TOUCHSTONE_PREFLIGHT_IN_PROGRESS:-0}" = "1" ]; then
+  echo "==> SKIP: test-preflight avoids recursive touchstone preflight"
+  exit 0
+fi
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_DIR="$(mktemp -d -t touchstone-test-preflight.XXXXXX)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+echo "==> Test: touchstone preflight exits clean on this tree"
+TOUCHSTONE_NO_AUTO_UPDATE=1 \
+  TOUCHSTONE_PREFLIGHT_VALIDATE_COMMAND=: \
+  bash "$TOUCHSTONE_ROOT/bin/touchstone" preflight "$TOUCHSTONE_ROOT" >"$TEST_DIR/clean.txt" 2>&1
+if grep -q '==> preflight clean' "$TEST_DIR/clean.txt"; then
+  echo "==> PASS: clean tree preflight exits 0"
+else
+  echo "FAIL: clean tree preflight did not report clean" >&2
+  cat "$TEST_DIR/clean.txt" >&2
+  exit 1
+fi
+
+echo "==> Test: broken shell fixture fails with a clear failure line"
+FIXTURE_REPO="$TEST_DIR/fixture-repo"
+FAKE_BIN="$TEST_DIR/bin"
+mkdir -p "$FIXTURE_REPO" "$FAKE_BIN"
+(
+  cd "$FIXTURE_REPO"
+  git init -q
+  git config user.email test@example.com
+  git config user.name "Touchstone Test"
+  printf 'if true; then\n  echo broken\n' >broken.sh
+  git add broken.sh
+  git commit -q -m "broken fixture"
+)
+cat >"$FAKE_BIN/shellcheck" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'broken.sh: missing fi\n' >&2
+exit 1
+EOF
+cat >"$FAKE_BIN/shfmt" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$FAKE_BIN/shellcheck" "$FAKE_BIN/shfmt"
+
+if PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+  TOUCHSTONE_NO_AUTO_UPDATE=1 \
+  TOUCHSTONE_PREFLIGHT_VALIDATE_COMMAND=: \
+  bash "$TOUCHSTONE_ROOT/bin/touchstone" preflight "$FIXTURE_REPO" >"$TEST_DIR/broken.txt" 2>&1; then
+  echo "FAIL: broken shell fixture unexpectedly passed preflight" >&2
+  cat "$TEST_DIR/broken.txt" >&2
+  exit 1
+fi
+if grep -q 'FAIL shellcheck' "$TEST_DIR/broken.txt" \
+  && grep -q 'FAIL preflight failed' "$TEST_DIR/broken.txt"; then
+  echo "==> PASS: broken shell fixture fails visibly"
+else
+  echo "FAIL: broken fixture did not produce expected failure lines" >&2
+  cat "$TEST_DIR/broken.txt" >&2
+  exit 1
+fi
+
+MERGE_DIR="$TEST_DIR/merge"
+mkdir -p "$MERGE_DIR/scripts" "$MERGE_DIR/lib" "$MERGE_DIR/bin" "$MERGE_DIR/repo"
+cp "$TOUCHSTONE_ROOT/scripts/merge-pr.sh" "$MERGE_DIR/scripts/merge-pr.sh"
+cp "$TOUCHSTONE_ROOT/lib/preflight.sh" "$MERGE_DIR/lib/preflight.sh"
+cp "$TOUCHSTONE_ROOT/lib/toml.sh" "$MERGE_DIR/lib/toml.sh"
+cat >"$MERGE_DIR/scripts/codex-review.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo invoked > "$CODEX_REVIEW_LOG"
+EOF
+chmod +x "$MERGE_DIR/scripts/merge-pr.sh" "$MERGE_DIR/scripts/codex-review.sh"
+printf '[review]\npreflight_required = true\n' >"$MERGE_DIR/repo/.codex-review.toml"
+printf 'if true; then\n  echo broken\n' >"$MERGE_DIR/repo/broken.sh"
+
+cat >"$MERGE_DIR/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-} ${2:-}" in
+  "repo view") echo "main" ;;
+  "pr view")
+    case "${5:-}" in
+      state) echo "OPEN" ;;
+      headRefName) echo "feature/test" ;;
+      headRefOid) echo "pr-head-oid" ;;
+      mergeStateStatus,mergeable) echo "CLEAN MERGEABLE" ;;
+      *) echo "unexpected gh pr view args: $*" >&2; exit 1 ;;
+    esac
+    ;;
+  "pr checkout") echo checked-out > "$GH_CHECKOUT_FILE" ;;
+  "pr merge") echo merged > "$GH_MERGE_FILE" ;;
+  "pr comment") echo comment > "$GH_COMMENT_FILE" ;;
+  *) echo "unexpected gh args: $*" >&2; exit 1 ;;
+esac
+EOF
+cat >"$MERGE_DIR/bin/git" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  "rev-parse --show-toplevel") printf '%s\n' "$TEST_REPO_ROOT" ;;
+  "rev-parse --abbrev-ref HEAD")
+    if [ -f "$GH_CHECKOUT_FILE" ]; then echo "HEAD"; else echo "feature/test"; fi
+    ;;
+  "rev-parse HEAD")
+    if [ -f "$GH_CHECKOUT_FILE" ]; then echo "pr-head-oid"; else echo "stale-local-oid"; fi
+    ;;
+  "rev-parse --git-path touchstone/reviewer-clean") printf '%s\n' "$TEST_REPO_ROOT/.git/touchstone/reviewer-clean" ;;
+  "rev-parse --git-path touchstone/squash-map.jsonl") printf '%s\n' "$TEST_REPO_ROOT/.git/touchstone/squash-map.jsonl" ;;
+  "rev-parse feature/test") echo "pr-head-oid" ;;
+  "rev-parse --verify --quiet origin/main^{commit}") echo "base-oid" ;;
+  "fetch origin +refs/heads/main:refs/remotes/origin/main") echo fetched ;;
+  "cat-file -e pr-head-oid^{commit}") ;;
+  "merge-base origin/main pr-head-oid") echo "base-oid" ;;
+  "status --porcelain") ;;
+  "diff --name-only origin/main...HEAD") echo "broken.sh" ;;
+  "diff --name-only --cached") ;;
+  "diff --name-only") ;;
+  "ls-files") echo "broken.sh" ;;
+  "worktree list --porcelain") ;;
+  *) echo "unexpected git args: $*" >&2; exit 1 ;;
+esac
+EOF
+cat >"$MERGE_DIR/bin/shellcheck" <<'EOF'
+#!/usr/bin/env bash
+exit "${PREFLIGHT_SHELLCHECK_EXIT:-1}"
+EOF
+cat >"$MERGE_DIR/bin/shfmt" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$MERGE_DIR/bin/gh" "$MERGE_DIR/bin/git" "$MERGE_DIR/bin/shellcheck" "$MERGE_DIR/bin/shfmt"
+
+run_merge_fixture() {
+  local output_file="$1"
+  shift
+  PATH="$MERGE_DIR/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+    TEST_REPO_ROOT="$MERGE_DIR/repo" \
+    GH_CHECKOUT_FILE="$TEST_DIR/gh-checkout" \
+    GH_MERGE_FILE="$TEST_DIR/gh-merge" \
+    GH_COMMENT_FILE="$TEST_DIR/gh-comment" \
+    CODEX_REVIEW_LOG="$TEST_DIR/codex-review.log" \
+    TOUCHSTONE_PREFLIGHT_VALIDATE_COMMAND=: \
+    bash "$MERGE_DIR/scripts/merge-pr.sh" "$@" >"$output_file" 2>&1
+}
+
+echo "==> Test: merge-pr short-circuits when preflight fails"
+rm -f "$TEST_DIR/codex-review.log" "$TEST_DIR/gh-merge"
+if run_merge_fixture "$TEST_DIR/merge-preflight-fail.txt" 123; then
+  echo "FAIL: merge-pr unexpectedly succeeded with failing preflight" >&2
+  cat "$TEST_DIR/merge-preflight-fail.txt" >&2
+  exit 1
+fi
+if grep -q 'Deterministic preflight failed' "$TEST_DIR/merge-preflight-fail.txt" \
+  && [ ! -f "$TEST_DIR/codex-review.log" ] \
+  && [ ! -f "$TEST_DIR/gh-merge" ]; then
+  echo "==> PASS: preflight failure blocks before review"
+else
+  echo "FAIL: preflight failure did not short-circuit review/merge" >&2
+  cat "$TEST_DIR/merge-preflight-fail.txt" >&2
+  exit 1
+fi
+
+echo "==> Test: TOUCHSTONE_NO_PREFLIGHT skips preflight and invokes review"
+rm -f "$TEST_DIR/codex-review.log" "$TEST_DIR/gh-merge"
+TOUCHSTONE_NO_PREFLIGHT=1 run_merge_fixture "$TEST_DIR/merge-preflight-skip.txt" 123
+if grep -q 'Skipping preflight because TOUCHSTONE_NO_PREFLIGHT=1' "$TEST_DIR/merge-preflight-skip.txt" \
+  && grep -q '^invoked$' "$TEST_DIR/codex-review.log"; then
+  echo "==> PASS: TOUCHSTONE_NO_PREFLIGHT bypasses preflight"
+else
+  echo "FAIL: TOUCHSTONE_NO_PREFLIGHT did not skip preflight cleanly" >&2
+  cat "$TEST_DIR/merge-preflight-skip.txt" >&2
+  exit 1
+fi

--- a/tests/test-review-comment.sh
+++ b/tests/test-review-comment.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+#
+# tests/test-review-comment.sh — clean-review PR comment helper and merge wiring.
+#
+set -euo pipefail
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_DIR="$(mktemp -d -t touchstone-test-review-comment.XXXXXX)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+echo "==> Test: format_clean_review_comment produces one-line audit text"
+# shellcheck source=../lib/review-comment.sh
+source "$TOUCHSTONE_ROOT/lib/review-comment.sh"
+COMMENT="$(format_clean_review_comment '{"reviewer":"Conductor","provider":"gemini","model":"gemini-2.5-pro","peer_provider":"none","iterations":1,"mode":"review-only","findings":0}')"
+EXPECTED='Conductor review clean - provider: gemini, model: gemini-2.5-pro, peer: none, iterations: 1, mode: review-only, findings: 0'
+if [ "$COMMENT" = "$EXPECTED" ]; then
+  echo "==> PASS: formatter output matches"
+else
+  echo "FAIL: formatter output mismatch" >&2
+  printf 'expected: %s\nactual:   %s\n' "$EXPECTED" "$COMMENT" >&2
+  exit 1
+fi
+
+MERGE_DIR="$TEST_DIR/merge"
+FAKE_BIN="$MERGE_DIR/bin"
+mkdir -p "$MERGE_DIR/scripts" "$MERGE_DIR/lib" "$MERGE_DIR/repo" "$FAKE_BIN"
+cp "$TOUCHSTONE_ROOT/scripts/merge-pr.sh" "$MERGE_DIR/scripts/merge-pr.sh"
+cp "$TOUCHSTONE_ROOT/lib/preflight.sh" "$MERGE_DIR/lib/preflight.sh"
+cp "$TOUCHSTONE_ROOT/lib/review-comment.sh" "$MERGE_DIR/lib/review-comment.sh"
+cp "$TOUCHSTONE_ROOT/lib/toml.sh" "$MERGE_DIR/lib/toml.sh"
+cat >"$MERGE_DIR/scripts/codex-review.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '{"reviewer":"Conductor","provider":"claude","model":"claude-opus-4-1","peer_provider":"none","iterations":1,"mode":"%s","findings":0,"exit_reason":"clean"}\n' "${CODEX_REVIEW_MODE:-unknown}" > "$CODEX_REVIEW_SUMMARY_FILE"
+printf 'review invoked\n' > "$CODEX_REVIEW_LOG"
+exit 0
+EOF
+chmod +x "$MERGE_DIR/scripts/merge-pr.sh" "$MERGE_DIR/scripts/codex-review.sh"
+
+cat >"$FAKE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-} ${2:-}" in
+  "repo view")
+    echo "main"
+    ;;
+  "pr view")
+    case "${5:-}" in
+      state)
+        if [ -f "${GH_MERGED_MARKER:-/dev/null/never}" ]; then echo "MERGED"; else echo "OPEN"; fi
+        ;;
+      headRefName) echo "feature/test" ;;
+      headRefOid) echo "pr-head-oid" ;;
+      mergeStateStatus,mergeable) echo "CLEAN MERGEABLE" ;;
+      mergedAt) echo "2026-05-07T15:00:00Z" ;;
+      mergeCommit) echo "squash-oid" ;;
+      *) echo "unexpected gh pr view args: $*" >&2; exit 1 ;;
+    esac
+    ;;
+  "pr checkout")
+    echo checked-out > "$GH_CHECKOUT_FILE"
+    ;;
+  "pr comment")
+    if [ "${4:-}" != "--body" ]; then
+      echo "unexpected gh pr comment args: $*" >&2
+      exit 1
+    fi
+    printf '%s\n' "${5:-}" >> "$GH_COMMENT_FILE"
+    ;;
+  "pr merge")
+    echo "$7" > "$GH_MERGE_HEAD_FILE"
+    [ -n "${GH_MERGED_MARKER:-}" ] && touch "$GH_MERGED_MARKER"
+    if [ "${8:-}" = "--body" ]; then
+      printf '%s\n' "${9:-}" > "$GH_MERGE_BODY_FILE"
+    fi
+    ;;
+  *) echo "unexpected gh args: $*" >&2; exit 1 ;;
+esac
+EOF
+
+cat >"$FAKE_BIN/git" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  "rev-parse --show-toplevel") printf '%s\n' "$TEST_REPO_ROOT" ;;
+  "rev-parse --abbrev-ref HEAD")
+    if [ -f "$GH_CHECKOUT_FILE" ]; then echo "HEAD"; else echo "feature/test"; fi
+    ;;
+  "rev-parse HEAD")
+    if [ -f "$GH_CHECKOUT_FILE" ]; then echo "pr-head-oid"; else echo "stale-local-oid"; fi
+    ;;
+  "rev-parse feature/test") echo "pr-head-oid" ;;
+  "rev-parse --verify --quiet origin/main^{commit}") echo "base-oid" ;;
+  "rev-parse --git-path touchstone/reviewer-clean") printf '%s\n' "$TEST_REPO_ROOT/.git/touchstone/reviewer-clean" ;;
+  "rev-parse --git-path touchstone/squash-map.jsonl") printf '%s\n' "$TEST_REPO_ROOT/.git/touchstone/squash-map.jsonl" ;;
+  rev-parse\ --git-path\ touchstone/review-summary-pr-123.json) printf '%s\n' "$TEST_REPO_ROOT/.git/touchstone/review-summary-pr-123.json" ;;
+  "fetch origin +refs/heads/main:refs/remotes/origin/main") echo fetched ;;
+  "cat-file -e pr-head-oid^{commit}") ;;
+  "merge-base origin/main pr-head-oid") echo "base-oid" ;;
+  "status --porcelain") ;;
+  "diff --name-only origin/main...HEAD") ;;
+  "diff --name-only --cached") ;;
+  "diff --name-only") ;;
+  "ls-files") ;;
+  "worktree list --porcelain") ;;
+  "checkout main") echo main > "$GIT_CHECKOUT_MAIN_FILE" ;;
+  "pull --rebase") ;;
+  "show-ref --verify --quiet refs/heads/feature/test") ;;
+  "branch -D feature/test") ;;
+  *) echo "unexpected git args: $*" >&2; exit 1 ;;
+esac
+EOF
+chmod +x "$FAKE_BIN/gh" "$FAKE_BIN/git"
+
+reset_fixture() {
+  rm -f "$TEST_DIR"/comments "$TEST_DIR"/merge-head "$TEST_DIR"/merge-body \
+    "$TEST_DIR"/review.log "$TEST_DIR"/merged "$TEST_DIR"/checkout "$TEST_DIR"/git-checkout-main
+  rm -rf "$MERGE_DIR/repo/.git"
+  mkdir -p "$MERGE_DIR/repo/.git"
+}
+
+run_merge() {
+  local output_file="$1"
+  shift
+  PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    TEST_REPO_ROOT="$MERGE_DIR/repo" \
+    GH_COMMENT_FILE="$TEST_DIR/comments" \
+    GH_MERGE_HEAD_FILE="$TEST_DIR/merge-head" \
+    GH_MERGE_BODY_FILE="$TEST_DIR/merge-body" \
+    GH_MERGED_MARKER="$TEST_DIR/merged" \
+    GH_CHECKOUT_FILE="$TEST_DIR/checkout" \
+    GIT_CHECKOUT_MAIN_FILE="$TEST_DIR/git-checkout-main" \
+    CODEX_REVIEW_LOG="$TEST_DIR/review.log" \
+    TOUCHSTONE_NO_PREFLIGHT=1 \
+    bash "$MERGE_DIR/scripts/merge-pr.sh" "$@" >"$output_file" 2>&1
+}
+
+echo "==> Test: clean merge review posts a one-line PR comment"
+reset_fixture
+printf '[review]\ncomment_on_clean = true\n' >"$MERGE_DIR/repo/.codex-review.toml"
+run_merge "$TEST_DIR/merge-clean.txt" 123
+if grep -q '^Conductor review clean - provider: claude, model: claude-opus-4-1, peer: none, iterations: 1, mode: review-only, findings: 0$' "$TEST_DIR/comments" \
+  && grep -q '==> Posted clean-review PR comment\.' "$TEST_DIR/merge-clean.txt"; then
+  echo "==> PASS: clean review comment posted"
+else
+  echo "FAIL: clean review comment was not posted as expected" >&2
+  cat "$TEST_DIR/merge-clean.txt" >&2
+  [ -f "$TEST_DIR/comments" ] && cat "$TEST_DIR/comments" >&2
+  exit 1
+fi
+
+echo "==> Test: comment_on_clean=false skips clean-review comment"
+reset_fixture
+printf '[review]\ncomment_on_clean = false\n' >"$MERGE_DIR/repo/.codex-review.toml"
+run_merge "$TEST_DIR/merge-disabled.txt" 123
+if grep -q 'Clean-review PR comment disabled' "$TEST_DIR/merge-disabled.txt" \
+  && [ ! -f "$TEST_DIR/comments" ]; then
+  echo "==> PASS: config disables clean-review comment"
+else
+  echo "FAIL: comment_on_clean=false did not skip comment" >&2
+  cat "$TEST_DIR/merge-disabled.txt" >&2
+  [ -f "$TEST_DIR/comments" ] && cat "$TEST_DIR/comments" >&2
+  exit 1
+fi
+
+echo "==> Test: bypass path still posts only existing disclosure"
+reset_fixture
+printf '[review]\ncomment_on_clean = true\n' >"$MERGE_DIR/repo/.codex-review.toml"
+mkdir -p "$MERGE_DIR/repo/.git/touchstone/reviewer-clean"
+printf 'result=CODEX_REVIEW_CLEAN\nbranch=feature/test\nhead=pr-head-oid\nmerge_base=base-oid\n' >"$MERGE_DIR/repo/.git/touchstone/reviewer-clean/feature_test.clean"
+run_merge "$TEST_DIR/merge-bypass.txt" 123 --bypass-with-disclosure="reviewer wedged after clean marker"
+if grep -q 'Reviewer bypassed via `--bypass-with-disclosure`. Reason: reviewer wedged after clean marker' "$TEST_DIR/comments" \
+  && ! grep -q 'review clean' "$TEST_DIR/comments"; then
+  echo "==> PASS: bypass disclosure unchanged and no clean comment posted"
+else
+  echo "FAIL: bypass disclosure path regressed" >&2
+  cat "$TEST_DIR/merge-bypass.txt" >&2
+  [ -f "$TEST_DIR/comments" ] && cat "$TEST_DIR/comments" >&2
+  exit 1
+fi

--- a/tests/test-update.sh
+++ b/tests/test-update.sh
@@ -124,12 +124,16 @@ assert_exists "$PROJECT/scripts/spawn-worktree.sh"
 assert_exists "$PROJECT/scripts/cleanup-worktrees.sh"
 assert_exists "$PROJECT/lib/toml.sh"
 assert_exists "$PROJECT/lib/events.sh"
+assert_exists "$PROJECT/lib/preflight.sh"
+assert_exists "$PROJECT/lib/review-comment.sh"
 assert_exists "$PROJECT/.touchstone-manifest"
 assert_contains "$PROJECT/.touchstone-manifest" '^scripts/touchstone-run.sh$'
 assert_contains "$PROJECT/.touchstone-manifest" '^scripts/spawn-worktree.sh$'
 assert_contains "$PROJECT/.touchstone-manifest" '^scripts/cleanup-worktrees.sh$'
 assert_contains "$PROJECT/.touchstone-manifest" '^lib/toml\.sh$'
 assert_contains "$PROJECT/.touchstone-manifest" '^lib/events\.sh$'
+assert_contains "$PROJECT/.touchstone-manifest" '^lib/preflight\.sh$'
+assert_contains "$PROJECT/.touchstone-manifest" '^lib/review-comment\.sh$'
 assert_not_exists "$PROJECT/principles/engineering-principles.md.bak"
 assert_not_exists "$PROJECT/.claude/settings.json.touchstone-pre-update.bak"
 


### PR DESCRIPTION
## Linked Issues

Closes #199
Closes #196

Invariant: synced merge-pr.sh dependencies exist in bootstrapped and updated projects.

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
