### PR TITLE
feat(review): surface fix-loop findings history as PR-visible audit artifact

### DIFF
--- a/.codex-review.toml
+++ b/.codex-review.toml
@@ -35,3 +35,4 @@ exclude = ["ollama"]
 [review]
 preflight_required = true
 comment_on_clean = true
+advisory_at_pr_open = true

--- a/.codex-review.toml
+++ b/.codex-review.toml
@@ -36,3 +36,4 @@ exclude = ["ollama"]
 preflight_required = true
 comment_on_clean = true
 advisory_at_pr_open = true
+comment_findings_history = true

--- a/hooks/codex-review.config.example.toml
+++ b/hooks/codex-review.config.example.toml
@@ -68,6 +68,7 @@ unsafe_paths = [
 # preflight_required = true  # Run deterministic lint/test preflight before merge review; skips missing local tools visibly.
 # comment_on_clean = true    # Leave a one-line PR audit trail after a clean merge review; set false for quiet repos.
 # advisory_at_pr_open = true       # Run non-blocking review after PR creation and post the result as a PR comment.
+# comment_findings_history = true  # After merge, post a collapsed history when the fix loop raised or auto-fixed findings.
 # # reviewer = "conductor"   # single-valued in 2.0+; absent reviewers[]
 
 # --------------------------------------------------------------------------

--- a/hooks/codex-review.config.example.toml
+++ b/hooks/codex-review.config.example.toml
@@ -67,6 +67,7 @@ unsafe_paths = [
 # enabled = true
 # preflight_required = true  # Run deterministic lint/test preflight before merge review; skips missing local tools visibly.
 # comment_on_clean = true    # Leave a one-line PR audit trail after a clean merge review; set false for quiet repos.
+# advisory_at_pr_open = true       # Run non-blocking review after PR creation and post the result as a PR comment.
 # # reviewer = "conductor"   # single-valued in 2.0+; absent reviewers[]
 
 # --------------------------------------------------------------------------

--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -1970,6 +1970,15 @@ review_findings_file() {
   printf '%s/%s.findings' "$(review_findings_dir)" "$(review_clean_marker_key "$branch")"
 }
 
+review_findings_history_dir() {
+  git rev-parse --git-path touchstone/reviewer-findings-history
+}
+
+review_findings_history_file() {
+  local branch="$1"
+  printf '%s/%s.jsonl' "$(review_findings_history_dir)" "$(review_clean_marker_key "$branch")"
+}
+
 # Strip trailing whitespace from each line and drop empty trailing lines.
 # Findings text comes from the reviewer's stdout, which can include shell
 # color codes or stray indentation; the gate only persists lines that start
@@ -2018,6 +2027,106 @@ clear_review_findings() {
   findings_file="$(review_findings_file "$branch")"
   [ -f "$findings_file" ] || return 0
   rm -f "$findings_file" 2>/dev/null || true
+}
+
+json_escape() {
+  awk '
+    {
+      gsub(/\\/, "\\\\")
+      gsub(/"/, "\\\"")
+      if (NR > 1) {
+        printf "\\n"
+      }
+      printf "%s", $0
+    }
+  '
+}
+
+review_history_path() {
+  local branch
+  if [ -n "${CODEX_REVIEW_FINDINGS_HISTORY_FILE:-}" ]; then
+    printf '%s' "$CODEX_REVIEW_FINDINGS_HISTORY_FILE"
+    return 0
+  fi
+  branch="$(review_clean_marker_branch)"
+  [ -n "$branch" ] || return 1
+  review_findings_history_file "$branch"
+}
+
+review_history_last_head() {
+  local history_file="$1"
+  [ -f "$history_file" ] || return 0
+  awk -F'"head":"' '
+    /"schema":"touchstone.review.findings_history.v1"/ && NF > 1 {
+      split($2, parts, "\"")
+      head = parts[1]
+    }
+    END { if (head != "") print head }
+  ' "$history_file" 2>/dev/null
+}
+
+review_history_commits_since_prior() {
+  local prior_head="$1"
+  local current_head="$2"
+  [ -n "$prior_head" ] || return 0
+  [ -n "$current_head" ] || return 0
+  [ "$prior_head" != "$current_head" ] || return 0
+  git rev-parse --verify --quiet "$prior_head^{commit}" >/dev/null 2>&1 || return 0
+  git merge-base --is-ancestor "$prior_head" "$current_head" 2>/dev/null || return 0
+  git log --format='%h %s' "$prior_head..$current_head" 2>/dev/null \
+    | awk 'NF { if (out != "") out = out "; "; out = out $0 } END { print out }'
+}
+
+extract_review_body_without_sentinel() {
+  printf '%s\n' "$1" | awk '
+    /^[[:space:]]*CODEX_REVIEW_(CLEAN|FIXED|BLOCKED)[[:space:]]*$/ { next }
+    { print }
+  ' | sed '/^[[:space:]]*$/d'
+}
+
+append_findings_history_event() {
+  local result="$1"
+  local iteration="$2"
+  local output="${3:-}"
+  local auto_fixed_count="${4:-0}"
+  local branch history_file history_dir timestamp head prior_head commits findings_block findings_count
+  local esc_branch esc_base esc_merge_base esc_head esc_commits esc_findings esc_mode
+
+  branch="$(review_clean_marker_branch)"
+  [ -n "$branch" ] || return 0
+  if ! history_file="$(review_history_path)"; then
+    return 0
+  fi
+  history_dir="$(dirname "$history_file")"
+  mkdir -p "$history_dir" 2>/dev/null || return 0
+
+  timestamp="$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo "")"
+  head="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+  prior_head="$(review_history_last_head "$history_file")"
+  commits="$(review_history_commits_since_prior "$prior_head" "$head")"
+
+  findings_block="$(extract_findings_block "$output")"
+  if [ -z "$findings_block" ] && [ "$result" = "CODEX_REVIEW_FIXED" ]; then
+    findings_block="$(extract_review_body_without_sentinel "$output")"
+  fi
+  findings_count="$(printf '%s\n' "$findings_block" | grep -c '^- ' || true)"
+  if [ "$result" = "CODEX_REVIEW_FIXED" ] && [ "$auto_fixed_count" -eq 0 ] && [ -n "$findings_block" ]; then
+    auto_fixed_count="$findings_count"
+    [ "$auto_fixed_count" -gt 0 ] || auto_fixed_count=1
+  fi
+
+  esc_branch="$(printf '%s' "$branch" | json_escape)"
+  esc_base="$(printf '%s' "$BASE" | json_escape)"
+  esc_merge_base="$(printf '%s' "$MERGE_BASE" | json_escape)"
+  esc_head="$(printf '%s' "$head" | json_escape)"
+  esc_commits="$(printf '%s' "$commits" | json_escape)"
+  esc_findings="$(printf '%s' "$findings_block" | json_escape)"
+  esc_mode="$(printf '%s' "$REVIEW_MODE" | json_escape)"
+
+  printf '{"schema":"touchstone.review.findings_history.v1","timestamp":"%s","branch":"%s","base":"%s","merge_base":"%s","head":"%s","iteration":%s,"result":"%s","mode":"%s","findings_count":%s,"auto_fixed_count":%s,"fix_commits":%s,"commits_since_prior":"%s","findings":"%s"}\n' \
+    "$timestamp" "$esc_branch" "$esc_base" "$esc_merge_base" "$esc_head" "$iteration" "$result" "$esc_mode" \
+    "${findings_count:-0}" "${auto_fixed_count:-0}" "$FIX_COMMITS" "$esc_commits" "$esc_findings" \
+    >>"$history_file" 2>/dev/null || true
 }
 
 # Build a "verification checkpoint" prompt prefix when a prior BLOCKED review
@@ -2776,6 +2885,7 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
       write_clean_review_cache "$REVIEW_CACHE_KEY" "$DIFF_LINE_COUNT"
       write_clean_review_marker "$DIFF_LINE_COUNT"
       clear_review_findings
+      append_findings_history_event "CODEX_REVIEW_CLEAN" "$iter" "$OUTPUT" 0
       # The "ran" denominator: a successful review actually executed.
       # skip-rate = log_skip_count / (log_skip_count + log_ran_count).
       log_skip_event ran "clean:iter=${iter}:lines=${DIFF_LINE_COUNT}:fix-commits=${FIX_COMMITS}"
@@ -2821,6 +2931,7 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
 
       git add -A
       git commit -m "fix: address $REVIEWER_LABEL review findings (auto, $REVIEW_MODE, iter $iter)"
+      append_findings_history_event "CODEX_REVIEW_FIXED" "$iter" "$OUTPUT" 0
       WORKTREE_DIRTY_BEFORE_REVIEW=false
       FIX_COMMITS=$((FIX_COMMITS + 1))
       echo "==> Created fix commit $(git rev-parse --short HEAD). Re-running review on new HEAD..."
@@ -2846,6 +2957,7 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
       # on a descendant HEAD prepends a verification checkpoint instead of
       # auditing from scratch.
       write_review_findings "$OUTPUT"
+      append_findings_history_event "CODEX_REVIEW_BLOCKED" "$iter" "$OUTPUT" 0
       # The reviewer actually ran and produced a verdict — counts as "ran"
       # for the skip-rate denominator even though the push is blocked.
       log_skip_event ran "blocked:iter=${iter}:findings=${REVIEW_FINDINGS_COUNT}"

--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -2659,6 +2659,9 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
     if [ -n "$REVIEW_CACHE_KEY" ] && [ -f "$(clean_review_cache_file "$REVIEW_CACHE_KEY")" ]; then
       echo "==> Review previously passed for this exact diff — skipping repeat review."
       echo "    Force a fresh review with: CODEX_REVIEW_DISABLE_CACHE=1 git push"
+      REVIEW_EXIT_REASON="cache-hit"
+      REVIEW_FINDINGS_COUNT=0
+      print_summary
       log_skip_event other "cache-hit:${REVIEW_CACHE_KEY}"
       exit 0
     fi

--- a/lib/review-comment.sh
+++ b/lib/review-comment.sh
@@ -5,6 +5,7 @@
 # Public interface:
 #   format_clean_review_comment <review-summary-json>
 #   format_advisory_findings_comment <review-summary-json> <review-output>
+#   format_findings_history_comment <history-jsonl-path>
 #   post_pr_review_comment <pr-number> <comment-string>
 #   read_latest_review_event <jsonl-path>
 #
@@ -72,6 +73,69 @@ format_advisory_findings_comment() {
     else
       printf 'Review exited with findings, but no bullet-form findings were parsed from reviewer output.\n'
     fi
+  }
+}
+
+format_findings_history_comment() {
+  local history_path="$1"
+  local actionable_count total_count
+
+  [ -f "$history_path" ] || return 1
+  actionable_count="$(grep -E -c '"result":"CODEX_REVIEW_(BLOCKED|FIXED)"' "$history_path" 2>/dev/null || true)"
+  total_count="$(grep -c '"schema":"touchstone.review.findings_history.v1"' "$history_path" 2>/dev/null || true)"
+  [ "${actionable_count:-0}" -gt 0 ] || return 1
+
+  {
+    printf '<details>\n'
+    printf '<summary>Conductor review findings history (%s actionable iteration(s), %s total)</summary>\n\n' "$actionable_count" "$total_count"
+    awk '
+      function field(line, key, pattern, value) {
+        pattern = "\"" key "\":\"(([^\"\\\\]|\\\\.)*)\""
+        if (match(line, pattern)) {
+          value = substr(line, RSTART + length(key) + 4, RLENGTH - length(key) - 5)
+          gsub(/\\n/, "\n", value)
+          gsub(/\\"/, "\"", value)
+          gsub(/\\\\/, "\\", value)
+          return value
+        }
+        return ""
+      }
+      function number_field(line, key, pattern, value) {
+        pattern = "\"" key "\":[0-9]+"
+        if (match(line, pattern)) {
+          value = substr(line, RSTART + length(key) + 3, RLENGTH - length(key) - 3)
+          return value
+        }
+        return "0"
+      }
+      {
+        result = field($0, "result")
+        if (result == "") {
+          next
+        }
+        iteration = number_field($0, "iteration")
+        findings_count = number_field($0, "findings_count")
+        auto_fixed_count = number_field($0, "auto_fixed_count")
+        head = field($0, "head")
+        commits = field($0, "commits_since_prior")
+        findings = field($0, "findings")
+
+        printf "### Iteration %s: %s\n\n", iteration, result
+        printf "- Findings raised: %s\n", findings_count
+        printf "- Auto-fixed by reviewer: %s\n", auto_fixed_count
+        if (commits != "") {
+          printf "- Commits since prior finding: %s\n", commits
+        }
+        if (head != "") {
+          printf "- Reviewed HEAD: `%s`\n", head
+        }
+        if (findings != "") {
+          printf "\n%s\n", findings
+        }
+        printf "\n"
+      }
+    ' "$history_path"
+    printf '</details>\n'
   }
 }
 

--- a/lib/review-comment.sh
+++ b/lib/review-comment.sh
@@ -4,6 +4,7 @@
 #
 # Public interface:
 #   format_clean_review_comment <review-summary-json>
+#   format_advisory_findings_comment <review-summary-json> <review-output>
 #   post_pr_review_comment <pr-number> <comment-string>
 #   read_latest_review_event <jsonl-path>
 #
@@ -30,6 +31,10 @@ review_comment_clean_value() {
   printf '%s' "$value"
 }
 
+review_comment_findings_from_output() {
+  printf '%s\n' "$1" | awk '/^- / { print } /^$/ { if (found) exit } /^- / { found = 1 }'
+}
+
 format_clean_review_comment() {
   local json="$1"
   local reviewer provider model peer iterations mode findings
@@ -44,6 +49,30 @@ format_clean_review_comment() {
 
   printf '%s review clean - provider: %s, model: %s, peer: %s, iterations: %s, mode: %s, findings: %s' \
     "$reviewer" "$provider" "$model" "$peer" "$iterations" "$mode" "$findings"
+}
+
+format_advisory_findings_comment() {
+  local json="$1"
+  local output="$2"
+  local reviewer provider model iterations mode findings findings_block
+
+  reviewer="$(review_comment_clean_value "$(review_comment_json_field "$json" reviewer)")"
+  provider="$(review_comment_clean_value "$(review_comment_json_field "$json" provider)")"
+  model="$(review_comment_clean_value "$(review_comment_json_field "$json" model)")"
+  iterations="$(review_comment_clean_value "$(review_comment_json_number "$json" iterations)")"
+  mode="$(review_comment_clean_value "$(review_comment_json_field "$json" mode)")"
+  findings="$(review_comment_clean_value "$(review_comment_json_number "$json" findings)")"
+  findings_block="$(review_comment_findings_from_output "$output")"
+
+  {
+    printf '%s advisory review found %s finding(s) - provider: %s, model: %s, iterations: %s, mode: %s\n\n' \
+      "$reviewer" "$findings" "$provider" "$model" "$iterations" "$mode"
+    if [ -n "$findings_block" ]; then
+      printf '%s\n' "$findings_block"
+    else
+      printf 'Review exited with findings, but no bullet-form findings were parsed from reviewer output.\n'
+    fi
+  }
 }
 
 post_pr_review_comment() {

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -1970,6 +1970,15 @@ review_findings_file() {
   printf '%s/%s.findings' "$(review_findings_dir)" "$(review_clean_marker_key "$branch")"
 }
 
+review_findings_history_dir() {
+  git rev-parse --git-path touchstone/reviewer-findings-history
+}
+
+review_findings_history_file() {
+  local branch="$1"
+  printf '%s/%s.jsonl' "$(review_findings_history_dir)" "$(review_clean_marker_key "$branch")"
+}
+
 # Strip trailing whitespace from each line and drop empty trailing lines.
 # Findings text comes from the reviewer's stdout, which can include shell
 # color codes or stray indentation; the gate only persists lines that start
@@ -2018,6 +2027,106 @@ clear_review_findings() {
   findings_file="$(review_findings_file "$branch")"
   [ -f "$findings_file" ] || return 0
   rm -f "$findings_file" 2>/dev/null || true
+}
+
+json_escape() {
+  awk '
+    {
+      gsub(/\\/, "\\\\")
+      gsub(/"/, "\\\"")
+      if (NR > 1) {
+        printf "\\n"
+      }
+      printf "%s", $0
+    }
+  '
+}
+
+review_history_path() {
+  local branch
+  if [ -n "${CODEX_REVIEW_FINDINGS_HISTORY_FILE:-}" ]; then
+    printf '%s' "$CODEX_REVIEW_FINDINGS_HISTORY_FILE"
+    return 0
+  fi
+  branch="$(review_clean_marker_branch)"
+  [ -n "$branch" ] || return 1
+  review_findings_history_file "$branch"
+}
+
+review_history_last_head() {
+  local history_file="$1"
+  [ -f "$history_file" ] || return 0
+  awk -F'"head":"' '
+    /"schema":"touchstone.review.findings_history.v1"/ && NF > 1 {
+      split($2, parts, "\"")
+      head = parts[1]
+    }
+    END { if (head != "") print head }
+  ' "$history_file" 2>/dev/null
+}
+
+review_history_commits_since_prior() {
+  local prior_head="$1"
+  local current_head="$2"
+  [ -n "$prior_head" ] || return 0
+  [ -n "$current_head" ] || return 0
+  [ "$prior_head" != "$current_head" ] || return 0
+  git rev-parse --verify --quiet "$prior_head^{commit}" >/dev/null 2>&1 || return 0
+  git merge-base --is-ancestor "$prior_head" "$current_head" 2>/dev/null || return 0
+  git log --format='%h %s' "$prior_head..$current_head" 2>/dev/null \
+    | awk 'NF { if (out != "") out = out "; "; out = out $0 } END { print out }'
+}
+
+extract_review_body_without_sentinel() {
+  printf '%s\n' "$1" | awk '
+    /^[[:space:]]*CODEX_REVIEW_(CLEAN|FIXED|BLOCKED)[[:space:]]*$/ { next }
+    { print }
+  ' | sed '/^[[:space:]]*$/d'
+}
+
+append_findings_history_event() {
+  local result="$1"
+  local iteration="$2"
+  local output="${3:-}"
+  local auto_fixed_count="${4:-0}"
+  local branch history_file history_dir timestamp head prior_head commits findings_block findings_count
+  local esc_branch esc_base esc_merge_base esc_head esc_commits esc_findings esc_mode
+
+  branch="$(review_clean_marker_branch)"
+  [ -n "$branch" ] || return 0
+  if ! history_file="$(review_history_path)"; then
+    return 0
+  fi
+  history_dir="$(dirname "$history_file")"
+  mkdir -p "$history_dir" 2>/dev/null || return 0
+
+  timestamp="$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo "")"
+  head="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+  prior_head="$(review_history_last_head "$history_file")"
+  commits="$(review_history_commits_since_prior "$prior_head" "$head")"
+
+  findings_block="$(extract_findings_block "$output")"
+  if [ -z "$findings_block" ] && [ "$result" = "CODEX_REVIEW_FIXED" ]; then
+    findings_block="$(extract_review_body_without_sentinel "$output")"
+  fi
+  findings_count="$(printf '%s\n' "$findings_block" | grep -c '^- ' || true)"
+  if [ "$result" = "CODEX_REVIEW_FIXED" ] && [ "$auto_fixed_count" -eq 0 ] && [ -n "$findings_block" ]; then
+    auto_fixed_count="$findings_count"
+    [ "$auto_fixed_count" -gt 0 ] || auto_fixed_count=1
+  fi
+
+  esc_branch="$(printf '%s' "$branch" | json_escape)"
+  esc_base="$(printf '%s' "$BASE" | json_escape)"
+  esc_merge_base="$(printf '%s' "$MERGE_BASE" | json_escape)"
+  esc_head="$(printf '%s' "$head" | json_escape)"
+  esc_commits="$(printf '%s' "$commits" | json_escape)"
+  esc_findings="$(printf '%s' "$findings_block" | json_escape)"
+  esc_mode="$(printf '%s' "$REVIEW_MODE" | json_escape)"
+
+  printf '{"schema":"touchstone.review.findings_history.v1","timestamp":"%s","branch":"%s","base":"%s","merge_base":"%s","head":"%s","iteration":%s,"result":"%s","mode":"%s","findings_count":%s,"auto_fixed_count":%s,"fix_commits":%s,"commits_since_prior":"%s","findings":"%s"}\n' \
+    "$timestamp" "$esc_branch" "$esc_base" "$esc_merge_base" "$esc_head" "$iteration" "$result" "$esc_mode" \
+    "${findings_count:-0}" "${auto_fixed_count:-0}" "$FIX_COMMITS" "$esc_commits" "$esc_findings" \
+    >>"$history_file" 2>/dev/null || true
 }
 
 # Build a "verification checkpoint" prompt prefix when a prior BLOCKED review
@@ -2776,6 +2885,7 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
       write_clean_review_cache "$REVIEW_CACHE_KEY" "$DIFF_LINE_COUNT"
       write_clean_review_marker "$DIFF_LINE_COUNT"
       clear_review_findings
+      append_findings_history_event "CODEX_REVIEW_CLEAN" "$iter" "$OUTPUT" 0
       # The "ran" denominator: a successful review actually executed.
       # skip-rate = log_skip_count / (log_skip_count + log_ran_count).
       log_skip_event ran "clean:iter=${iter}:lines=${DIFF_LINE_COUNT}:fix-commits=${FIX_COMMITS}"
@@ -2821,6 +2931,7 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
 
       git add -A
       git commit -m "fix: address $REVIEWER_LABEL review findings (auto, $REVIEW_MODE, iter $iter)"
+      append_findings_history_event "CODEX_REVIEW_FIXED" "$iter" "$OUTPUT" 0
       WORKTREE_DIRTY_BEFORE_REVIEW=false
       FIX_COMMITS=$((FIX_COMMITS + 1))
       echo "==> Created fix commit $(git rev-parse --short HEAD). Re-running review on new HEAD..."
@@ -2846,6 +2957,7 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
       # on a descendant HEAD prepends a verification checkpoint instead of
       # auditing from scratch.
       write_review_findings "$OUTPUT"
+      append_findings_history_event "CODEX_REVIEW_BLOCKED" "$iter" "$OUTPUT" 0
       # The reviewer actually ran and produced a verdict — counts as "ran"
       # for the skip-rate denominator even though the push is blocked.
       log_skip_event ran "blocked:iter=${iter}:findings=${REVIEW_FINDINGS_COUNT}"

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -2659,6 +2659,9 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
     if [ -n "$REVIEW_CACHE_KEY" ] && [ -f "$(clean_review_cache_file "$REVIEW_CACHE_KEY")" ]; then
       echo "==> Review previously passed for this exact diff — skipping repeat review."
       echo "    Force a fresh review with: CODEX_REVIEW_DISABLE_CACHE=1 git push"
+      REVIEW_EXIT_REASON="cache-hit"
+      REVIEW_FINDINGS_COUNT=0
+      print_summary
       log_skip_event other "cache-hit:${REVIEW_CACHE_KEY}"
       exit 0
     fi

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -46,6 +46,7 @@ BYPASS_REVIEW=false
 TOUCHSTONE_MERGE_FAILURE_REASON="nonzero-exit"
 PREFLIGHT_REQUIRED=true
 COMMENT_ON_CLEAN=true
+COMMENT_FINDINGS_HISTORY=true
 REVIEW_SUMMARY_FILE=""
 
 on_merge_exit() {
@@ -143,6 +144,8 @@ load_merge_review_config() {
       PREFLIGHT_REQUIRED="$(normalize_bool "$value")"
     elif [ "$section" = "review" ] && [ "$key" = "comment_on_clean" ]; then
       COMMENT_ON_CLEAN="$(normalize_bool "$value")"
+    elif [ "$section" = "review" ] && [ "$key" = "comment_findings_history" ]; then
+      COMMENT_FINDINGS_HISTORY="$(normalize_bool "$value")"
     fi
   }
 
@@ -158,6 +161,13 @@ review_clean_marker_file() {
   local branch="$1"
   printf '%s/%s.clean' \
     "$(git rev-parse --git-path touchstone/reviewer-clean)" \
+    "$(review_clean_marker_key "$branch")"
+}
+
+review_findings_history_file() {
+  local branch="$1"
+  printf '%s/%s.jsonl' \
+    "$(git rev-parse --git-path touchstone/reviewer-findings-history)" \
     "$(review_clean_marker_key "$branch")"
 }
 
@@ -462,6 +472,42 @@ post_clean_review_comment() {
   fi
 
   echo "WARNING: failed to post clean-review PR comment for PR #$PR_NUMBER." >&2
+  return 0
+}
+
+post_findings_history_comment() {
+  local branch="$1"
+  local history_file comment
+
+  if ! truthy "$COMMENT_FINDINGS_HISTORY"; then
+    echo "==> Findings-history PR comment disabled by [review].comment_findings_history=false."
+    return 0
+  fi
+  if [ "$BYPASS_REVIEW" = true ]; then
+    return 0
+  fi
+  if ! declare -F format_findings_history_comment >/dev/null 2>&1 \
+    || ! declare -F post_pr_review_comment >/dev/null 2>&1; then
+    echo "WARNING: review comment helper not found at $REVIEW_COMMENT_SCRIPT; skipping findings-history comment." >&2
+    return 0
+  fi
+  if [ -z "$branch" ]; then
+    echo "WARNING: PR head branch missing; skipping findings-history comment." >&2
+    return 0
+  fi
+
+  history_file="$(review_findings_history_file "$branch")"
+  if ! comment="$(format_findings_history_comment "$history_file")"; then
+    echo "==> No actionable review findings history to comment."
+    return 0
+  fi
+
+  if post_pr_review_comment "$PR_NUMBER" "$comment"; then
+    echo "==> Posted findings-history PR comment."
+    return 0
+  fi
+
+  echo "WARNING: failed to post findings-history PR comment for PR #$PR_NUMBER." >&2
   return 0
 }
 
@@ -771,6 +817,7 @@ fi
 MERGED_AT="$(gh pr view "$PR_NUMBER" --json mergedAt --jq '.mergedAt // empty' 2>/dev/null || echo "")"
 touchstone_emit_event merged pr_number="$PR_NUMBER" merged_at="$MERGED_AT" head_sha="$REVIEWED_HEAD_OID"
 post_clean_review_comment "$REVIEW_SUMMARY_FILE"
+post_findings_history_comment "$PR_HEAD_BRANCH"
 
 # Record squash-merge metadata for cleanup-branches.sh. The merge has
 # succeeded on GitHub; this is best-effort persistence for later cleanup.

--- a/scripts/open-pr.sh
+++ b/scripts/open-pr.sh
@@ -173,7 +173,7 @@ run_advisory_review_at_pr_open() {
   if ! declare -F post_pr_review_comment >/dev/null 2>&1 \
     || ! declare -F format_clean_review_comment >/dev/null 2>&1 \
     || ! declare -F format_advisory_findings_comment >/dev/null 2>&1; then
-    echo "WARNING: review comment helper not found at $REVIEW_COMMENT_SCRIPT; skipping advisory PR comment." >&2
+    echo "==> Review comment helper not found at $REVIEW_COMMENT_SCRIPT; skipping advisory review."
     return 0
   fi
 

--- a/scripts/open-pr.sh
+++ b/scripts/open-pr.sh
@@ -42,11 +42,21 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PREFLIGHT_SCRIPT="$SCRIPT_DIR/../lib/preflight.sh"
+REVIEW_COMMENT_SCRIPT="$SCRIPT_DIR/../lib/review-comment.sh"
 if [ -f "$SCRIPT_DIR/../lib/events.sh" ]; then
   # shellcheck source=../lib/events.sh
   source "$SCRIPT_DIR/../lib/events.sh"
 else
   touchstone_emit_event() { :; }
+fi
+if [ -f "$PREFLIGHT_SCRIPT" ]; then
+  # shellcheck source=../lib/preflight.sh
+  source "$PREFLIGHT_SCRIPT"
+fi
+if [ -f "$REVIEW_COMMENT_SCRIPT" ]; then
+  # shellcheck source=../lib/review-comment.sh
+  source "$REVIEW_COMMENT_SCRIPT"
 fi
 
 # orphan_warning is set to a PR URL once we know one — any nonzero exit after
@@ -55,6 +65,8 @@ fi
 ORPHAN_PR_URL=""
 ORPHAN_PR_NUMBER=""
 BODY_FILE=""
+ADVISORY_AT_PR_OPEN=true
+PREFLIGHT_REQUIRED=true
 
 on_exit() {
   local rc="$?"
@@ -107,6 +119,120 @@ verify_pr_merged() {
     return 0
   fi
   return 1
+}
+
+truthy() {
+  case "$(printf '%s' "${1:-false}" | tr '[:upper:]' '[:lower:]')" in
+    true | 1 | yes | on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+normalize_bool() {
+  case "$(printf '%s' "${1:-false}" | tr '[:upper:]' '[:lower:]')" in
+    true | 1 | yes | on) printf 'true' ;;
+    false | 0 | no | off) printf 'false' ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
+
+load_open_pr_review_config() {
+  local config_file
+  config_file="$(git rev-parse --show-toplevel 2>/dev/null)/.codex-review.toml"
+  [ -f "$config_file" ] || return 0
+  [ -f "$SCRIPT_DIR/../lib/toml.sh" ] || return 0
+
+  # shellcheck source=../lib/toml.sh
+  source "$SCRIPT_DIR/../lib/toml.sh"
+
+  open_pr_toml_callback() {
+    local section="$1"
+    local key="$2"
+    local value="$3"
+
+    if [ "$section" = "review" ] && [ "$key" = "advisory_at_pr_open" ]; then
+      ADVISORY_AT_PR_OPEN="$(normalize_bool "$value")"
+    elif [ "$section" = "review" ] && [ "$key" = "preflight_required" ]; then
+      PREFLIGHT_REQUIRED="$(normalize_bool "$value")"
+    fi
+  }
+
+  toml_parse "$config_file" open_pr_toml_callback
+}
+
+run_advisory_review_at_pr_open() {
+  local pr_number="$1"
+  local base_branch="$2"
+  local review_script summary_file output_file review_rc summary_json comment
+
+  if ! truthy "$ADVISORY_AT_PR_OPEN"; then
+    echo "==> Advisory review at PR open disabled by [review].advisory_at_pr_open=false."
+    return 0
+  fi
+
+  if ! declare -F post_pr_review_comment >/dev/null 2>&1 \
+    || ! declare -F format_clean_review_comment >/dev/null 2>&1 \
+    || ! declare -F format_advisory_findings_comment >/dev/null 2>&1; then
+    echo "WARNING: review comment helper not found at $REVIEW_COMMENT_SCRIPT; skipping advisory PR comment." >&2
+    return 0
+  fi
+
+  if truthy "$PREFLIGHT_REQUIRED" && ! truthy "${TOUCHSTONE_NO_PREFLIGHT:-false}"; then
+    if declare -F touchstone_preflight_main >/dev/null 2>&1; then
+      echo "==> Running deterministic preflight before advisory review ..."
+      if ! TOUCHSTONE_PREFLIGHT_BASE="origin/$base_branch" touchstone_preflight_main "$(git rev-parse --show-toplevel)"; then
+        echo "WARNING: preflight failed; skipping non-blocking advisory review to avoid spending provider tokens." >&2
+        return 0
+      fi
+    else
+      echo "==> Preflight helper not found at $PREFLIGHT_SCRIPT — skipping preflight."
+    fi
+  else
+    echo "==> Preflight disabled before advisory review."
+  fi
+
+  review_script="$SCRIPT_DIR/codex-review.sh"
+  if [ ! -f "$review_script" ]; then
+    echo "WARNING: codex-review.sh not found at $review_script; skipping advisory review." >&2
+    return 0
+  fi
+
+  summary_file="$(git rev-parse --git-path "touchstone/review-summary-pr-${pr_number}-advisory.json" 2>/dev/null || echo "")"
+  output_file="$(mktemp -t touchstone-advisory-review.XXXXXX.txt)"
+  if [ -n "$summary_file" ]; then
+    mkdir -p "$(dirname "$summary_file")" 2>/dev/null || true
+    rm -f "$summary_file" 2>/dev/null || true
+  fi
+
+  echo "==> Running advisory conductor review for PR #$pr_number ..."
+  review_rc=0
+  CODEX_REVIEW_BASE="origin/$base_branch" \
+    CODEX_REVIEW_BRANCH_NAME="$CURRENT_BRANCH" \
+    CODEX_REVIEW_FORCE=1 \
+    CODEX_REVIEW_MODE=review-only \
+    CODEX_REVIEW_SUMMARY_FILE="$summary_file" \
+    bash "$review_script" >"$output_file" 2>&1 || review_rc=$?
+
+  summary_json="$(tail -n 1 "$summary_file" 2>/dev/null || true)"
+  if [ -z "$summary_json" ]; then
+    echo "WARNING: advisory review summary missing; skipping advisory PR comment." >&2
+    rm -f "$output_file"
+    return 0
+  fi
+
+  if [ "$review_rc" -eq 0 ]; then
+    comment="$(format_clean_review_comment "$summary_json")"
+  else
+    comment="$(format_advisory_findings_comment "$summary_json" "$(cat "$output_file" 2>/dev/null || true)")"
+  fi
+
+  if post_pr_review_comment "$pr_number" "$comment"; then
+    echo "==> Posted advisory review PR comment."
+  else
+    echo "WARNING: failed to post advisory review PR comment for PR #$pr_number." >&2
+  fi
+  rm -f "$output_file"
+  return 0
 }
 
 # Locate the worktree that has the default branch checked out, by parsing
@@ -200,6 +326,7 @@ find_issue_closing_refs() {
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 TEMPLATE_PATH="$REPO_ROOT/.github/pull_request_template.md"
+load_open_pr_review_config
 
 # Fail fast if gh is missing or unauthenticated.
 if ! command -v gh >/dev/null 2>&1; then
@@ -464,6 +591,8 @@ touchstone_emit_event pr_opened \
   branch="$CURRENT_BRANCH" \
   base_branch="$BASE_BRANCH" \
   head_sha="$HEAD_SHA"
+
+run_advisory_review_at_pr_open "$ORPHAN_PR_NUMBER" "$BASE_BRANCH"
 
 if [ -n "$DRAFT_FLAG" ]; then
   echo "    Opened as draft. Mark ready on github.com when ready to merge."

--- a/tests/test-advisory-at-pr-open.sh
+++ b/tests/test-advisory-at-pr-open.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+#
+# tests/test-advisory-at-pr-open.sh — PR-open advisory review comment flow.
+#
+set -euo pipefail
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_DIR="$(mktemp -d -t touchstone-test-advisory-pr-open.XXXXXX)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+ERRORS=0
+RUN_DIR="$TEST_DIR/run"
+REPO_DIR="$TEST_DIR/repo"
+FAKE_BIN="$TEST_DIR/bin"
+mkdir -p "$RUN_DIR/scripts" "$RUN_DIR/lib" "$REPO_DIR" "$FAKE_BIN"
+
+cp "$TOUCHSTONE_ROOT/scripts/open-pr.sh" "$RUN_DIR/scripts/open-pr.sh"
+cp "$TOUCHSTONE_ROOT/lib/review-comment.sh" "$RUN_DIR/lib/review-comment.sh"
+cp "$TOUCHSTONE_ROOT/lib/preflight.sh" "$RUN_DIR/lib/preflight.sh"
+cp "$TOUCHSTONE_ROOT/lib/toml.sh" "$RUN_DIR/lib/toml.sh"
+chmod +x "$RUN_DIR/scripts/open-pr.sh"
+
+cat >"$RUN_DIR/scripts/codex-review.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '{"reviewer":"Conductor","provider":"claude","model":"claude-opus-4-1","peer_provider":"none","iterations":1,"mode":"%s","findings":%s,"exit_reason":"%s"}\n' \
+  "${CODEX_REVIEW_MODE:-unknown}" "${CODEX_REVIEW_STUB_FINDINGS:-0}" "${CODEX_REVIEW_STUB_REASON:-clean}" > "$CODEX_REVIEW_SUMMARY_FILE"
+if [ "${CODEX_REVIEW_STUB_EXIT:-0}" != "0" ]; then
+  printf -- '- blocking advisory finding\n'
+  printf 'CODEX_REVIEW_BLOCKED\n'
+  exit "$CODEX_REVIEW_STUB_EXIT"
+fi
+printf 'CODEX_REVIEW_CLEAN\n'
+EOF
+chmod +x "$RUN_DIR/scripts/codex-review.sh"
+
+cat >"$FAKE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-} ${2:-}" in
+  "repo view")
+    echo "main"
+    ;;
+  "pr list")
+    echo ""
+    ;;
+  "pr create")
+    echo "https://example.test/touchstone/pull/456"
+    ;;
+  "pr comment")
+    if [ "${4:-}" != "--body" ]; then
+      echo "unexpected gh pr comment args: $*" >&2
+      exit 1
+    fi
+    printf '%s\n' "${5:-}" >> "$GH_COMMENT_FILE"
+    ;;
+  *)
+    echo "unexpected gh args: $*" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "$FAKE_BIN/gh"
+
+REAL_GIT="$(command -v git)"
+cat >"$FAKE_BIN/git" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "push" ]; then
+  echo "[mock] git push \$*"
+  exit 0
+fi
+exec "$REAL_GIT" "\$@"
+EOF
+chmod +x "$FAKE_BIN/git"
+
+git -C "$REPO_DIR" init -b main >/dev/null 2>&1
+git -C "$REPO_DIR" config user.name "Touchstone Test"
+git -C "$REPO_DIR" config user.email "touchstone@example.com"
+printf 'base\n' >"$REPO_DIR/file.txt"
+git -C "$REPO_DIR" add file.txt
+git -C "$REPO_DIR" commit -m "base commit" >/dev/null 2>&1
+git -C "$REPO_DIR" checkout -b feat/advisory >/dev/null 2>&1
+printf 'change\n' >>"$REPO_DIR/file.txt"
+git -C "$REPO_DIR" add file.txt
+git -C "$REPO_DIR" commit -m "test advisory" >/dev/null 2>&1
+
+run_open_pr() {
+  local output_file="$1"
+  (
+    cd "$REPO_DIR"
+    PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+      GH_COMMENT_FILE="$TEST_DIR/comments" \
+      CODEX_REVIEW_STUB_EXIT="${CODEX_REVIEW_STUB_EXIT:-0}" \
+      CODEX_REVIEW_STUB_FINDINGS="${CODEX_REVIEW_STUB_FINDINGS:-0}" \
+      CODEX_REVIEW_STUB_REASON="${CODEX_REVIEW_STUB_REASON:-clean}" \
+      bash "$RUN_DIR/scripts/open-pr.sh"
+  ) >"$output_file" 2>&1
+}
+
+reset_case() {
+  rm -f "$TEST_DIR/comments"
+}
+
+echo "==> Case 1: clean advisory review posts clean summary"
+reset_case
+printf '[review]\npreflight_required = false\nadvisory_at_pr_open = true\n' >"$REPO_DIR/.codex-review.toml"
+git -C "$REPO_DIR" add .codex-review.toml
+git -C "$REPO_DIR" commit -m "configure advisory review" >/dev/null 2>&1
+OUT="$TEST_DIR/clean.out"
+CODEX_REVIEW_STUB_EXIT=0 CODEX_REVIEW_STUB_FINDINGS=0 CODEX_REVIEW_STUB_REASON=clean run_open_pr "$OUT"
+if grep -q '^Conductor review clean - provider: claude, model: claude-opus-4-1, peer: none, iterations: 1, mode: review-only, findings: 0$' "$TEST_DIR/comments"; then
+  echo "    PASS"
+else
+  echo "    FAIL: clean advisory comment missing" >&2
+  cat "$OUT" >&2
+  [ -f "$TEST_DIR/comments" ] && cat "$TEST_DIR/comments" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo "==> Case 2: findings advisory review is non-blocking and posts findings"
+reset_case
+OUT="$TEST_DIR/findings.out"
+CODEX_REVIEW_STUB_EXIT=1 CODEX_REVIEW_STUB_FINDINGS=1 CODEX_REVIEW_STUB_REASON=blocked run_open_pr "$OUT"
+if grep -q 'advisory review found 1 finding(s)' "$TEST_DIR/comments" \
+  && grep -q '^- blocking advisory finding$' "$TEST_DIR/comments" \
+  && grep -q '^https://example.test/touchstone/pull/456$' "$OUT"; then
+  echo "    PASS"
+else
+  echo "    FAIL: findings advisory comment missing or PR open blocked" >&2
+  cat "$OUT" >&2
+  [ -f "$TEST_DIR/comments" ] && cat "$TEST_DIR/comments" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo "==> Case 3: advisory_at_pr_open=false skips review and comment"
+reset_case
+printf '[review]\npreflight_required = false\nadvisory_at_pr_open = false\n' >"$REPO_DIR/.codex-review.toml"
+git -C "$REPO_DIR" add .codex-review.toml
+git -C "$REPO_DIR" commit -m "disable advisory review" >/dev/null 2>&1
+OUT="$TEST_DIR/disabled.out"
+CODEX_REVIEW_STUB_EXIT=0 CODEX_REVIEW_STUB_FINDINGS=0 CODEX_REVIEW_STUB_REASON=clean run_open_pr "$OUT"
+if grep -q 'Advisory review at PR open disabled' "$OUT" && [ ! -f "$TEST_DIR/comments" ]; then
+  echo "    PASS"
+else
+  echo "    FAIL: disabled advisory review still posted a comment" >&2
+  cat "$OUT" >&2
+  [ -f "$TEST_DIR/comments" ] && cat "$TEST_DIR/comments" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+if [ "$ERRORS" = "0" ]; then
+  echo "==> PASS: advisory review at PR open is commented and non-blocking"
+  exit 0
+fi
+echo "==> FAIL: $ERRORS case(s) regressed" >&2
+exit 1

--- a/tests/test-fixloop-findings-comment.sh
+++ b/tests/test-fixloop-findings-comment.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+#
+# tests/test-fixloop-findings-comment.sh — persisted fix-loop findings history.
+#
+set -euo pipefail
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_DIR="$(mktemp -d -t touchstone-test-fixloop-history.XXXXXX)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+ERRORS=0
+
+echo "==> Case 1: codex-review.sh records FIXED and CLEAN iterations"
+REVIEW_REPO="$TEST_DIR/review-repo"
+FAKE_BIN="$TEST_DIR/bin-review"
+mkdir -p "$REVIEW_REPO/lib" "$FAKE_BIN"
+cp "$TOUCHSTONE_ROOT/lib/toml.sh" "$REVIEW_REPO/lib/toml.sh"
+git -C "$REVIEW_REPO" init -b main >/dev/null 2>&1
+git -C "$REVIEW_REPO" config user.name "Touchstone Test"
+git -C "$REVIEW_REPO" config user.email "touchstone@example.com"
+printf 'base\n' >"$REVIEW_REPO/file.txt"
+git -C "$REVIEW_REPO" add file.txt lib/toml.sh
+git -C "$REVIEW_REPO" commit -m "base commit" >/dev/null 2>&1
+git -C "$REVIEW_REPO" checkout -b feat/fixloop >/dev/null 2>&1
+printf 'change\n' >>"$REVIEW_REPO/file.txt"
+git -C "$REVIEW_REPO" add file.txt
+git -C "$REVIEW_REPO" commit -m "feature change" >/dev/null 2>&1
+
+cat >"$REVIEW_REPO/.codex-review.toml" <<'EOF'
+[codex_review]
+safe_by_default = true
+cache_clean_reviews = false
+max_iterations = 2
+on_error = "fail-closed"
+EOF
+git -C "$REVIEW_REPO" add .codex-review.toml
+git -C "$REVIEW_REPO" commit -m "configure review hook" >/dev/null 2>&1
+
+cat >"$FAKE_BIN/conductor" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  doctor)
+    printf '{"configured":true}\n'
+    ;;
+  exec)
+    count_file="$CONDUCTOR_COUNT_FILE"
+    count=0
+    [ -f "$count_file" ] && count="$(cat "$count_file")"
+    count=$((count + 1))
+    printf '%s\n' "$count" > "$count_file"
+    if [ "$count" -eq 1 ]; then
+      printf 'auto-fixed missing review artifact\n' >> file.txt
+      printf -- '- missing review artifact for auto-fixed finding\n'
+      printf 'CODEX_REVIEW_FIXED\n'
+    else
+      printf 'CODEX_REVIEW_CLEAN\n'
+    fi
+    ;;
+  *)
+    echo "unexpected conductor args: $*" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "$FAKE_BIN/conductor"
+
+OUT="$TEST_DIR/review.out"
+(
+  cd "$REVIEW_REPO"
+  PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CONDUCTOR_COUNT_FILE="$TEST_DIR/conductor-count" \
+    TOUCHSTONE_REVIEW_LOG=/dev/null \
+    CODEX_REVIEW_FORCE=1 \
+    CODEX_REVIEW_BASE=main \
+    CODEX_REVIEW_MODE=fix \
+    bash "$TOUCHSTONE_ROOT/scripts/codex-review.sh"
+) >"$OUT" 2>&1 || {
+  echo "    FAIL: codex-review.sh fixture failed" >&2
+  cat "$OUT" >&2
+  exit 1
+}
+
+HISTORY_FILE="$REVIEW_REPO/.git/touchstone/reviewer-findings-history/feat_fixloop.jsonl"
+if [ -f "$HISTORY_FILE" ] \
+  && grep -q '"result":"CODEX_REVIEW_FIXED"' "$HISTORY_FILE" \
+  && grep -q '"result":"CODEX_REVIEW_CLEAN"' "$HISTORY_FILE" \
+  && grep -q '"findings":"- missing review artifact for auto-fixed finding"' "$HISTORY_FILE"; then
+  echo "    PASS"
+else
+  echo "    FAIL: findings history did not capture FIXED + CLEAN iterations" >&2
+  cat "$OUT" >&2
+  [ -f "$HISTORY_FILE" ] && cat "$HISTORY_FILE" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo "==> Case 2: formatter renders collapsed actionable history"
+# shellcheck source=../lib/review-comment.sh
+source "$TOUCHSTONE_ROOT/lib/review-comment.sh"
+COMMENT="$(format_findings_history_comment "$HISTORY_FILE")"
+if printf '%s\n' "$COMMENT" | grep -q '^<details>$' \
+  && printf '%s\n' "$COMMENT" | grep -q 'Conductor review findings history' \
+  && printf '%s\n' "$COMMENT" | grep -q 'CODEX_REVIEW_FIXED' \
+  && printf '%s\n' "$COMMENT" | grep -q 'missing review artifact'; then
+  echo "    PASS"
+else
+  echo "    FAIL: collapsed formatter output missing expected history" >&2
+  printf '%s\n' "$COMMENT" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo "==> Case 3: merge-pr.sh posts findings-history comment after merge"
+MERGE_DIR="$TEST_DIR/merge"
+MERGE_FAKE_BIN="$TEST_DIR/bin-merge"
+mkdir -p "$MERGE_DIR/scripts" "$MERGE_DIR/lib" "$MERGE_DIR/repo/.git/touchstone/reviewer-findings-history" "$MERGE_FAKE_BIN"
+cp "$TOUCHSTONE_ROOT/scripts/merge-pr.sh" "$MERGE_DIR/scripts/merge-pr.sh"
+cp "$TOUCHSTONE_ROOT/lib/preflight.sh" "$MERGE_DIR/lib/preflight.sh"
+cp "$TOUCHSTONE_ROOT/lib/review-comment.sh" "$MERGE_DIR/lib/review-comment.sh"
+cp "$TOUCHSTONE_ROOT/lib/toml.sh" "$MERGE_DIR/lib/toml.sh"
+chmod +x "$MERGE_DIR/scripts/merge-pr.sh"
+cat >"$MERGE_DIR/scripts/codex-review.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '{"reviewer":"Conductor","provider":"claude","model":"claude-opus-4-1","peer_provider":"none","iterations":1,"mode":"review-only","findings":0,"exit_reason":"clean"}\n' > "$CODEX_REVIEW_SUMMARY_FILE"
+exit 0
+EOF
+chmod +x "$MERGE_DIR/scripts/codex-review.sh"
+cp "$HISTORY_FILE" "$MERGE_DIR/repo/.git/touchstone/reviewer-findings-history/feature_test.jsonl"
+printf '[review]\ncomment_on_clean = true\ncomment_findings_history = true\n' >"$MERGE_DIR/repo/.codex-review.toml"
+
+cat >"$MERGE_FAKE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-} ${2:-}" in
+  "repo view")
+    echo "main"
+    ;;
+  "pr view")
+    case "${5:-}" in
+      state)
+        if [ -f "${GH_MERGED_MARKER:-/dev/null/never}" ]; then echo "MERGED"; else echo "OPEN"; fi
+        ;;
+      headRefName) echo "feature/test" ;;
+      headRefOid) echo "pr-head-oid" ;;
+      mergeStateStatus,mergeable) echo "CLEAN MERGEABLE" ;;
+      mergedAt) echo "2026-05-07T15:00:00Z" ;;
+      mergeCommit) echo "squash-oid" ;;
+      *) echo "unexpected gh pr view args: $*" >&2; exit 1 ;;
+    esac
+    ;;
+  "pr checkout")
+    echo checked-out > "$GH_CHECKOUT_FILE"
+    ;;
+  "pr comment")
+    if [ "${4:-}" != "--body" ]; then
+      echo "unexpected gh pr comment args: $*" >&2
+      exit 1
+    fi
+    printf '%s\n---COMMENT---\n' "${5:-}" >> "$GH_COMMENT_FILE"
+    ;;
+  "pr merge")
+    [ -n "${GH_MERGED_MARKER:-}" ] && touch "$GH_MERGED_MARKER"
+    ;;
+  *)
+    echo "unexpected gh args: $*" >&2
+    exit 1
+    ;;
+esac
+EOF
+
+cat >"$MERGE_FAKE_BIN/git" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  "rev-parse --show-toplevel") printf '%s\n' "$TEST_REPO_ROOT" ;;
+  "rev-parse --abbrev-ref HEAD")
+    if [ -f "$GH_CHECKOUT_FILE" ]; then echo "HEAD"; else echo "feature/test"; fi
+    ;;
+  "rev-parse HEAD")
+    if [ -f "$GH_CHECKOUT_FILE" ]; then echo "pr-head-oid"; else echo "stale-local-oid"; fi
+    ;;
+  "rev-parse feature/test") echo "pr-head-oid" ;;
+  "rev-parse --verify --quiet origin/main^{commit}") echo "base-oid" ;;
+  "rev-parse --git-path touchstone/reviewer-clean") printf '%s\n' "$TEST_REPO_ROOT/.git/touchstone/reviewer-clean" ;;
+  "rev-parse --git-path touchstone/reviewer-findings-history") printf '%s\n' "$TEST_REPO_ROOT/.git/touchstone/reviewer-findings-history" ;;
+  "rev-parse --git-path touchstone/squash-map.jsonl") printf '%s\n' "$TEST_REPO_ROOT/.git/touchstone/squash-map.jsonl" ;;
+  rev-parse\ --git-path\ touchstone/review-summary-pr-123.json) printf '%s\n' "$TEST_REPO_ROOT/.git/touchstone/review-summary-pr-123.json" ;;
+  "fetch origin +refs/heads/main:refs/remotes/origin/main") ;;
+  "cat-file -e pr-head-oid^{commit}") ;;
+  "merge-base origin/main pr-head-oid") echo "base-oid" ;;
+  "status --porcelain") ;;
+  "diff --name-only origin/main...HEAD") ;;
+  "diff --name-only --cached") ;;
+  "diff --name-only") ;;
+  "ls-files") ;;
+  "worktree list --porcelain") ;;
+  "checkout main") ;;
+  "pull --rebase") ;;
+  "show-ref --verify --quiet refs/heads/feature/test") ;;
+  "branch -D feature/test") ;;
+  *) echo "unexpected git args: $*" >&2; exit 1 ;;
+esac
+EOF
+chmod +x "$MERGE_FAKE_BIN/gh" "$MERGE_FAKE_BIN/git"
+
+MERGE_OUT="$TEST_DIR/merge.out"
+PATH="$MERGE_FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+  TEST_REPO_ROOT="$MERGE_DIR/repo" \
+  GH_COMMENT_FILE="$TEST_DIR/merge-comments" \
+  GH_MERGED_MARKER="$TEST_DIR/merged" \
+  GH_CHECKOUT_FILE="$TEST_DIR/checkout" \
+  TOUCHSTONE_NO_PREFLIGHT=1 \
+  bash "$MERGE_DIR/scripts/merge-pr.sh" 123 >"$MERGE_OUT" 2>&1
+
+if grep -q 'Posted findings-history PR comment' "$MERGE_OUT" \
+  && grep -q '<details>' "$TEST_DIR/merge-comments" \
+  && grep -q 'CODEX_REVIEW_FIXED' "$TEST_DIR/merge-comments"; then
+  echo "    PASS"
+else
+  echo "    FAIL: merge did not post findings-history comment" >&2
+  cat "$MERGE_OUT" >&2
+  [ -f "$TEST_DIR/merge-comments" ] && cat "$TEST_DIR/merge-comments" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo "==> Case 4: comment_findings_history=false skips post-merge history"
+rm -f "$TEST_DIR/merge-comments" "$TEST_DIR/merged" "$TEST_DIR/checkout"
+printf '[review]\ncomment_on_clean = true\ncomment_findings_history = false\n' >"$MERGE_DIR/repo/.codex-review.toml"
+PATH="$MERGE_FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+  TEST_REPO_ROOT="$MERGE_DIR/repo" \
+  GH_COMMENT_FILE="$TEST_DIR/merge-comments" \
+  GH_MERGED_MARKER="$TEST_DIR/merged" \
+  GH_CHECKOUT_FILE="$TEST_DIR/checkout" \
+  TOUCHSTONE_NO_PREFLIGHT=1 \
+  bash "$MERGE_DIR/scripts/merge-pr.sh" 123 >"$TEST_DIR/merge-disabled.out" 2>&1
+
+if grep -q 'Findings-history PR comment disabled' "$TEST_DIR/merge-disabled.out" \
+  && ! grep -q '<details>' "$TEST_DIR/merge-comments"; then
+  echo "    PASS"
+else
+  echo "    FAIL: disabled findings-history comment still posted" >&2
+  cat "$TEST_DIR/merge-disabled.out" >&2
+  [ -f "$TEST_DIR/merge-comments" ] && cat "$TEST_DIR/merge-comments" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+if [ "$ERRORS" = "0" ]; then
+  echo "==> PASS: fix-loop findings history is persisted and posted"
+  exit 0
+fi
+echo "==> FAIL: $ERRORS case(s) regressed" >&2
+exit 1


