### PR TITLE
chore(update): satisfy shell preflight for sync drift tests

### DIFF
--- a/bin/touchstone
+++ b/bin/touchstone
@@ -1625,6 +1625,8 @@ cmd_help() {
   echo "  ${BOLD}Environment:${RESET}"
   printf "    ${BOLD}TOUCHSTONE_NO_AUTO_UPDATE=1${RESET}        Disable CLI auto-update and project auto-sync\n"
   printf "    ${BOLD}TOUCHSTONE_NO_AUTO_PROJECT_SYNC=1${RESET}  Disable project auto-sync only\n"
+  printf "    ${BOLD}TOUCHSTONE_FORCE_OVERLAP=1${RESET}         Force project sync through dirty overlap\n"
+  printf "    ${BOLD}TOUCHSTONE_NO_DRIFT_WARNING=1${RESET}      Suppress skipped-sync drift warning\n"
   echo ""
   printf "  Install: ${DIM}brew tap autumngarage/touchstone && brew install touchstone${RESET}\n"
   echo ""
@@ -1639,6 +1641,9 @@ shift 2>/dev/null || true
 
 # Auto-project-sync runs after command parsing so read-only commands can skip
 # it and before dispatch so write-capable commands see current Touchstone files.
+if project_root_for_drift="$(touchstone_find_project_root 2>/dev/null)"; then
+  touchstone_sync_warn_if_drift_skipped "$project_root_for_drift" "$(touchstone_installed_id)" || true
+fi
 touchstone_auto_project_sync "$COMMAND" "$@" || true
 
 case "$COMMAND" in

--- a/bootstrap/update-project.sh
+++ b/bootstrap/update-project.sh
@@ -24,6 +24,8 @@ TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 source "$TOUCHSTONE_ROOT/lib/install-hooks.sh"
 # shellcheck source=../lib/agents-principles-block.sh
 source "$TOUCHSTONE_ROOT/lib/agents-principles-block.sh"
+# shellcheck source=../lib/sync-discipline.sh
+source "$TOUCHSTONE_ROOT/lib/sync-discipline.sh"
 PROJECT_DIR="$(pwd)"
 DRY_RUN=false
 CHECK_ONLY=false
@@ -33,6 +35,7 @@ IN_PLACE=false
 
 usage() {
   echo "Usage: $0 [--dry-run|-n] [--check] [--branch <name>] [--in-place|--no-branch] [--ship]"
+  echo "Env: TOUCHSTONE_FORCE_OVERLAP=1 proceeds even when dirty paths overlap planned writes."
 }
 
 while [ "$#" -gt 0 ]; do
@@ -271,11 +274,25 @@ require_clean_git_repo() {
     exit 1
   fi
 
-  if [ -n "$(git -C "$PROJECT_DIR" status --porcelain)" ]; then
+  local dirty_paths overlap_paths
+  dirty_paths="$(touchstone_sync_dirty_paths "$PROJECT_DIR")"
+  overlap_paths="$(touchstone_sync_dirty_overlap_paths "$PROJECT_DIR" "$TOUCHSTONE_ROOT")"
+
+  if [ -n "$overlap_paths" ] && [ "${TOUCHSTONE_FORCE_OVERLAP:-}" != "1" ]; then
     echo "ERROR: Working tree is dirty. touchstone update needs a clean git boundary." >&2
+    echo "       Dirty paths overlap planned touchstone writes:" >&2
+    printf '%s\n' "$overlap_paths" | sed 's/^/         - /' >&2
     echo "       Commit, stash, or revert local changes, then run touchstone update." >&2
     echo "       Preview safely with: touchstone update --dry-run" >&2
     exit 1
+  fi
+
+  if [ -n "$overlap_paths" ]; then
+    echo "WARNING: TOUCHSTONE_FORCE_OVERLAP=1 set; proceeding despite dirty paths that overlap planned touchstone writes:" >&2
+    printf '%s\n' "$overlap_paths" | sed 's/^/         - /' >&2
+  elif [ -n "$dirty_paths" ]; then
+    printf '==> Proceeding with sync past unrelated dirty paths: '
+    printf '%s\n' "$dirty_paths" | touchstone_sync_format_path_list
   fi
 }
 

--- a/bootstrap/update-project.sh
+++ b/bootstrap/update-project.sh
@@ -284,6 +284,7 @@ require_clean_git_repo() {
     printf '%s\n' "$overlap_paths" | sed 's/^/         - /' >&2
     echo "       Commit, stash, or revert local changes, then run touchstone update." >&2
     echo "       Preview safely with: touchstone update --dry-run" >&2
+    touchstone_sync_log_skip "$PROJECT_DIR" "$OLD_SHA" "$CURRENT_SHA" "dirty-overlap" "$overlap_paths" "touchstone update"
     exit 1
   fi
 

--- a/lib/auto-update.sh
+++ b/lib/auto-update.sh
@@ -121,13 +121,13 @@ touchstone_auto_project_sync_command_skips() {
   local command="${1:-}" subcommand="${2:-}"
 
   case "$command" in
-    ""|help|-h|--help|version|--version|status|list|ls|diff|changelog|doctor|detect|skills|update|sync|new|init|migrate-from-toolkit|migrate-review-config|release)
+    "" | help | -h | --help | version | --version | status | list | ls | diff | changelog | doctor | detect | skills | update | sync | new | init | migrate-from-toolkit | migrate-review-config | release)
       return 0
       ;;
   esac
 
   case "$command:$subcommand" in
-    adr:list|worker:status|worker:list|review:--dry-run|review:-n)
+    adr:list | worker:status | worker:list | review:--dry-run | review:-n)
       return 0
       ;;
   esac

