### PR TITLE
fix(review): portable mktemp for conductor log file (BSD/macOS compat)

### DIFF
--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -1518,7 +1518,7 @@ reviewer_label() {
 REVIEW_OUTPUT_FILE="$(mktemp "${TMPDIR:-/tmp}/touchstone-review-output.XXXXXX")"
 ASSIST_OUTPUT_FILE="$(mktemp "${TMPDIR:-/tmp}/touchstone-review-assist-output.XXXXXX")"
 REVIEW_STDERR_FILE="$(mktemp "${TMPDIR:-/tmp}/touchstone-review-stderr.XXXXXX")"
-REVIEW_CONDUCTOR_LOG_FILE="$(mktemp "${TMPDIR:-/tmp}/touchstone-review-conductor.XXXXXX.ndjson")"
+REVIEW_CONDUCTOR_LOG_FILE="$(mktemp "${TMPDIR:-/tmp}/touchstone-review-conductor.XXXXXX")"
 PEER_CONDUCTOR_LOG_FILE=""
 trap 'rm -f "$REVIEW_OUTPUT_FILE" "$ASSIST_OUTPUT_FILE" "$REVIEW_STDERR_FILE" "$REVIEW_CONDUCTOR_LOG_FILE"' EXIT
 

--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -1346,6 +1346,9 @@ reviewer_conductor_exec() {
   if [ "$subcommand" = "exec" ]; then
     args+=(--tools "$tools")
     args+=(--timeout "${CODEX_REVIEW_TIMEOUT:-300}")
+    if [ -n "${REVIEW_CONDUCTOR_LOG_FILE:-}" ]; then
+      args+=(--log-file "$REVIEW_CONDUCTOR_LOG_FILE")
+    fi
   fi
 
   # Pass the prompt via stdin. Avoids argv length limits on large diffs and
@@ -1515,7 +1518,9 @@ reviewer_label() {
 REVIEW_OUTPUT_FILE="$(mktemp "${TMPDIR:-/tmp}/touchstone-review-output.XXXXXX")"
 ASSIST_OUTPUT_FILE="$(mktemp "${TMPDIR:-/tmp}/touchstone-review-assist-output.XXXXXX")"
 REVIEW_STDERR_FILE="$(mktemp "${TMPDIR:-/tmp}/touchstone-review-stderr.XXXXXX")"
-trap 'rm -f "$REVIEW_OUTPUT_FILE" "$ASSIST_OUTPUT_FILE" "$REVIEW_STDERR_FILE"' EXIT
+REVIEW_CONDUCTOR_LOG_FILE="$(mktemp "${TMPDIR:-/tmp}/touchstone-review-conductor.XXXXXX.ndjson")"
+PEER_CONDUCTOR_LOG_FILE=""
+trap 'rm -f "$REVIEW_OUTPUT_FILE" "$ASSIST_OUTPUT_FILE" "$REVIEW_STDERR_FILE" "$REVIEW_CONDUCTOR_LOG_FILE"' EXIT
 
 kill_process_tree() {
   local pid="$1"
@@ -1543,6 +1548,9 @@ run_reviewer_with_timeout() {
   # stderr, hence the historical /dev/null redirect; capturing instead is
   # safe because non-[conductor] lines are filtered before display.
   : >"$REVIEW_STDERR_FILE"
+  if [ "${ACTIVE_REVIEWER:-}" = "conductor" ] && [ -n "${REVIEW_CONDUCTOR_LOG_FILE:-}" ]; then
+    : >"$REVIEW_CONDUCTOR_LOG_FILE"
+  fi
 
   # No timeout: run directly
   if [ "$timeout_secs" -le 0 ] 2>/dev/null; then
@@ -2457,6 +2465,41 @@ print_route_log() {
   done
 }
 
+latest_conductor_session_log() {
+  local session_dir="${CONDUCTOR_SESSION_DIR:-${HOME:-}/.cache/conductor/sessions}"
+  [ -n "$session_dir" ] || return 0
+  [ -d "$session_dir" ] || return 0
+  ls -t "$session_dir"/*.ndjson 2>/dev/null | head -1
+}
+
+conductor_log_event_line() {
+  local log_file="$1"
+  local event="$2"
+  [ -f "$log_file" ] || return 0
+  awk -v event="$event" '
+    index($0, "\"event\": \"" event "\"") || index($0, "\"event\":\"" event "\"") {
+      line = $0
+    }
+    END {
+      if (line != "") {
+        print line
+      }
+    }
+  ' "$log_file" 2>/dev/null || true
+}
+
+conductor_log_string_field() {
+  local log_file="$1"
+  local event="$2"
+  local key="$3"
+  local line
+  line="$(conductor_log_event_line "$log_file" "$event")"
+  [ -n "$line" ] || return 0
+  printf '%s\n' "$line" \
+    | sed -nE 's/.*"'"$key"'"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/p' \
+    | head -1
+}
+
 # --------------------------------------------------------------------------
 # Peer review ([review.assist], v2.1) — second-opinion pass via Conductor.
 # --------------------------------------------------------------------------
@@ -2468,6 +2511,13 @@ print_route_log() {
 #
 # shellcheck disable=SC2120  # $1 is intentionally optional with a default.
 parse_primary_provider() {
+  local provider
+  provider="$(conductor_log_string_field "${REVIEW_CONDUCTOR_LOG_FILE:-}" provider_finished provider)"
+  if [ -n "$provider" ]; then
+    printf '%s' "$provider"
+    return
+  fi
+
   local stderr_file="${1:-$REVIEW_STDERR_FILE}"
   [ -f "$stderr_file" ] || {
     printf ''
@@ -2487,6 +2537,13 @@ parse_primary_provider() {
 }
 
 parse_primary_model() {
+  local model
+  model="$(conductor_log_string_field "${REVIEW_CONDUCTOR_LOG_FILE:-}" provider_finished model)"
+  if [ -n "$model" ]; then
+    printf '%s' "$model"
+    return
+  fi
+
   local stderr_file="${1:-$REVIEW_STDERR_FILE}"
   [ -f "$stderr_file" ] || {
     printf ''
@@ -2501,6 +2558,20 @@ parse_primary_model() {
   printf '%s' "$line" \
     | sed -nE 's/.*(model|model_id|model-id)[=:][[:space:]]*([a-zA-Z0-9_.:/@-]+).*/\2/p' \
     | head -1
+}
+
+parse_peer_provider() {
+  local provider
+  provider="$(conductor_log_string_field "${PEER_CONDUCTOR_LOG_FILE:-}" provider_finished provider)"
+  if [ -n "$provider" ]; then
+    printf '%s' "$provider"
+    return
+  fi
+  if [ "${ASSIST_ROUNDS_DONE:-0}" -gt 0 ]; then
+    printf 'unknown'
+  else
+    printf 'none'
+  fi
 }
 
 conductor_invocation_label() {
@@ -2548,10 +2619,12 @@ run_peer_review() {
 
   # Peer is single-turn (no tools). `conductor call` sees the primary's
   # findings + a framing prompt; the router picks a non-primary provider.
-  local peer_output
+  local peer_output peer_log_before peer_log_after
   # ASSIST_TIMEOUT config applies via the outer run_reviewer_with_timeout
   # wrapper when the primary timed out; peer call runs synchronously and
   # relies on conductor's own per-provider timeout (currently 300s default).
+  PEER_CONDUCTOR_LOG_FILE=""
+  peer_log_before="$(latest_conductor_session_log)"
   peer_output="$(printf '%s' "$peer_prompt" \
     | conductor call --auto \
       --exclude "$primary_provider" \
@@ -2559,6 +2632,10 @@ run_peer_review() {
       --effort medium \
       --silent-route \
       2>/dev/null || true)"
+  peer_log_after="$(latest_conductor_session_log)"
+  if [ -n "$peer_log_after" ] && [ "$peer_log_after" != "$peer_log_before" ]; then
+    PEER_CONDUCTOR_LOG_FILE="$peer_log_after"
+  fi
 
   if [ -z "$peer_output" ]; then
     phase "peer review produced no output (skipped)"
@@ -2637,7 +2714,8 @@ print_summary() {
   [ -n "$provider" ] || provider="${CONDUCTOR_WITH:-unknown}"
   model="$(parse_primary_model)"
   [ -n "$model" ] || model="unknown"
-  peer_provider="none"
+  peer_provider="$(parse_peer_provider)"
+  [ -n "$peer_provider" ] || peer_provider="none"
 
   printf "\n  ${C_DIM}─── review summary ────────────────────────${C_RESET}\n"
   printf "  ${C_DIM}reviewer:       %s${C_RESET}\n" "$REVIEWER_LABEL"

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -1518,7 +1518,7 @@ reviewer_label() {
 REVIEW_OUTPUT_FILE="$(mktemp "${TMPDIR:-/tmp}/touchstone-review-output.XXXXXX")"
 ASSIST_OUTPUT_FILE="$(mktemp "${TMPDIR:-/tmp}/touchstone-review-assist-output.XXXXXX")"
 REVIEW_STDERR_FILE="$(mktemp "${TMPDIR:-/tmp}/touchstone-review-stderr.XXXXXX")"
-REVIEW_CONDUCTOR_LOG_FILE="$(mktemp "${TMPDIR:-/tmp}/touchstone-review-conductor.XXXXXX.ndjson")"
+REVIEW_CONDUCTOR_LOG_FILE="$(mktemp "${TMPDIR:-/tmp}/touchstone-review-conductor.XXXXXX")"
 PEER_CONDUCTOR_LOG_FILE=""
 trap 'rm -f "$REVIEW_OUTPUT_FILE" "$ASSIST_OUTPUT_FILE" "$REVIEW_STDERR_FILE" "$REVIEW_CONDUCTOR_LOG_FILE"' EXIT
 

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -1346,6 +1346,9 @@ reviewer_conductor_exec() {
   if [ "$subcommand" = "exec" ]; then
     args+=(--tools "$tools")
     args+=(--timeout "${CODEX_REVIEW_TIMEOUT:-300}")
+    if [ -n "${REVIEW_CONDUCTOR_LOG_FILE:-}" ]; then
+      args+=(--log-file "$REVIEW_CONDUCTOR_LOG_FILE")
+    fi
   fi
 
   # Pass the prompt via stdin. Avoids argv length limits on large diffs and
@@ -1515,7 +1518,9 @@ reviewer_label() {
 REVIEW_OUTPUT_FILE="$(mktemp "${TMPDIR:-/tmp}/touchstone-review-output.XXXXXX")"
 ASSIST_OUTPUT_FILE="$(mktemp "${TMPDIR:-/tmp}/touchstone-review-assist-output.XXXXXX")"
 REVIEW_STDERR_FILE="$(mktemp "${TMPDIR:-/tmp}/touchstone-review-stderr.XXXXXX")"
-trap 'rm -f "$REVIEW_OUTPUT_FILE" "$ASSIST_OUTPUT_FILE" "$REVIEW_STDERR_FILE"' EXIT
+REVIEW_CONDUCTOR_LOG_FILE="$(mktemp "${TMPDIR:-/tmp}/touchstone-review-conductor.XXXXXX.ndjson")"
+PEER_CONDUCTOR_LOG_FILE=""
+trap 'rm -f "$REVIEW_OUTPUT_FILE" "$ASSIST_OUTPUT_FILE" "$REVIEW_STDERR_FILE" "$REVIEW_CONDUCTOR_LOG_FILE"' EXIT
 
 kill_process_tree() {
   local pid="$1"
@@ -1543,6 +1548,9 @@ run_reviewer_with_timeout() {
   # stderr, hence the historical /dev/null redirect; capturing instead is
   # safe because non-[conductor] lines are filtered before display.
   : >"$REVIEW_STDERR_FILE"
+  if [ "${ACTIVE_REVIEWER:-}" = "conductor" ] && [ -n "${REVIEW_CONDUCTOR_LOG_FILE:-}" ]; then
+    : >"$REVIEW_CONDUCTOR_LOG_FILE"
+  fi
 
   # No timeout: run directly
   if [ "$timeout_secs" -le 0 ] 2>/dev/null; then
@@ -2457,6 +2465,41 @@ print_route_log() {
   done
 }
 
+latest_conductor_session_log() {
+  local session_dir="${CONDUCTOR_SESSION_DIR:-${HOME:-}/.cache/conductor/sessions}"
+  [ -n "$session_dir" ] || return 0
+  [ -d "$session_dir" ] || return 0
+  ls -t "$session_dir"/*.ndjson 2>/dev/null | head -1
+}
+
+conductor_log_event_line() {
+  local log_file="$1"
+  local event="$2"
+  [ -f "$log_file" ] || return 0
+  awk -v event="$event" '
+    index($0, "\"event\": \"" event "\"") || index($0, "\"event\":\"" event "\"") {
+      line = $0
+    }
+    END {
+      if (line != "") {
+        print line
+      }
+    }
+  ' "$log_file" 2>/dev/null || true
+}
+
+conductor_log_string_field() {
+  local log_file="$1"
+  local event="$2"
+  local key="$3"
+  local line
+  line="$(conductor_log_event_line "$log_file" "$event")"
+  [ -n "$line" ] || return 0
+  printf '%s\n' "$line" \
+    | sed -nE 's/.*"'"$key"'"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/p' \
+    | head -1
+}
+
 # --------------------------------------------------------------------------
 # Peer review ([review.assist], v2.1) — second-opinion pass via Conductor.
 # --------------------------------------------------------------------------
@@ -2468,6 +2511,13 @@ print_route_log() {
 #
 # shellcheck disable=SC2120  # $1 is intentionally optional with a default.
 parse_primary_provider() {
+  local provider
+  provider="$(conductor_log_string_field "${REVIEW_CONDUCTOR_LOG_FILE:-}" provider_finished provider)"
+  if [ -n "$provider" ]; then
+    printf '%s' "$provider"
+    return
+  fi
+
   local stderr_file="${1:-$REVIEW_STDERR_FILE}"
   [ -f "$stderr_file" ] || {
     printf ''
@@ -2487,6 +2537,13 @@ parse_primary_provider() {
 }
 
 parse_primary_model() {
+  local model
+  model="$(conductor_log_string_field "${REVIEW_CONDUCTOR_LOG_FILE:-}" provider_finished model)"
+  if [ -n "$model" ]; then
+    printf '%s' "$model"
+    return
+  fi
+
   local stderr_file="${1:-$REVIEW_STDERR_FILE}"
   [ -f "$stderr_file" ] || {
     printf ''
@@ -2501,6 +2558,20 @@ parse_primary_model() {
   printf '%s' "$line" \
     | sed -nE 's/.*(model|model_id|model-id)[=:][[:space:]]*([a-zA-Z0-9_.:/@-]+).*/\2/p' \
     | head -1
+}
+
+parse_peer_provider() {
+  local provider
+  provider="$(conductor_log_string_field "${PEER_CONDUCTOR_LOG_FILE:-}" provider_finished provider)"
+  if [ -n "$provider" ]; then
+    printf '%s' "$provider"
+    return
+  fi
+  if [ "${ASSIST_ROUNDS_DONE:-0}" -gt 0 ]; then
+    printf 'unknown'
+  else
+    printf 'none'
+  fi
 }
 
 conductor_invocation_label() {
@@ -2548,10 +2619,12 @@ run_peer_review() {
 
   # Peer is single-turn (no tools). `conductor call` sees the primary's
   # findings + a framing prompt; the router picks a non-primary provider.
-  local peer_output
+  local peer_output peer_log_before peer_log_after
   # ASSIST_TIMEOUT config applies via the outer run_reviewer_with_timeout
   # wrapper when the primary timed out; peer call runs synchronously and
   # relies on conductor's own per-provider timeout (currently 300s default).
+  PEER_CONDUCTOR_LOG_FILE=""
+  peer_log_before="$(latest_conductor_session_log)"
   peer_output="$(printf '%s' "$peer_prompt" \
     | conductor call --auto \
       --exclude "$primary_provider" \
@@ -2559,6 +2632,10 @@ run_peer_review() {
       --effort medium \
       --silent-route \
       2>/dev/null || true)"
+  peer_log_after="$(latest_conductor_session_log)"
+  if [ -n "$peer_log_after" ] && [ "$peer_log_after" != "$peer_log_before" ]; then
+    PEER_CONDUCTOR_LOG_FILE="$peer_log_after"
+  fi
 
   if [ -z "$peer_output" ]; then
     phase "peer review produced no output (skipped)"
@@ -2637,7 +2714,8 @@ print_summary() {
   [ -n "$provider" ] || provider="${CONDUCTOR_WITH:-unknown}"
   model="$(parse_primary_model)"
   [ -n "$model" ] || model="unknown"
-  peer_provider="none"
+  peer_provider="$(parse_peer_provider)"
+  [ -n "$peer_provider" ] || peer_provider="none"
 
   printf "\n  ${C_DIM}─── review summary ────────────────────────${C_RESET}\n"
   printf "  ${C_DIM}reviewer:       %s${C_RESET}\n" "$REVIEWER_LABEL"

--- a/tests/test-review-hook.sh
+++ b/tests/test-review-hook.sh
@@ -44,6 +44,7 @@ unset PRE_COMMIT_REMOTE_NAME PRE_COMMIT_REMOTE_URL
 unset CODEX_REVIEW_FORCE CODEX_REVIEW_NO_AUTOFIX CODEX_REVIEW_DISABLE_CACHE
 unset CODEX_REVIEW_ASSIST CODEX_REVIEW_ASSIST_TIMEOUT CODEX_REVIEW_ASSIST_MAX_ROUNDS
 unset CODEX_REVIEW_IN_PROGRESS
+unset TOUCHSTONE_NO_PREFLIGHT TOUCHSTONE_NO_AUTO_UPDATE
 
 mkdir -p "$FAKE_BIN"
 setup_test_repo "$REPO_DIR"
@@ -1382,7 +1383,7 @@ printf 'peer-review test\n' >>"$CTX_REPO/example.txt"
 git -C "$CTX_REPO" add example.txt && git -C "$CTX_REPO" commit -m "peer review" >/dev/null 2>&1
 # Enable peer review in the project config.
 {
-  cat "$CTX_REPO/.codex-review.toml"
+  cat "$CTX_REPO/.codex-review.toml" 2>/dev/null || true
   printf '\n[review.assist]\nenabled = true\nmax_rounds = 1\n'
 } >"$CTX_REPO/.codex-review.toml.tmp" && mv "$CTX_REPO/.codex-review.toml.tmp" "$CTX_REPO/.codex-review.toml"
 git -C "$CTX_REPO" add .codex-review.toml && git -C "$CTX_REPO" commit -m "enable assist" >/dev/null 2>&1
@@ -1458,6 +1459,155 @@ if [ -f "$JSON_SUMMARY" ] \
 else
   echo "FAIL: expected JSON summary file" >&2
   cat "$JSON_SUMMARY" 2>/dev/null >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo "==> Test: JSON summary extracts provider/model from Conductor session log"
+setup_ctx_repo
+setup_ctx_bin
+cat >"$CTX_BIN/conductor" <<'CXEOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = "doctor" ]; then printf '{"providers":[{"configured":true}]}\n'; exit 0; fi
+log_file=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --log-file)
+      log_file="${2:-}"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+cat >/dev/null
+if [ -n "$log_file" ]; then
+  printf '{"event":"route_decision","data":{"provider":"gemini"}}\n' >"$log_file"
+  printf '{"event":"provider_finished","data":{"provider":"claude","model":"sonnet","duration_ms":1234,"session_id":"primary-fixture"}}\n' >>"$log_file"
+fi
+printf '[conductor] auto -> claude (tier: frontier)\n' >&2
+printf 'CODEX_REVIEW_CLEAN\n'
+CXEOF
+chmod +x "$CTX_BIN/conductor"
+JSON_SUMMARY="$TEST_DIR/review-summary-provider.json"
+rm -f "$JSON_SUMMARY"
+(
+  cd "$CTX_REPO"
+  PATH="$CTX_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    CODEX_REVIEW_SUMMARY_FILE="$JSON_SUMMARY" \
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$CTX_OUTPUT" 2>&1
+)
+
+if grep -q '"provider":"claude"' "$JSON_SUMMARY" \
+  && grep -q '"model":"sonnet"' "$JSON_SUMMARY" \
+  && grep -q '"peer_provider":"none"' "$JSON_SUMMARY"; then
+  echo "==> PASS: summary used structured Conductor provider/model"
+else
+  echo "FAIL: expected structured provider/model in JSON summary" >&2
+  cat "$JSON_SUMMARY" 2>/dev/null >&2
+  cat "$CTX_OUTPUT" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo "==> Test: missing Conductor session log keeps provider/model unknown"
+setup_ctx_repo
+setup_ctx_bin
+cat >"$CTX_BIN/conductor" <<'CXEOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = "doctor" ]; then printf '{"providers":[{"configured":true}]}\n'; exit 0; fi
+cat >/dev/null
+printf 'CODEX_REVIEW_CLEAN\n'
+CXEOF
+chmod +x "$CTX_BIN/conductor"
+JSON_SUMMARY="$TEST_DIR/review-summary-missing-log.json"
+rm -f "$JSON_SUMMARY"
+(
+  cd "$CTX_REPO"
+  PATH="$CTX_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    CODEX_REVIEW_SUMMARY_FILE="$JSON_SUMMARY" \
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$CTX_OUTPUT" 2>&1
+)
+
+if grep -q '"provider":"unknown"' "$JSON_SUMMARY" \
+  && grep -q '"model":"unknown"' "$JSON_SUMMARY" \
+  && grep -q '"peer_provider":"none"' "$JSON_SUMMARY"; then
+  echo "==> PASS: missing session log falls back without blocking"
+else
+  echo "FAIL: expected unknown provider/model fallback" >&2
+  cat "$JSON_SUMMARY" 2>/dev/null >&2
+  cat "$CTX_OUTPUT" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo "==> Test: peer review provider is extracted when peer session exists"
+setup_ctx_repo
+setup_ctx_bin
+cat >"$CTX_BIN/conductor" <<'CXEOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = "doctor" ]; then printf '{"providers":[{"configured":true}]}\n'; exit 0; fi
+subcmd="${1:-}"; shift || true
+log_file=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --log-file)
+      log_file="${2:-}"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+cat >/dev/null
+case "$subcmd" in
+  exec)
+    if [ -n "$log_file" ]; then
+      printf '{"event":"provider_finished","data":{"provider":"claude","model":"sonnet","duration_ms":1234,"session_id":"primary-fixture"}}\n' >"$log_file"
+    fi
+    printf '[conductor] auto -> claude (tier: frontier)\n' >&2
+    printf 'CODEX_REVIEW_CLEAN\n'
+    ;;
+  call)
+    session_dir="$HOME/.cache/conductor/sessions"
+    mkdir -p "$session_dir"
+    printf '{"event":"provider_finished","data":{"provider":"gemini","model":"gemini-2.5-pro","duration_ms":4321,"session_id":"peer-fixture"}}\n' >"$session_dir/peer-fixture.ndjson"
+    printf 'AGREE\n'
+    ;;
+esac
+CXEOF
+chmod +x "$CTX_BIN/conductor"
+{
+  cat "$CTX_REPO/.codex-review.toml" 2>/dev/null || true
+  printf '\n[review.assist]\nenabled = true\nmax_rounds = 1\n'
+} >"$CTX_REPO/.codex-review.toml.tmp" && mv "$CTX_REPO/.codex-review.toml.tmp" "$CTX_REPO/.codex-review.toml"
+git -C "$CTX_REPO" add .codex-review.toml && git -C "$CTX_REPO" commit -m "enable assist summary" >/dev/null 2>&1
+JSON_SUMMARY="$TEST_DIR/review-summary-peer.json"
+PEER_HOME="$TEST_DIR/peer-home"
+rm -rf "$PEER_HOME"
+mkdir -p "$PEER_HOME"
+rm -f "$JSON_SUMMARY"
+(
+  cd "$CTX_REPO"
+  HOME="$PEER_HOME" \
+    PATH="$CTX_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CODEX_REVIEW_BASE="HEAD~2" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    CODEX_REVIEW_SUMMARY_FILE="$JSON_SUMMARY" \
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$CTX_OUTPUT" 2>&1
+)
+
+if grep -q '"provider":"claude"' "$JSON_SUMMARY" \
+  && grep -q '"model":"sonnet"' "$JSON_SUMMARY" \
+  && grep -q '"peer_provider":"gemini"' "$JSON_SUMMARY"; then
+  echo "==> PASS: peer provider surfaced in summary"
+else
+  echo "FAIL: expected peer provider in JSON summary" >&2
+  cat "$JSON_SUMMARY" 2>/dev/null >&2
+  cat "$CTX_OUTPUT" >&2
   ERRORS=$((ERRORS + 1))
 fi
 


### PR DESCRIPTION
## Linked Issues

Closes #229

Lane M's commit 9c979c1 added a new tmpfile path
'touchstone-review-conductor.XXXXXX.ndjson' but BSD/macOS mktemp does
not expand XXXXXX when followed by additional template characters —
it creates a literal file with that exact name, so the second test
run fails with "File exists" on the same path.

Match the existing portable pattern at lines 1518-1520
(touchstone-review-output.XXXXXX, etc.) — XXXXXX at the end, no
suffix. The .ndjson convention is for human convenience; conductor
takes the path as a string and doesn't care about the extension.

Fixes test-codex-review-sentinel.sh failure: "missing sentinel should
block with provider and command diagnostics" was the symptom; the
mktemp-fails-on-stale-file was the cause.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
