### PR TITLE
chore: refresh conductor integrations to v0.10.2

### DIFF
--- a/.cursor/rules/conductor-delegation.mdc
+++ b/.cursor/rules/conductor-delegation.mdc
@@ -2,7 +2,7 @@
 description: Use when delegating or routing tasks to a different LLM via the conductor CLI — e.g., cheap second opinions, long-context reads, web search, or offline runs.
 globs: ""
 alwaysApply: false
-managed-by: conductor v0.8.2
+managed-by: conductor v0.10.2
 ---
 
 # Conductor delegation
@@ -27,7 +27,7 @@ Use it when:
 - You want a cheap second opinion (`conductor call --with kimi --brief "..."`).
 - You need fresh web information (`conductor call --with gemini --brief "..."`).
 - You want to stay local / offline (`conductor call --with ollama --brief "..."`).
-- You want a true read-only code review:
+- You want a native code review:
   `conductor review --auto --base origin/main --brief-file /tmp/review.md`.
 - You're not sure which provider fits — let the router pick:
   `conductor call --auto --tags <tag1>,<tag2> --brief "..."`.
@@ -42,7 +42,7 @@ fit.
 For longer running tool-using sessions:
 
     conductor exec --with <provider> --tools Read,Edit,Bash \
-        --sandbox workspace-write --brief-file /tmp/conductor-brief.md
+        --brief-file /tmp/conductor-brief.md
 
 Discover configured providers: `conductor list`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,7 +188,7 @@ Flag any of the following:
 
 If there are zero blocking issues: "LGTM."
 
-<!-- conductor:begin v0.10.1 -->
+<!-- conductor:begin v0.10.2 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,47 +148,8 @@ Required repo secret: `HOMEBREW_TAP_PAT` (classic PAT with `repo` scope on the t
 
 Do not call a Touchstone release complete until GitHub Releases, the Homebrew formula, `origin/main`, and the local brew install all agree on the same version.
 
-<!-- conductor:begin v0.10.1 -->
-## Conductor delegation
-
-This project has [conductor](https://github.com/autumngarage/conductor)
-available for delegating tasks to other LLMs from inside an agent loop.
-You can shell out to it instead of trying to do everything yourself.
-
-Quick reference:
-
-- Quick factual/background ask:
-  `conductor ask --kind research --effort minimal --brief-file /tmp/brief.md`.
-- Deeper synthesis/research:
-  `conductor ask --kind research --effort medium --brief-file /tmp/brief.md`.
-- Code explanation or small coding judgment:
-  `conductor ask --kind code --effort low --brief-file /tmp/brief.md`.
-- Repo-changing implementation/debugging:
-  `conductor ask --kind code --effort high --brief-file /tmp/brief.md`.
-- Merge/PR/diff review:
-  `conductor ask --kind review --base <ref> --brief-file /tmp/review.md`.
-- Architecture/product judgment needing multiple views:
-  `conductor ask --kind council --effort medium --brief-file /tmp/brief.md`.
-- `conductor list` — show configured providers and their tags.
-
-Conductor does not inherit your conversation context. For delegation,
-write a complete brief with goal, context, scope, constraints, expected
-output, and validation; use `--brief-file` for nontrivial `exec` tasks.
-Default to `conductor ask`; use provider-specific `call` / `exec` only
-when the user explicitly asks for a provider or the semantic API does not
-fit.
-
-Providers commonly worth delegating to:
-
-- `kimi` — long-context summarization, cheap second opinions.
-- `gemini` — web search, multimodal.
-- `claude` / `codex` — strongest reasoning / coding agent loops.
-- `ollama` — local, offline, privacy-sensitive.
-- `council` kind — OpenRouter-only multi-model deliberation and synthesis.
-
-Full delegation guidance (when to delegate, when not to, error handling):
-
-    ~/.conductor/delegation-guidance.md
+<!-- conductor:begin v0.10.2 -->
+@~/.conductor/delegation-guidance.md
 <!-- conductor:end -->
 
 ## Current state (read this first)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -50,7 +50,7 @@ Run the slow tier when changing live guidance-probe behavior or before release-l
 
 Lint is not part of the test suite. The full lint suite runs at pre-commit and via `pre-commit run --all-files`: `shellcheck`, `shfmt` for shell-script formatting, `markdownlint` for prose, and `actionlint` for `.github/workflows/`. `.pre-commit-config.yaml` and `.markdownlint.json` are the canonical config files; `actionlint` is repo-only and is not synced to downstream templates.
 
-<!-- conductor:begin v0.10.1 -->
+<!-- conductor:begin v0.10.2 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)


### PR DESCRIPTION
Refresh conductor-managed AGENTS.md and Cursor rule from conductor v0.10.2 (released 2026-05-07).

Companion to autumngarage/conductor v0.10.2 — see [release notes](https://github.com/autumngarage/conductor/releases/tag/v0.10.2) for what changed in conductor itself. This repo's wired files were stale at v0.8.2 (or earlier); this refresh brings them current.

Generated automatically via `conductor refresh-consumers`.