### PR TITLE
--body

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ homebrew-touchstone/
 .cortex/.index.json
 .cortex/.index/
 .cortex/pending/
+.cortex/.last-cli-version


### PR DESCRIPTION
The cortex CLI writes .cortex/.last-cli-version into project worktrees
to track which version of the CLI last touched .cortex/ state, but does
not ship a .gitignore entry for it. Result: every project that uses
cortex ends up with an untracked file that breaks dirty-tree gates —
release helper, scripts/codex-review.sh, scripts/open-pr.sh, and
auto-sync all refuse to proceed until it's stashed or moved.

Hit during the v2.10.2 release: had to move the marker aside before
'touchstone release --patch' would run.

This is a workaround in touchstone (cortex CLI should ship its own
gitignore for this file). Filed upstream as autumngarage/cortex#<N>;
this entry can be removed once cortex manages it itself.

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
