### PR TITLE
feat(claim): deterministic claim-issue enforcement (script + CI check)

### DIFF
--- a/.github/workflows/issue-claim-check.yml
+++ b/.github/workflows/issue-claim-check.yml
@@ -1,0 +1,119 @@
+name: Issue claim check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  issues: read
+  pull-requests: write
+  contents: read
+
+jobs:
+  claim-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce claim-before-dispatch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          echo "==> Loading PR #$PR_NUMBER body"
+          PR_BODY="$(gh pr view "$PR_NUMBER" --json body --jq '.body // ""')"
+
+          if printf '%s' "$PR_BODY" | grep -Eqi '\[skip-claim-check\]'; then
+            echo "[skip-claim-check] token found in PR body; bypassing issue claim check."
+            exit 0
+          fi
+
+          issue_refs_file="$(mktemp)"
+          failures_file="$(mktemp)"
+          trap 'rm -f "$issue_refs_file" "$failures_file"' EXIT
+
+          # Pattern 1: same-repo numeric refs including closes-issue.
+          while IFS= read -r match; do
+            issue_number="$(printf '%s' "$match" | sed -E 's/.*#([0-9]+).*/\1/')"
+            if [ -n "$issue_number" ]; then
+              printf '%s\n' "$issue_number" >>"$issue_refs_file"
+            fi
+          done < <(printf '%s' "$PR_BODY" | grep -Eoi '\b(closes|fixes|resolves|closes-issue):?[[:space:]]*#[0-9]+\b' || true)
+
+          # Pattern 2: closes/fixes/resolves with optional owner/repo prefix.
+          while IFS= read -r match; do
+            normalized="$(printf '%s' "$match" | tr '[:upper:]' '[:lower:]')"
+            if printf '%s' "$normalized" | grep -Eq 'autumngarage/[a-z0-9_-]+#'; then
+              echo "==> Skipping cross-repo reference: $match"
+              continue
+            fi
+            issue_number="$(printf '%s' "$match" | sed -E 's/.*#([0-9]+).*/\1/')"
+            if [ -n "$issue_number" ]; then
+              printf '%s\n' "$issue_number" >>"$issue_refs_file"
+            fi
+          done < <(printf '%s' "$PR_BODY" | grep -Eoi '\b(closes|fixes|resolves):?[[:space:]]*(autumngarage/[[:alnum:]_-]+)?#[0-9]+\b' || true)
+
+          if [ ! -s "$issue_refs_file" ]; then
+            echo "No closing issue references found in PR body; nothing to enforce."
+            exit 0
+          fi
+
+          unique_issues="$(sort -u "$issue_refs_file")"
+          echo "==> Checking issue ownership for PR author @$PR_AUTHOR"
+
+          while IFS= read -r issue_number; do
+            [ -n "$issue_number" ] || continue
+            echo "==> Checking issue #$issue_number"
+
+            issue_state="$(gh issue view "$issue_number" --json state --jq '.state')"
+            if [ "$issue_state" = "CLOSED" ]; then
+              echo "    issue is closed; skipping"
+              continue
+            fi
+
+            assignees="$(gh issue view "$issue_number" --json assignees --jq '.assignees | map(.login) | join("\n")')"
+            if printf '%s\n' "$assignees" | grep -Fxq "$PR_AUTHOR"; then
+              echo "    pass: @$PR_AUTHOR is assigned"
+              continue
+            fi
+
+            assignee_label="(none)"
+            if [ -n "$assignees" ]; then
+              assignee_label="$(printf '%s' "$assignees" | paste -sd ', ' -)"
+            fi
+            printf '%s|%s\n' "$issue_number" "$assignee_label" >>"$failures_file"
+          done <<<"$unique_issues"
+
+          if [ ! -s "$failures_file" ]; then
+            echo "✓ All referenced issues are claimed by the PR author."
+            exit 0
+          fi
+
+          comment_file="$(mktemp)"
+          trap 'rm -f "$issue_refs_file" "$failures_file" "$comment_file"' EXIT
+          {
+            echo "❌ **Issue claim check failed**"
+            echo ""
+            echo "This PR references issue(s) with closing keywords, but the PR author (@$PR_AUTHOR) is not assigned to all open referenced issues:"
+            echo ""
+            while IFS='|' read -r issue_number assignees; do
+              [ -n "$issue_number" ] || continue
+              echo "- #$issue_number — current assignees: $assignees"
+            done <"$failures_file"
+            echo ""
+            echo "### Remediation"
+            echo "1. Claim each open referenced issue before dispatch:"
+            # shellcheck disable=SC2016  # backticks are intentional Markdown, not subshell.
+            echo '   - `bash scripts/claim-issue.sh <issue-number>`'
+            echo "2. Keep the closing keyword in this PR body once claimed, then push any update if needed."
+            echo ""
+            # shellcheck disable=SC2016  # backticks are intentional Markdown, not subshell.
+            echo 'If this is a legitimate exception (drive-by fix, emergency PR), add `[skip-claim-check]` to the PR body as a documented bypass.'
+          } >"$comment_file"
+
+          gh pr comment "$PR_NUMBER" --body-file "$comment_file"
+          echo "Issue claim check failed; remediation comment posted to PR #$PR_NUMBER."
+          exit 1