--- a/lib/auto-update.sh
+++ b/lib/auto-update.sh
@@ -14,6 +14,9 @@
 #   TOUCHSTONE_UPDATE_INTERVAL   — seconds between checks (default: 3600 = 1 hour)
 #
 
+# shellcheck source=sync-discipline.sh
+source "$TOUCHSTONE_ROOT/lib/sync-discipline.sh"
+
 TOUCHSTONE_UPDATE_INTERVAL="${TOUCHSTONE_UPDATE_INTERVAL:-3600}"
 TOUCHSTONE_STATE_DIR="${TOUCHSTONE_STATE_DIR:-$HOME/.touchstone}"
 LAST_CHECK_FILE="$TOUCHSTONE_STATE_DIR/last-update-check"
@@ -167,9 +170,22 @@ touchstone_auto_project_sync() {
     return 0
   fi
 
-  if [ -n "$(git -C "$project_dir" status --porcelain)" ]; then
-    echo "WARNING: touchstone auto-sync skipped for $project_dir (working tree is dirty)." >&2
+  local dirty_paths overlap_paths
+  dirty_paths="$(touchstone_sync_dirty_paths "$project_dir")"
+  overlap_paths="$(touchstone_sync_dirty_overlap_paths "$project_dir" "$TOUCHSTONE_ROOT")"
+
+  if [ -n "$overlap_paths" ] && [ "${TOUCHSTONE_FORCE_OVERLAP:-}" != "1" ]; then
+    echo "WARNING: touchstone auto-sync skipped for $project_dir (dirty paths overlap planned touchstone writes)." >&2
+    printf '%s\n' "$overlap_paths" | sed 's/^/         - /' >&2
     return 0
+  fi
+
+  if [ -n "$overlap_paths" ]; then
+    echo "WARNING: TOUCHSTONE_FORCE_OVERLAP=1 set; auto-sync proceeding despite dirty paths that overlap planned touchstone writes:" >&2
+    printf '%s\n' "$overlap_paths" | sed 's/^/         - /' >&2
+  elif [ -n "$dirty_paths" ]; then
+    printf '==> Proceeding with sync past unrelated dirty paths: ' >&2
+    printf '%s\n' "$dirty_paths" | touchstone_sync_format_path_list >&2
   fi
 
   local log_file

--- a/lib/auto-update.sh
+++ b/lib/auto-update.sh
@@ -14,8 +14,13 @@
 #   TOUCHSTONE_UPDATE_INTERVAL   — seconds between checks (default: 3600 = 1 hour)
 #
 
+TOUCHSTONE_SYNC_DISCIPLINE_PATH="$TOUCHSTONE_ROOT/lib/sync-discipline.sh"
+if [ ! -f "$TOUCHSTONE_SYNC_DISCIPLINE_PATH" ]; then
+  TOUCHSTONE_AUTO_UPDATE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  TOUCHSTONE_SYNC_DISCIPLINE_PATH="$TOUCHSTONE_AUTO_UPDATE_LIB_DIR/sync-discipline.sh"
+fi
 # shellcheck source=sync-discipline.sh
-source "$TOUCHSTONE_ROOT/lib/sync-discipline.sh"
+source "$TOUCHSTONE_SYNC_DISCIPLINE_PATH"
 
 TOUCHSTONE_UPDATE_INTERVAL="${TOUCHSTONE_UPDATE_INTERVAL:-3600}"
 TOUCHSTONE_STATE_DIR="${TOUCHSTONE_STATE_DIR:-$HOME/.touchstone}"
@@ -177,6 +182,7 @@ touchstone_auto_project_sync() {
   if [ -n "$overlap_paths" ] && [ "${TOUCHSTONE_FORCE_OVERLAP:-}" != "1" ]; then
     echo "WARNING: touchstone auto-sync skipped for $project_dir (dirty paths overlap planned touchstone writes)." >&2
     printf '%s\n' "$overlap_paths" | sed 's/^/         - /' >&2
+    touchstone_sync_log_skip "$project_dir" "$project_id" "$installed_id" "dirty-overlap" "$overlap_paths" "touchstone $command"
     return 0
   fi
 
@@ -201,5 +207,6 @@ touchstone_auto_project_sync() {
   fi
 
   echo "WARNING: touchstone auto-sync failed for $project_dir; continuing. Log: $log_file" >&2
+  touchstone_sync_log_skip "$project_dir" "$project_id" "$installed_id" "auto-sync-failed" "" "touchstone $command"
   return 0
 }

--- a/lib/sync-discipline.sh
+++ b/lib/sync-discipline.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+#
+# Shared discipline for project sync safety checks and drift visibility.
+
+touchstone_sync_project_type() {
+  local project_dir="$1"
+  local project_type="generic"
+
+  if [ -f "$project_dir/.touchstone-config" ]; then
+    project_type="$(grep '^project_type=' "$project_dir/.touchstone-config" 2>/dev/null | cut -d= -f2 | tr -d '[:space:]' || true)"
+  fi
+
+  printf '%s\n' "${project_type:-generic}"
+}
+
+touchstone_sync_planned_write_paths() {
+  local project_dir="$1" touchstone_root="$2"
+  local project_type
+  project_type="$(touchstone_sync_project_type "$project_dir")"
+
+  {
+    printf '.touchstone-manifest\n'
+    printf '.touchstone-version\n'
+    printf '.claude/settings.json\n'
+    printf 'principles/\n'
+    printf 'scripts/codex-review.sh\n'
+    printf 'scripts/branch-guard.sh\n'
+    printf 'scripts/emergency-disclosure.sh\n'
+    printf 'scripts/cortex-pr-merged-hook.sh\n'
+    printf 'scripts/touchstone-run.sh\n'
+    printf 'scripts/open-pr.sh\n'
+    printf 'scripts/merge-pr.sh\n'
+    printf 'scripts/cleanup-branches.sh\n'
+    printf 'scripts/spawn-worktree.sh\n'
+    printf 'scripts/cleanup-worktrees.sh\n'
+    printf 'scripts/worker.sh\n'
+    printf 'lib/toml.sh\n'
+    printf 'lib/events.sh\n'
+    printf 'lib/worker-state.sh\n'
+    printf 'lib/preflight.sh\n'
+    printf 'lib/review-comment.sh\n'
+
+    if [ "$project_type" = "python" ] || [ -f "$project_dir/scripts/run-pytest-in-venv.sh" ]; then
+      printf 'scripts/run-pytest-in-venv.sh\n'
+    fi
+
+    if [ -d "$touchstone_root/.claude/skills" ]; then
+      local skill_dir skill_name f
+      for skill_dir in "$touchstone_root/.claude/skills/"touchstone-*/; do
+        [ -d "$skill_dir" ] || continue
+        skill_name="$(basename "$skill_dir")"
+        for f in "$skill_dir"*; do
+          [ -f "$f" ] || continue
+          printf '.claude/skills/%s/%s\n' "$skill_name" "$(basename "$f")"
+        done
+      done
+    fi
+
+    if [ "$project_type" = "swift" ] \
+      && [ -f "$touchstone_root/templates/swift/.swiftlint.yml" ] \
+      && [ ! -f "$project_dir/.swiftlint.yml" ]; then
+      printf '.swiftlint.yml\n'
+    fi
+
+    if [ -f "$touchstone_root/templates/GEMINI.md" ] && [ ! -f "$project_dir/GEMINI.md" ]; then
+      printf 'GEMINI.md\n'
+    fi
+
+    if [ -f "$project_dir/AGENTS.md" ]; then
+      printf 'AGENTS.md\n'
+    fi
+
+    if [ -f "$project_dir/.codex-review.toml" ]; then
+      if grep -qE '^[[:space:]]*reviewers[[:space:]]*=[[:space:]]*\[' "$project_dir/.codex-review.toml" \
+        || grep -qE '^\[review\.local\]' "$project_dir/.codex-review.toml" \
+        || grep -qE '^\[review\.assist\]' "$project_dir/.codex-review.toml" \
+        || grep -qE '^[[:space:]]*(small|large)_reviewers[[:space:]]*=[[:space:]]*\[' "$project_dir/.codex-review.toml"; then
+        printf '.codex-review.toml\n'
+      fi
+    fi
+  } | sort -u
+}
+
+touchstone_sync_dirty_paths() {
+  local project_dir="$1"
+
+  git -C "$project_dir" status --porcelain --untracked-files=all \
+    | while IFS= read -r line; do
+      [ -n "$line" ] || continue
+      local path="${line#???}"
+      case "$path" in
+        *" -> "*)
+          printf '%s\n' "${path%% -> *}"
+          printf '%s\n' "${path##* -> }"
+          ;;
+        *)
+          printf '%s\n' "$path"
+          ;;
+      esac
+    done | sort -u
+}
+
+touchstone_sync_paths_overlap() {
+  local dirty_path="$1" planned_path="$2"
+
+  dirty_path="${dirty_path#./}"
+  planned_path="${planned_path#./}"
+  dirty_path="${dirty_path%/}"
+  planned_path="${planned_path%/}"
+
+  [ -n "$dirty_path" ] || return 1
+  [ -n "$planned_path" ] || return 1
+
+  if [ "$dirty_path" = "$planned_path" ]; then
+    return 0
+  fi
+  case "$dirty_path/" in
+    "$planned_path"/*) return 0 ;;
+  esac
+  case "$planned_path/" in
+    "$dirty_path"/*) return 0 ;;
+  esac
+
+  return 1
+}
+
+touchstone_sync_dirty_overlap_paths() {
+  local project_dir="$1" touchstone_root="$2"
+  local tmp_dir dirty_file planned_file
+  tmp_dir="$(mktemp -d -t touchstone-sync-discipline.XXXXXX)"
+  dirty_file="$tmp_dir/dirty"
+  planned_file="$tmp_dir/planned"
+
+  touchstone_sync_dirty_paths "$project_dir" >"$dirty_file"
+  touchstone_sync_planned_write_paths "$project_dir" "$touchstone_root" >"$planned_file"
+
+  while IFS= read -r dirty_path; do
+    [ -n "$dirty_path" ] || continue
+    while IFS= read -r planned_path; do
+      [ -n "$planned_path" ] || continue
+      if touchstone_sync_paths_overlap "$dirty_path" "$planned_path"; then
+        printf '%s\n' "$dirty_path"
+        break
+      fi
+    done <"$planned_file"
+  done <"$dirty_file" | sort -u
+
+  rm -rf "$tmp_dir"
+}
+
+touchstone_sync_format_path_list() {
+  awk 'BEGIN { first = 1 } { if (!first) printf ", "; printf "%s", $0; first = 0 } END { printf "\n" }'
+}

--- a/lib/sync-discipline.sh
+++ b/lib/sync-discipline.sh
@@ -151,3 +151,120 @@ touchstone_sync_dirty_overlap_paths() {
 touchstone_sync_format_path_list() {
   awk 'BEGIN { first = 1 } { if (!first) printf ", "; printf "%s", $0; first = 0 } END { printf "\n" }'
 }
+
+touchstone_sync_git_dir() {
+  local project_dir="$1"
+  local git_dir
+
+  git_dir="$(git -C "$project_dir" rev-parse --git-dir 2>/dev/null || true)"
+  [ -n "$git_dir" ] || return 1
+  case "$git_dir" in
+    /*) printf '%s\n' "$git_dir" ;;
+    *) printf '%s\n' "$project_dir/$git_dir" ;;
+  esac
+}
+
+touchstone_sync_skip_log_file() {
+  local project_dir="$1" git_dir
+
+  git_dir="$(touchstone_sync_git_dir "$project_dir")" || return 1
+  printf '%s\n' "$git_dir/touchstone/sync-skips.jsonl"
+}
+
+touchstone_sync_json_escape() {
+  sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+touchstone_sync_paths_json_array() {
+  local first=true escaped
+
+  printf '['
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    escaped="$(printf '%s' "$path" | touchstone_sync_json_escape)"
+    if [ "$first" = true ]; then
+      first=false
+    else
+      printf ','
+    fi
+    printf '"%s"' "$escaped"
+  done
+  printf ']'
+}
+
+touchstone_sync_log_skip() {
+  local project_dir="$1" from_version="$2" to_version="$3" reason="$4" paths="$5" command="$6"
+  local log_file timestamp paths_json
+
+  log_file="$(touchstone_sync_skip_log_file "$project_dir" 2>/dev/null || true)"
+  [ -n "$log_file" ] || return 0
+  mkdir -p "$(dirname "$log_file")" 2>/dev/null || return 0
+
+  timestamp="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  paths_json="$(printf '%s\n' "$paths" | touchstone_sync_paths_json_array)"
+
+  printf '{"timestamp":"%s","from_version":"%s","to_version":"%s","reason":"%s","overlapping_paths":%s,"command":"%s"}\n' \
+    "$(printf '%s' "$timestamp" | touchstone_sync_json_escape)" \
+    "$(printf '%s' "$from_version" | touchstone_sync_json_escape)" \
+    "$(printf '%s' "$to_version" | touchstone_sync_json_escape)" \
+    "$(printf '%s' "$reason" | touchstone_sync_json_escape)" \
+    "$paths_json" \
+    "$(printf '%s' "$command" | touchstone_sync_json_escape)" >>"$log_file" 2>/dev/null || true
+}
+
+touchstone_sync_timestamp_epoch() {
+  local timestamp="$1"
+
+  date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$timestamp" '+%s' 2>/dev/null \
+    || date -u -d "$timestamp" '+%s' 2>/dev/null \
+    || printf '0\n'
+}
+
+touchstone_sync_warn_if_drift_skipped() {
+  local project_dir="$1" installed_id="$2"
+
+  [ "${TOUCHSTONE_NO_DRIFT_WARNING:-}" = "1" ] && return 0
+  [ -n "$installed_id" ] || return 0
+  [ -f "$project_dir/.touchstone-version" ] || return 0
+
+  local project_id
+  project_id="$(tr -d '[:space:]' <"$project_dir/.touchstone-version" 2>/dev/null || true)"
+  [ -n "$project_id" ] || return 0
+  [ "$project_id" != "$installed_id" ] || return 0
+
+  local log_file
+  log_file="$(touchstone_sync_skip_log_file "$project_dir" 2>/dev/null || true)"
+  [ -n "$log_file" ] || return 0
+  [ -s "$log_file" ] || return 0
+
+  local threshold_days threshold_count skip_count last_line timestamp last_epoch now_epoch age_days reason paths_text
+  threshold_count="${TOUCHSTONE_DRIFT_WARNING_SKIP_THRESHOLD:-3}"
+  threshold_days="${TOUCHSTONE_DRIFT_WARNING_DAYS:-7}"
+  skip_count="$(wc -l <"$log_file" | tr -d '[:space:]')"
+  last_line="$(tail -n 1 "$log_file" 2>/dev/null || true)"
+  [ -n "$last_line" ] || return 0
+
+  timestamp="$(printf '%s\n' "$last_line" | sed -n 's/.*"timestamp":"\([^"]*\)".*/\1/p')"
+  last_epoch="$(touchstone_sync_timestamp_epoch "$timestamp")"
+  now_epoch="$(date -u '+%s')"
+  if [ "$last_epoch" -gt 0 ] && [ "$now_epoch" -ge "$last_epoch" ]; then
+    age_days="$(((now_epoch - last_epoch) / 86400))"
+  else
+    age_days="$threshold_days"
+  fi
+
+  if [ "$skip_count" -le "$threshold_count" ] && [ "$age_days" -le "$threshold_days" ]; then
+    return 0
+  fi
+
+  reason="$(printf '%s\n' "$last_line" | sed -n 's/.*"reason":"\([^"]*\)".*/\1/p')"
+  reason="${reason:-unknown}"
+  paths_text="$(printf '%s\n' "$last_line" \
+    | sed -n 's/.*"overlapping_paths":\[\([^]]*\)\].*/\1/p' \
+    | sed 's/"//g; s/,/, /g')"
+  if [ -n "$paths_text" ]; then
+    paths_text=" on $paths_text"
+  fi
+
+  echo "[touchstone drift] project at $project_id, current is $installed_id - $skip_count sync attempts skipped, last $age_days days ago ($reason$paths_text). Run \`touchstone update\` after committing or .gitignoring those paths." >&2
+}

--- a/principles/git-workflow.md
+++ b/principles/git-workflow.md
@@ -33,11 +33,13 @@ The three layers are complementary — the local hook catches the honest mistake
 
 ### Touchstone CLI auto-sync
 
-When a brew-installed `touchstone` CLI runs a write-capable command inside a Touchstone-aware project, it compares the project's recorded `.touchstone-version` with the installed Touchstone version. If they differ and the project worktree is clean, the CLI runs the same `touchstone update` path before the requested command so `principles/`, `hooks/`, and `scripts/` stay current.
+When a brew-installed `touchstone` CLI runs a write-capable command inside a Touchstone-aware project, it compares the project's recorded `.touchstone-version` with the installed Touchstone version. If they differ and no dirty path overlaps planned Touchstone writes, the CLI runs the same `touchstone update` path before the requested command so `principles/`, `hooks/`, and `scripts/` stay current.
 
-If the project worktree is dirty, auto-sync prints a one-line warning and skips; the user's pending work is never stashed, overwritten, or committed. `touchstone version`, help, status, diff, doctor, list, changelog, and other read-only commands do not trigger auto-sync.
+If the project worktree is dirty, auto-sync compares dirty paths with the planned Touchstone write set and skips only when they overlap; unrelated dirty paths are reported in one line and sync proceeds. The user's pending work is never stashed, overwritten outside that planned write set, or committed separately. `touchstone version`, help, status, diff, doctor, list, changelog, and other read-only commands do not trigger auto-sync.
 
-Set `TOUCHSTONE_NO_AUTO_UPDATE=1` to disable both CLI self-update and project auto-sync. Set `TOUCHSTONE_NO_AUTO_PROJECT_SYNC=1` to keep CLI self-update enabled but disable only the per-project sync.
+When a sync attempt skips, Touchstone appends a project-local audit entry to `.git/touchstone/sync-skips.jsonl`. Later `touchstone <subcmd>` invocations warn when the project is still behind the installed Touchstone and the skip trail is persistent enough to indicate drift; the warning is informational and never blocks the subcommand.
+
+Set `TOUCHSTONE_NO_AUTO_UPDATE=1` to disable both CLI self-update and project auto-sync. Set `TOUCHSTONE_NO_AUTO_PROJECT_SYNC=1` to keep CLI self-update enabled but disable only the per-project sync. Set `TOUCHSTONE_FORCE_OVERLAP=1` to force project sync through dirty paths that overlap planned Touchstone writes. Set `TOUCHSTONE_NO_DRIFT_WARNING=1` to suppress skipped-sync drift warnings in scripted output.
 
 ## Commit discipline
 

--- a/tests/test-auto-project-sync.sh
+++ b/tests/test-auto-project-sync.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # real default-on behavior. Without this, `TOUCHSTONE_NO_AUTO_UPDATE=1` set
 # by an outer script (e.g., a pre-push hook caller) silently skips sync in
 # cases that expect it to fire, producing confusing per-context failures.
-unset TOUCHSTONE_NO_AUTO_UPDATE TOUCHSTONE_NO_AUTO_PROJECT_SYNC
+unset TOUCHSTONE_NO_AUTO_UPDATE TOUCHSTONE_NO_AUTO_PROJECT_SYNC TOUCHSTONE_FORCE_OVERLAP TOUCHSTONE_NO_DRIFT_WARNING
 
 TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TOUCHSTONE_BIN="$TOUCHSTONE_ROOT/bin/touchstone"
@@ -96,7 +96,7 @@ if ! git -C "$CLEAN_PROJECT" branch --show-current | grep -q '^chore/touchstone-
 fi
 
 echo ""
-echo "--- drift + dirty tree: warning, no sync, subcommand proceeds ---"
+echo "--- drift + unrelated dirty tree: sync proceeds, subcommand proceeds ---"
 DIRTY_HOME="$TEST_DIR/home-dirty"
 DIRTY_PROJECT="$TEST_DIR/project-dirty"
 DIRTY_OLD="0000000000000000000000000000000000000002"
@@ -104,9 +104,25 @@ make_project "$DIRTY_PROJECT" "$DIRTY_OLD"
 printf 'dirty\n' >>"$DIRTY_PROJECT/README.md"
 DIRTY_OUT="$TEST_DIR/dirty.out"
 (cd "$DIRTY_PROJECT" && run_touchstone "$DIRTY_HOME" run validate) >"$DIRTY_OUT" 2>&1
-assert_contains "$DIRTY_OUT" "WARNING: touchstone auto-sync skipped for $DIRTY_PROJECT (working tree is dirty)."
+assert_contains "$DIRTY_OUT" "Proceeding with sync past unrelated dirty paths: README.md"
+assert_contains "$DIRTY_OUT" "auto-synced touchstone $DIRTY_OLD -> $CURRENT_ID"
 assert_contains "$DIRTY_OUT" "generic project has no default 'lint' command"
-assert_version_equals "$DIRTY_PROJECT" "$DIRTY_OLD"
+assert_version_equals "$DIRTY_PROJECT" "$CURRENT_ID"
+
+echo ""
+echo "--- drift + overlapping dirty tree: warning, no sync, subcommand proceeds ---"
+OVERLAP_HOME="$TEST_DIR/home-overlap"
+OVERLAP_PROJECT="$TEST_DIR/project-overlap"
+OVERLAP_OLD="0000000000000000000000000000000000000007"
+make_project "$OVERLAP_PROJECT" "$OVERLAP_OLD"
+mkdir -p "$OVERLAP_PROJECT/scripts"
+printf 'dirty\n' >"$OVERLAP_PROJECT/scripts/touchstone-run.sh"
+OVERLAP_OUT="$TEST_DIR/overlap.out"
+(cd "$OVERLAP_PROJECT" && run_touchstone "$OVERLAP_HOME" run validate) >"$OVERLAP_OUT" 2>&1
+assert_contains "$OVERLAP_OUT" "WARNING: touchstone auto-sync skipped for $OVERLAP_PROJECT (dirty paths overlap planned touchstone writes)."
+assert_contains "$OVERLAP_OUT" "scripts/touchstone-run.sh"
+assert_contains "$OVERLAP_OUT" "generic project has no default 'lint' command"
+assert_version_equals "$OVERLAP_PROJECT" "$OVERLAP_OLD"
 
 echo ""
 echo "--- no drift: no-op, subcommand proceeds ---"

--- a/tests/test-auto-project-sync.sh
+++ b/tests/test-auto-project-sync.sh
@@ -123,6 +123,9 @@ assert_contains "$OVERLAP_OUT" "WARNING: touchstone auto-sync skipped for $OVERL
 assert_contains "$OVERLAP_OUT" "scripts/touchstone-run.sh"
 assert_contains "$OVERLAP_OUT" "generic project has no default 'lint' command"
 assert_version_equals "$OVERLAP_PROJECT" "$OVERLAP_OLD"
+OVERLAP_SKIP_LOG="$OVERLAP_PROJECT/.git/touchstone/sync-skips.jsonl"
+assert_contains "$OVERLAP_SKIP_LOG" '"reason":"dirty-overlap"'
+assert_contains "$OVERLAP_SKIP_LOG" '"overlapping_paths":\["scripts/touchstone-run.sh"\]'
 
 echo ""
 echo "--- no drift: no-op, subcommand proceeds ---"
@@ -216,6 +219,42 @@ HELP_OUT="$TEST_DIR/help.out"
 assert_not_contains "$HELP_OUT" "auto-synced touchstone"
 assert_contains "$HELP_OUT" "TOUCHSTONE_NO_AUTO_PROJECT_SYNC"
 assert_version_equals "$VERSION_PROJECT" "$VERSION_OLD"
+
+echo ""
+echo "--- drift warning surfaces after repeated skips ---"
+DRIFT_HOME="$TEST_DIR/home-drift-warning"
+DRIFT_PROJECT="$TEST_DIR/project-drift-warning"
+DRIFT_OLD="0000000000000000000000000000000000000008"
+make_project "$DRIFT_PROJECT" "$DRIFT_OLD"
+mkdir -p "$DRIFT_PROJECT/.git/touchstone"
+for i in 1 2 3 4; do
+  printf '{"timestamp":"%s","from_version":"%s","to_version":"%s","reason":"dirty-overlap","overlapping_paths":["scripts/touchstone-run.sh"],"command":"touchstone run"}\n' \
+    "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$DRIFT_OLD" "$CURRENT_ID" >>"$DRIFT_PROJECT/.git/touchstone/sync-skips.jsonl"
+done
+DRIFT_OUT="$TEST_DIR/drift-warning.out"
+(cd "$DRIFT_PROJECT" && run_touchstone "$DRIFT_HOME" version) >"$DRIFT_OUT" 2>&1
+assert_contains "$DRIFT_OUT" "\[touchstone drift\] project at $DRIFT_OLD, current is $CURRENT_ID"
+assert_contains "$DRIFT_OUT" "4 sync attempts skipped"
+assert_contains "$DRIFT_OUT" "dirty-overlap on scripts/touchstone-run.sh"
+
+echo ""
+echo "--- TOUCHSTONE_NO_DRIFT_WARNING=1 suppresses drift warning ---"
+NO_DRIFT_WARNING_HOME="$TEST_DIR/home-no-drift-warning"
+NO_DRIFT_WARNING_OUT="$TEST_DIR/no-drift-warning.out"
+(
+  cd "$DRIFT_PROJECT"
+  TOUCHSTONE_NO_DRIFT_WARNING=1 run_touchstone "$NO_DRIFT_WARNING_HOME" version
+) >"$NO_DRIFT_WARNING_OUT" 2>&1
+assert_not_contains "$NO_DRIFT_WARNING_OUT" "\[touchstone drift\]"
+
+echo ""
+echo "--- no drift and no skips: no drift warning ---"
+NO_WARNING_HOME="$TEST_DIR/home-no-warning"
+NO_WARNING_PROJECT="$TEST_DIR/project-no-warning"
+make_project "$NO_WARNING_PROJECT" "$CURRENT_ID"
+NO_WARNING_OUT="$TEST_DIR/no-warning.out"
+(cd "$NO_WARNING_PROJECT" && run_touchstone "$NO_WARNING_HOME" version) >"$NO_WARNING_OUT" 2>&1
+assert_not_contains "$NO_WARNING_OUT" "\[touchstone drift\]"
 
 if [ -e "$TEST_DIR/home-clean/.touchstone-projects" ] \
   || [ -e "$TEST_DIR/home-dirty/.touchstone-projects" ] \

--- a/tests/test-auto-project-sync.sh
+++ b/tests/test-auto-project-sync.sh
@@ -227,7 +227,7 @@ DRIFT_PROJECT="$TEST_DIR/project-drift-warning"
 DRIFT_OLD="0000000000000000000000000000000000000008"
 make_project "$DRIFT_PROJECT" "$DRIFT_OLD"
 mkdir -p "$DRIFT_PROJECT/.git/touchstone"
-for i in 1 2 3 4; do
+for _ in 1 2 3 4; do
   printf '{"timestamp":"%s","from_version":"%s","to_version":"%s","reason":"dirty-overlap","overlapping_paths":["scripts/touchstone-run.sh"],"command":"touchstone run"}\n' \
     "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$DRIFT_OLD" "$CURRENT_ID" >>"$DRIFT_PROJECT/.git/touchstone/sync-skips.jsonl"
 done

--- a/tests/test-sync-scope-aware.sh
+++ b/tests/test-sync-scope-aware.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+#
+# tests/test-sync-scope-aware.sh — scope-aware dirty checks for project sync.
+#
+set -euo pipefail
+
+exec </dev/null
+
+unset TOUCHSTONE_NO_AUTO_UPDATE TOUCHSTONE_NO_AUTO_PROJECT_SYNC TOUCHSTONE_FORCE_OVERLAP TOUCHSTONE_NO_DRIFT_WARNING
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_DIR="$(mktemp -d -t touchstone-test-sync-scope.XXXXXX)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+ERRORS=0
+
+assert_contains() {
+  local file="$1" needle="$2"
+  if ! grep -q -- "$needle" "$file" 2>/dev/null; then
+    echo "FAIL: expected '$file' to contain '$needle'" >&2
+    sed 's/^/    /' "$file" >&2 || true
+    ERRORS=$((ERRORS + 1))
+  fi
+}
+
+assert_not_contains() {
+  local file="$1" needle="$2"
+  if grep -q -- "$needle" "$file" 2>/dev/null; then
+    echo "FAIL: expected '$file' to NOT contain '$needle'" >&2
+    sed 's/^/    /' "$file" >&2 || true
+    ERRORS=$((ERRORS + 1))
+  fi
+}
+
+configure_git() {
+  local repo="$1"
+  git -C "$repo" config user.email "touchstone-test@example.com"
+  git -C "$repo" config user.name "Touchstone Test"
+}
+
+commit_all() {
+  local repo="$1" message="$2"
+  git -C "$repo" add -A
+  if [ -n "$(git -C "$repo" status --porcelain)" ] \
+    || ! git -C "$repo" rev-parse --verify HEAD >/dev/null 2>&1; then
+    git -C "$repo" commit --no-verify -m "$message" >/dev/null
+  fi
+}
+
+make_stale_project() {
+  local project="$1" old_id="$2"
+  bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$project" --no-register >/dev/null
+  configure_git "$project"
+  commit_all "$project" "initial project"
+  printf '%s\n' "$old_id" >"$project/.touchstone-version"
+  commit_all "$project" "simulate stale touchstone"
+}
+
+assert_version_current() {
+  local project="$1" current_id
+  if [ -d "$TOUCHSTONE_ROOT/.git" ]; then
+    current_id="$(git -C "$TOUCHSTONE_ROOT" rev-parse HEAD)"
+  else
+    current_id="$(tr -d '[:space:]' <"$TOUCHSTONE_ROOT/VERSION")"
+  fi
+  if [ "$(tr -d '[:space:]' <"$project/.touchstone-version")" != "$current_id" ]; then
+    echo "FAIL: expected $project to update to current touchstone id" >&2
+    ERRORS=$((ERRORS + 1))
+  fi
+}
+
+echo "==> Test: scope-aware sync dirty checks"
+echo "    Test dir: $TEST_DIR"
+
+echo ""
+echo "--- clean tree with drift: sync runs without unrelated-dirty notice ---"
+CLEAN_PROJECT="$TEST_DIR/clean-project"
+make_stale_project "$CLEAN_PROJECT" "0000000000000000000000000000000000000101"
+(cd "$CLEAN_PROJECT" && bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh") >"$TEST_DIR/clean.out" 2>&1
+assert_contains "$TEST_DIR/clean.out" "Committed: chore: update touchstone to"
+assert_not_contains "$TEST_DIR/clean.out" "Proceeding with sync past unrelated dirty paths"
+assert_version_current "$CLEAN_PROJECT"
+
+echo ""
+echo "--- dirty path inside owned set: sync refuses with overlap list ---"
+OVERLAP_PROJECT="$TEST_DIR/overlap-project"
+make_stale_project "$OVERLAP_PROJECT" "0000000000000000000000000000000000000102"
+printf '\n# dirty overlap\n' >>"$OVERLAP_PROJECT/scripts/touchstone-run.sh"
+if (cd "$OVERLAP_PROJECT" && bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh") >"$TEST_DIR/overlap.out" 2>&1; then
+  echo "FAIL: expected dirty overlap to refuse sync" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+assert_contains "$TEST_DIR/overlap.out" "Working tree is dirty"
+assert_contains "$TEST_DIR/overlap.out" "Dirty paths overlap planned touchstone writes"
+assert_contains "$TEST_DIR/overlap.out" "scripts/touchstone-run.sh"
+
+echo ""
+echo "--- dirty path outside owned set: sync proceeds with notice ---"
+UNRELATED_PROJECT="$TEST_DIR/unrelated-project"
+make_stale_project "$UNRELATED_PROJECT" "0000000000000000000000000000000000000103"
+mkdir -p "$UNRELATED_PROJECT/audits/drafts"
+printf 'draft\n' >"$UNRELATED_PROJECT/audits/drafts/notes.md"
+printf 'lock\n' >"$UNRELATED_PROJECT/uv.lock"
+(cd "$UNRELATED_PROJECT" && bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh") >"$TEST_DIR/unrelated.out" 2>&1
+assert_contains "$TEST_DIR/unrelated.out" "Proceeding with sync past unrelated dirty paths"
+assert_contains "$TEST_DIR/unrelated.out" "audits/drafts/notes.md"
+assert_contains "$TEST_DIR/unrelated.out" "uv.lock"
+assert_contains "$TEST_DIR/unrelated.out" "Committed: chore: update touchstone to"
+assert_version_current "$UNRELATED_PROJECT"
+
+echo ""
+echo "--- mixed dirty paths: sync refuses because overlap is non-empty ---"
+MIXED_PROJECT="$TEST_DIR/mixed-project"
+make_stale_project "$MIXED_PROJECT" "0000000000000000000000000000000000000104"
+printf '\n# dirty overlap\n' >>"$MIXED_PROJECT/lib/toml.sh"
+printf 'outside\n' >"$MIXED_PROJECT/uv.lock"
+if (cd "$MIXED_PROJECT" && bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh") >"$TEST_DIR/mixed.out" 2>&1; then
+  echo "FAIL: expected mixed dirty tree to refuse sync" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+assert_contains "$TEST_DIR/mixed.out" "lib/toml.sh"
+assert_not_contains "$TEST_DIR/mixed.out" "Proceeding with sync past unrelated dirty paths"
+
+echo ""
+echo "--- TOUCHSTONE_FORCE_OVERLAP=1: sync proceeds despite overlap ---"
+FORCE_PROJECT="$TEST_DIR/force-project"
+make_stale_project "$FORCE_PROJECT" "0000000000000000000000000000000000000105"
+printf '\n# dirty overlap\n' >>"$FORCE_PROJECT/scripts/touchstone-run.sh"
+(cd "$FORCE_PROJECT" && TOUCHSTONE_FORCE_OVERLAP=1 bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh") >"$TEST_DIR/force.out" 2>&1
+assert_contains "$TEST_DIR/force.out" "TOUCHSTONE_FORCE_OVERLAP=1 set"
+assert_contains "$TEST_DIR/force.out" "scripts/touchstone-run.sh"
+assert_contains "$TEST_DIR/force.out" "Committed: chore: update touchstone to"
+assert_version_current "$FORCE_PROJECT"
+
+if [ "$ERRORS" -ne 0 ]; then
+  echo ""
+  echo "FAIL: $ERRORS scope-aware sync assertion(s) failed" >&2
+  exit 1
+fi
+
+echo ""
+echo "PASS: scope-aware sync dirty checks"

--- a/tests/test-sync-scope-aware.sh
+++ b/tests/test-sync-scope-aware.sh
@@ -93,6 +93,8 @@ fi
 assert_contains "$TEST_DIR/overlap.out" "Working tree is dirty"
 assert_contains "$TEST_DIR/overlap.out" "Dirty paths overlap planned touchstone writes"
 assert_contains "$TEST_DIR/overlap.out" "scripts/touchstone-run.sh"
+assert_contains "$OVERLAP_PROJECT/.git/touchstone/sync-skips.jsonl" '"reason":"dirty-overlap"'
+assert_contains "$OVERLAP_PROJECT/.git/touchstone/sync-skips.jsonl" '"command":"touchstone update"'
 
 echo ""
 echo "--- dirty path outside owned set: sync proceeds with notice ---"


### PR DESCRIPTION
## Linked Issues

Closes #232

Lint-only follow-up kept separate because the branch already had the two requested feature commits and the brief prohibited amend.

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
