### PR TITLE
fix(test): stop test-bootstrap leaking a real GitHub repo

### DIFF
--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -1705,8 +1705,11 @@ assert_contains "$TEST_DIR/wizard-yes.txt" '--no-github'
 
 # --yes with --with-cortex / --with-sentinel / --github-public must be reflected
 # in the equivalent-to-rerun printout even when the underlying tool isn't present.
+# PATH=/usr/bin:/bin hides gh/cortex/sentinel from the bootstrap so the
+# gh-repo-create branch self-skips — without it the test creates a real
+# public GitHub repo on whoever's authenticated account.
 PROJECT_WIZARD_YES_FLAGS="$TEST_DIR/test-project-wizard-yes-flags"
-bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_WIZARD_YES_FLAGS" --yes --no-register \
+PATH="/usr/bin:/bin" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_WIZARD_YES_FLAGS" --yes --no-register \
   --with-cortex --with-sentinel --github-public \
   >"$TEST_DIR/wizard-yes-flags.txt" 2>&1 || true
 assert_contains "$TEST_DIR/wizard-yes-flags.txt" '--with-cortex'


### PR DESCRIPTION
## Summary

- The `wizard-yes-flags` block in `tests/test-bootstrap.sh` ran `bootstrap/new-project.sh` with `--github-public`, which calls real `gh repo create` whenever `gh` is authenticated. Discovered in the wild as the orphan public repo `henrymodisett/test-project-wizard-yes-flags` created 2026-04-28.
- The block's own comment says "even when the underlying tool isn't present" — that's the case to test. Hide `gh` from PATH using the same `PATH=/usr/bin:/bin` pattern already used at line 1117. The flag-echo path the test asserts is independent of `gh` availability and still runs.
- Verified locally: `tests/test-bootstrap.sh` passes (`==> PASS: all assertions passed`); `gh repo view henrymodisett/test-project-wizard-yes-flags --json pushedAt` is unchanged after the run, confirming no re-leak.

## Test plan

- [x] `bash tests/test-bootstrap.sh` passes locally
- [x] Confirmed `gh repo view ...` `pushedAt` is unchanged after a local run (no new repo created)
- [ ] CI bootstrap suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)