--- a/principles/git-workflow.md
+++ b/principles/git-workflow.md
@@ -152,6 +152,12 @@ Before spawning a coding agent — Claude Code subagent, Conductor `exec` worker
 **The mechanical steps.**
 
 ```bash
+bash scripts/claim-issue.sh <n>
+```
+
+Under the hood this uses the same GitHub API flow (claim + dispatch comment), equivalent to:
+
+```bash
 gh issue edit <n> --add-assignee @me
 gh issue comment <n> --body "Wave N Lane X dispatched. Branch \`<branch>\`, worktree at \`<path>\`. <agent type> implementing. PR will land via \`open-pr.sh --auto-merge\`."
 ```
@@ -180,6 +186,19 @@ If you decide not to ship — the work turns out to be wrong, the approach pivot
 **For multi-issue bundles.**
 
 When one lane closes multiple issues (e.g., Wave 1's Lane A bundling shfmt + markdownlint + actionlint into one branch), claim and comment on all of them with the same lane / branch reference. The dispatch comment becomes the per-issue audit thread; the bundling is visible from any of them.
+
+**Deterministic enforcement.**
+
+Two layers back the convention so a missed claim doesn't reach merge silently:
+
+- **`scripts/claim-issue.sh`** is the canonical claim path. It does the claim + dispatch comment in one step, and detects races (another assignee appeared between the API read and write — back off, exit non-zero so the dispatching agent knows not to spawn a worker). Use it instead of raw `gh issue edit` when an agent is about to start work.
+- **`.github/workflows/issue-claim-check.yml`** runs on every `pull_request` open/edit/synchronize. It parses `Closes #N` / `Fixes #N` / `Resolves #N` / `Closes-issue: #N` from the PR body, fetches each open referenced issue, and fails the check if the PR author is not in the issue's assignees. The failure posts a comment on the PR explaining what to fix.
+
+The CI check is the hard backstop: even if an agent skips the dispatch-time claim, a PR that tries to close an unclaimed issue fails its checks and won't auto-merge.
+
+**Bypass token: `[skip-claim-check]`.**
+
+For documented exemptions (drive-by typo fix, true emergency, sandbox PR you don't intend to merge), put the literal token `[skip-claim-check]` somewhere in the PR body. The CI check sees the token and skips with a workflow-run note, leaving an audit trail. Like other bypasses (`git push --no-verify`, `merge-pr.sh --bypass-with-disclosure`), this is a documented escape hatch — not a daily shortcut.
 
 ## Parallel work with worktrees
 

--- a/scripts/claim-issue.sh
+++ b/scripts/claim-issue.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+#
+# scripts/claim-issue.sh — deterministically claim an issue before dispatch.
+#
+# Usage:
+#   bash scripts/claim-issue.sh <issue-number> [<dispatch-comment>]
+#
+set -euo pipefail
+
+usage() {
+  echo "Usage: bash scripts/claim-issue.sh <issue-number> [<dispatch-comment>]" >&2
+}
+
+log() {
+  echo "==> $*" >&2
+}
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+  usage
+  exit 2
+fi
+
+ISSUE_NUMBER="$1"
+if ! [[ "$ISSUE_NUMBER" =~ ^[0-9]+$ ]]; then
+  usage
+  exit 2
+fi
+
+DISPATCH_COMMENT="${2-}"
+COMMENT_PROVIDED=0
+if [ "$#" -eq 2 ]; then
+  COMMENT_PROVIDED=1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: gh CLI is required." >&2
+  exit 2
+fi
+
+log "Checking gh authentication ..."
+if ! gh auth status >/dev/null 2>&1; then
+  echo "ERROR: gh is not authenticated. Run: gh auth login" >&2
+  exit 2
+fi
+
+if ! GH_LOGIN="$(gh api user --jq '.login' 2>/dev/null)" || [ -z "$GH_LOGIN" ]; then
+  echo "ERROR: failed to resolve GitHub login via gh api user." >&2
+  exit 2
+fi
+
+log "Inspecting issue #$ISSUE_NUMBER ..."
+if ! ISSUE_STATE="$(gh issue view "$ISSUE_NUMBER" --json state --jq '.state' 2>/dev/null)"; then
+  echo "ERROR: issue #$ISSUE_NUMBER not found." >&2
+  exit 2
+fi
+
+if [ "$ISSUE_STATE" = "CLOSED" ]; then
+  echo "ERROR: can't claim closed issue (#$ISSUE_NUMBER)." >&2
+  exit 1
+fi
+
+if ! PRE_ASSIGNEES="$(gh issue view "$ISSUE_NUMBER" --json assignees --jq '.assignees | map(.login) | join("\n")' 2>/dev/null)"; then
+  echo "ERROR: failed to read assignees for issue #$ISSUE_NUMBER." >&2
+  exit 2
+fi
+
+OTHER_ASSIGNEE=""
+ASSIGNEE_COUNT=0
+ME_ONLY=0
+if [ -n "$PRE_ASSIGNEES" ]; then
+  while IFS= read -r assignee; do
+    [ -n "$assignee" ] || continue
+    ASSIGNEE_COUNT=$((ASSIGNEE_COUNT + 1))
+    if [ "$assignee" != "$GH_LOGIN" ]; then
+      OTHER_ASSIGNEE="$assignee"
+      break
+    fi
+  done <<<"$PRE_ASSIGNEES"
+
+  if [ -n "$OTHER_ASSIGNEE" ]; then
+    echo "ERROR: already claimed by @$OTHER_ASSIGNEE." >&2
+    exit 1
+  fi
+
+  if [ "$ASSIGNEE_COUNT" -eq 1 ]; then
+    ME_ONLY=1
+  fi
+fi
+
+post_dispatch_comment() {
+  local body="$1"
+  log "Posting dispatch comment to issue #$ISSUE_NUMBER ..."
+  gh issue comment "$ISSUE_NUMBER" --body "$body" >/dev/null
+}
+
+if [ "$ME_ONLY" -eq 1 ]; then
+  log "Issue #$ISSUE_NUMBER is already assigned to @$GH_LOGIN (idempotent)."
+  if [ "$COMMENT_PROVIDED" -eq 1 ] && [ -n "$DISPATCH_COMMENT" ]; then
+    post_dispatch_comment "$DISPATCH_COMMENT"
+  fi
+  exit 0
+fi
+
+log "Claiming issue #$ISSUE_NUMBER as @$GH_LOGIN ..."
+gh issue edit "$ISSUE_NUMBER" --add-assignee @me >/dev/null
+
+if ! POST_ASSIGNEES="$(gh issue view "$ISSUE_NUMBER" --json assignees --jq '.assignees | map(.login) | join("\n")' 2>/dev/null)"; then
+  echo "ERROR: failed to re-read assignees after claiming issue #$ISSUE_NUMBER." >&2
+  exit 2
+fi
+
+RACE_ASSIGNEE=""
+I_AM_ASSIGNEE=0
+if [ -n "$POST_ASSIGNEES" ]; then
+  while IFS= read -r assignee; do
+    [ -n "$assignee" ] || continue
+    if [ "$assignee" = "$GH_LOGIN" ]; then
+      I_AM_ASSIGNEE=1
+      continue
+    fi
+    RACE_ASSIGNEE="$assignee"
+    break
+  done <<<"$POST_ASSIGNEES"
+fi
+
+if [ -n "$RACE_ASSIGNEE" ]; then
+  log "Race detected; removing @me from issue #$ISSUE_NUMBER ..."
+  gh issue edit "$ISSUE_NUMBER" --remove-assignee @me >/dev/null
+  echo "ERROR: race detected — @$RACE_ASSIGNEE claimed concurrently, backed off." >&2
+  exit 1
+fi
+
+if [ "$I_AM_ASSIGNEE" -ne 1 ]; then
+  echo "ERROR: claim did not stick; @$GH_LOGIN is not assigned after claim attempt." >&2
+  exit 1
+fi
+
+if [ "$COMMENT_PROVIDED" -eq 1 ]; then
+  COMMENT_BODY="$DISPATCH_COMMENT"
+else
+  CURRENT_BRANCH="$(git branch --show-current 2>/dev/null || true)"
+  if [ -z "$CURRENT_BRANCH" ]; then
+    CURRENT_BRANCH="(detached-head)"
+  fi
+  AGENT_LABEL="${TOUCHSTONE_AGENT_LABEL:-$(whoami)}"
+  COMMENT_BODY="Dispatched: branch \`$CURRENT_BRANCH\`, agent \`${AGENT_LABEL}\` claiming this issue. PR will land via \`scripts/open-pr.sh --auto-merge\`."
+fi
+
+if [ -n "$COMMENT_BODY" ]; then
+  post_dispatch_comment "$COMMENT_BODY"
+fi
+
+log "Issue #$ISSUE_NUMBER claimed successfully by @$GH_LOGIN."

--- a/tests/test-claim-issue.sh
+++ b/tests/test-claim-issue.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+#
+# tests/test-claim-issue.sh — deterministic unit tests for claim-issue.sh.
+#
+set -euo pipefail
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_DIR="$(mktemp -d -t touchstone-test-claim-issue.XXXXXX)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+FAKE_BIN="$TEST_DIR/bin"
+mkdir -p "$FAKE_BIN"
+
+cat >"$FAKE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GH_CALL_LOG:?}"
+
+echo "$*" >>"$GH_CALL_LOG"
+
+cmd1="${1:-}"
+cmd2="${2:-}"
+
+if [ "$cmd1" = "auth" ] && [ "$cmd2" = "status" ]; then
+  exit "${GH_AUTH_EXIT:-0}"
+fi
+
+if [ "$cmd1" = "api" ] && [ "$cmd2" = "user" ]; then
+  echo "${GH_USER_LOGIN:-me}"
+  exit 0
+fi
+
+if [ "$cmd1" = "issue" ] && [ "$cmd2" = "view" ]; then
+  if [ "${GH_ISSUE_EXISTS:-true}" != "true" ]; then
+    exit 1
+  fi
+  case "$*" in
+    *"--json state"*)
+      echo "${GH_ISSUE_STATE:-OPEN}"
+      exit 0
+      ;;
+    *"--json assignees"*)
+      count_file="${GH_ASSIGNEE_VIEW_COUNT_FILE:?}"
+      count=0
+      if [ -f "$count_file" ]; then
+        count="$(cat "$count_file")"
+      fi
+      count=$((count + 1))
+      printf '%s' "$count" >"$count_file"
+      if [ "$count" -eq 1 ]; then
+        printf '%s' "${GH_PRE_ASSIGNEES:-}"
+      else
+        printf '%s' "${GH_POST_ASSIGNEES:-${GH_PRE_ASSIGNEES:-}}"
+      fi
+      exit 0
+      ;;
+    *)
+      exit 1
+      ;;
+  esac
+fi
+
+if [ "$cmd1" = "issue" ] && [ "$cmd2" = "edit" ]; then
+  exit 0
+fi
+
+if [ "$cmd1" = "issue" ] && [ "$cmd2" = "comment" ]; then
+  body=""
+  prev=""
+  for arg in "$@"; do
+    if [ "$prev" = "--body" ]; then
+      body="$arg"
+      break
+    fi
+    prev="$arg"
+  done
+  printf '%s\n' "$body" >>"${GH_COMMENT_LOG:?}"
+  exit 0
+fi
+
+echo "unexpected gh invocation: $*" >&2
+exit 1
+EOF
+chmod +x "$FAKE_BIN/gh"
+
+ERRORS=0
+fail() {
+  echo "FAIL: $*" >&2
+  ERRORS=$((ERRORS + 1))
+}
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" != "$actual" ]; then
+    fail "$label: expected '$expected', got '$actual'"
+  fi
+}
+
+assert_file_contains() {
+  local file="$1" needle="$2"
+  if ! grep -qF "$needle" "$file"; then
+    fail "expected $file to contain '$needle'"
+  fi
+}
+
+assert_file_not_contains() {
+  local file="$1" needle="$2"
+  if grep -qF "$needle" "$file"; then
+    fail "expected $file to NOT contain '$needle'"
+  fi
+}
+
+run_claim_issue() {
+  local output_file="$1"
+  shift
+  PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    GH_CALL_LOG="$TEST_DIR/gh-calls.log" \
+    GH_COMMENT_LOG="$TEST_DIR/gh-comments.log" \
+    GH_ASSIGNEE_VIEW_COUNT_FILE="$TEST_DIR/gh-assignee-views.count" \
+    GH_AUTH_EXIT="${GH_AUTH_EXIT:-0}" \
+    GH_USER_LOGIN="${GH_USER_LOGIN:-me}" \
+    GH_ISSUE_EXISTS="${GH_ISSUE_EXISTS:-true}" \
+    GH_ISSUE_STATE="${GH_ISSUE_STATE:-OPEN}" \
+    GH_PRE_ASSIGNEES="${GH_PRE_ASSIGNEES:-}" \
+    GH_POST_ASSIGNEES="${GH_POST_ASSIGNEES:-}" \
+    bash "$TOUCHSTONE_ROOT/scripts/claim-issue.sh" "$@" >"$output_file" 2>&1
+}
+
+reset_case() {
+  rm -f "$TEST_DIR/gh-calls.log" "$TEST_DIR/gh-comments.log" "$TEST_DIR/gh-assignee-views.count"
+  GH_AUTH_EXIT=0
+  GH_USER_LOGIN=me
+  GH_ISSUE_EXISTS=true
+  GH_ISSUE_STATE=OPEN
+  GH_PRE_ASSIGNEES=
+  GH_POST_ASSIGNEES=
+}
+
+echo "==> Case 1: happy path (unassigned -> claim succeeds)"
+reset_case
+OUT="$TEST_DIR/case1.out"
+GH_PRE_ASSIGNEES=""
+GH_POST_ASSIGNEES="me"
+if run_claim_issue "$OUT" 101 "dispatch: case1"; then
+  assert_file_contains "$TEST_DIR/gh-calls.log" "issue edit 101 --add-assignee @me"
+  assert_file_contains "$TEST_DIR/gh-calls.log" "issue comment 101 --body dispatch: case1"
+else
+  fail "case 1 expected exit 0"
+  cat "$OUT" >&2
+fi
+
+echo "==> Case 2: already claimed by me (idempotent)"
+reset_case
+OUT="$TEST_DIR/case2.out"
+GH_PRE_ASSIGNEES="me"
+GH_POST_ASSIGNEES="me"
+if run_claim_issue "$OUT" 102 "dispatch: case2"; then
+  assert_file_not_contains "$TEST_DIR/gh-calls.log" "issue edit 102 --add-assignee @me"
+  assert_file_contains "$TEST_DIR/gh-calls.log" "issue comment 102 --body dispatch: case2"
+else
+  fail "case 2 expected exit 0"
+  cat "$OUT" >&2
+fi
+
+echo "==> Case 3: already claimed by other user"
+reset_case
+OUT="$TEST_DIR/case3.out"
+GH_PRE_ASSIGNEES="someoneelse"
+if run_claim_issue "$OUT" 103; then
+  fail "case 3 expected exit 1"
+else
+  rc=$?
+  assert_eq "case 3 rc" "1" "$rc"
+  assert_file_contains "$OUT" "already claimed by @someoneelse"
+  assert_file_not_contains "$TEST_DIR/gh-calls.log" "issue edit 103 --add-assignee @me"
+fi
+
+echo "==> Case 4: race detected after add-assignee"
+reset_case
+OUT="$TEST_DIR/case4.out"
+GH_PRE_ASSIGNEES=""
+GH_POST_ASSIGNEES=$'me\notheruser'
+if run_claim_issue "$OUT" 104; then
+  fail "case 4 expected exit 1"
+else
+  rc=$?
+  assert_eq "case 4 rc" "1" "$rc"
+  assert_file_contains "$TEST_DIR/gh-calls.log" "issue edit 104 --add-assignee @me"
+  assert_file_contains "$TEST_DIR/gh-calls.log" "issue edit 104 --remove-assignee @me"
+  assert_file_contains "$OUT" "race detected"
+fi
+
+echo "==> Case 5: closed issue"
+reset_case
+OUT="$TEST_DIR/case5.out"
+GH_ISSUE_STATE="CLOSED"
+if run_claim_issue "$OUT" 105; then
+  fail "case 5 expected exit 1"
+else
+  rc=$?
+  assert_eq "case 5 rc" "1" "$rc"
+  assert_file_contains "$OUT" "can't claim closed issue"
+fi
+
+echo "==> Case 6: missing args"
+reset_case
+OUT="$TEST_DIR/case6.out"
+if run_claim_issue "$OUT"; then
+  fail "case 6 expected exit 2"
+else
+  rc=$?
+  assert_eq "case 6 rc" "2" "$rc"
+  assert_file_contains "$OUT" "Usage:"
+fi
+
+echo "==> Case 7: gh not authenticated"
+reset_case
+OUT="$TEST_DIR/case7.out"
+GH_AUTH_EXIT=1
+if run_claim_issue "$OUT" 107; then
+  fail "case 7 expected exit 2"
+else
+  rc=$?
+  assert_eq "case 7 rc" "2" "$rc"
+  assert_file_contains "$OUT" "not authenticated"
+fi
+
+if [ "$ERRORS" -gt 0 ]; then
+  echo ""
+  echo "==> FAIL: $ERRORS case(s) failed"
+  exit 1
+fi
+
+echo ""
+echo "==> PASS: claim-issue.sh behaves correctly across 7 cases"