### PR DESCRIPTION
## Linked Issues

Closes #197
Closes #200

(NOT closing #229 — that issue tracks the provider/model 'unknown' fallback which this PR inherits but does not fix.)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

## Summary

Wave 5 of the conductor-review-process work. Two related additions, both reusing the `lib/review-comment.sh` helper that landed in PR #228.

- **Advisory review at PR open (#197)** — `scripts/open-pr.sh` runs `CODEX_REVIEW_FORCE=1 CODEX_REVIEW_MODE=review-only` after `gh pr create` and posts the result as a non-blocking PR comment. Gated by `[review].advisory_at_pr_open`.
- **Fix-loop findings history (#200)** — `scripts/codex-review.sh` now writes per-iteration findings to branch-scoped JSONL in `.git/touchstone/`. After successful merge, `merge-pr.sh` posts a collapsed `<details>` summary as a PR comment. Gated by `[review].comment_findings_history`.

## Invariants

- **#197**: advisory comments never gate PR creation — non-blocking, idempotent, cache-friendly.
- **#200**: findings-history comments are emitted only from persisted review history — reproducible from log, never from in-memory state.

## Testing

- New `tests/test-advisory-at-pr-open.sh` and `tests/test-fixloop-findings-comment.sh`
- Full fast tier passed pre-push
- Local conductor reviews ran clean twice during iteration

## Notes for the merger

- Provider/model "unknown" in clean-comment fallback is tracked separately by #229 and is intentionally inherited as-is by both new comment paths in this PR.
- Lane I (codex) hit the 30-min wall-clock cap during open-pr.sh's redundant validate tier; the PR is reviewed-clean at HEAD and just needs the merge to land.