### PR TITLE
chore(conductor): pick up cursor-rule version bump (v0.10.2 → v0.10.7)

### DIFF
--- a/.cursor/rules/conductor-delegation.mdc
+++ b/.cursor/rules/conductor-delegation.mdc
@@ -2,7 +2,7 @@
 description: Use when delegating or routing tasks to a different LLM via the conductor CLI — e.g., cheap second opinions, long-context reads, web search, or offline runs.
 globs: ""
 alwaysApply: false
-managed-by: conductor v0.10.2
+managed-by: conductor v0.10.7
 ---
 
 # Conductor delegation


### PR DESCRIPTION
## Linked Issues

Closes #251

Conductor's managed cursor rule auto-bumped its `managed-by:` frontmatter
from v0.10.2 to v0.10.7 during prior dogfood work. The body content is
otherwise unchanged. Committing the version bump so the working tree is
clean for the v2.11.0 release.

The conductor:begin/end blocks in CLAUDE.md/AGENTS.md/GEMINI.md/templates
still reference v0.10.2; those are conductor-managed and will be refreshed
on the next conductor managed-block sync (separate concern, not this PR).

Closes #251

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