### PR DESCRIPTION
## Linked Issues

Closes #253

Adds two enforcement layers for the issue-claim-before-dispatch convention
already documented in principles/git-workflow.md:

- scripts/claim-issue.sh — pre-dispatch wrapper. Reads pre-state assignees,
  calls `gh issue edit --add-assignee @me`, re-reads post-state. If a
  competing assignee appears between read and write (sub-second race),
  removes @me and exits non-zero so the dispatching agent knows not to
  spawn a worker. Idempotent on re-run when @me is already the only
  assignee. Refuses on closed issues. Auto-generates a dispatch comment
  from the current branch + agent label when one isn't provided. Exit
  codes: 0 success, 1 already-claimed/race/closed, 2 usage/auth.

- .github/workflows/issue-claim-check.yml — PR-time hard backstop. On
  every pull_request open/edit/synchronize/reopen, parses Closes/Fixes/
  Resolves/Closes-issue references from the PR body, fetches each open
  referenced issue, and fails the check if the PR author is not in the
  assignees. Cross-repo refs (autumngarage/<repo>#N) are skipped — only
  same-repo numeric refs are validated. The failure posts a remediation
  comment on the PR. The token `[skip-claim-check]` in the PR body is the
  documented bypass for drive-by fixes / emergencies.

- tests/test-claim-issue.sh — covers 7 cases via a `gh` mock on PATH:
  happy path, idempotent re-claim, claimed-by-other refusal, race-after-
  add-assignee back-off, closed issue refusal, missing args, and gh-not-
  authenticated. Test is fully offline.

- principles/git-workflow.md — documents scripts/claim-issue.sh as the
  canonical claim path, names the CI check as the deterministic backstop,
  and documents the [skip-claim-check] bypass token alongside other
  documented escape hatches.

The CI workflow file added in this PR can't self-test (GitHub Actions
added in a PR don't trigger on that same PR until after merge). Manual
fail/bypass verification will be done with a follow-up draft PR after
this merges.

Closes #253

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
