### PR TITLE
feat(cli): adopt update-all and structural doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ touchstone update
 # Commit the Touchstone update on your current task branch
 touchstone update --in-place
 
-# See all registered projects
-touchstone status
+# Update all registered projects
+touchstone update-all
 
 # Re-run dependency setup later without reinstalling hooks/tools
 bash setup.sh --deps-only
@@ -151,9 +151,10 @@ bash setup.sh --deps-only
 | `touchstone update --dry-run` | Preview what would change |
 | `touchstone update --check` | Report whether the current project needs an update |
 | `touchstone update --ship` | Push, open a PR, run the final AI review, and auto-merge when clean |
-| `touchstone sync` | Update all registered projects at once |
-| `touchstone sync --check` | Report which registered projects need sync |
-| `touchstone sync --pull-first` | Pull latest touchstone first, then sync all projects |
+| `touchstone update-all` | Update all registered projects at once |
+| `touchstone update-all --check` | Report which registered projects need update |
+| `touchstone update-all --pull-first` | Pull latest touchstone first, then update all projects |
+| `touchstone sync` | Deprecated alias for `touchstone update-all` |
 | `touchstone diff` | Compare core project-owned files against the latest templates |
 | `touchstone adr "Title"` | Create an Architecture Decision Record |
 | `touchstone adr list` | List project ADRs |
@@ -163,6 +164,7 @@ bash setup.sh --deps-only
 | `touchstone version` | Show installed version and install method |
 | `touchstone changelog [N]` | Show the last N GitHub releases |
 | `touchstone doctor` | Health check — version, tools, project staleness |
+| `touchstone review-stats` | Report conductor-review fail-open trends from the local review log |
 | `touchstone skills` | List Claude Code skills visible to the current repo and user |
 | `touchstone skills check` | Validate Claude Code skill frontmatter |
 | `touchstone release [--major\|--minor\|--patch]` | Cut a Touchstone release; maintainers only |
@@ -185,7 +187,7 @@ When you run `touchstone new`, these files get created in your project:
 - `.github/pull_request_template.md` — PR checklist
 - `setup.sh` — One-command setup for dev tools, hooks, and project dependencies
 
-**Touchstone-owned** (auto-updated when you run `touchstone update` or `touchstone sync`):
+**Touchstone-owned** (auto-updated when you run `touchstone update` or `touchstone update-all`):
 - `.touchstone-version` — The touchstone revision this project has applied
 - `.touchstone-manifest` — The visible list of touchstone-managed paths
 - `principles/*.md` — Universal engineering principles
@@ -202,17 +204,19 @@ When you run `touchstone new`, these files get created in your project:
 
 Touchstone enforces a test **runner**, not a test **suite**. The pre-push hook invokes `scripts/touchstone-run.sh validate`, which dispatches lint/typecheck/build/test per profile — but every profile silently skips when the underlying tool or test file is absent (correct runtime UX: a fresh scaffold shouldn't reject pushes just because the first test hasn't been written yet). Consequence: a repo with zero test files passes the gate.
 
-`touchstone doctor --project` is where those gaps become visible. It reports per-profile test presence, profile-specific linter availability (`ruff`, `swift-format`), pre-push hook integrity, and unknown profile values — in lock-step with the runner's dispatcher so doctor never claims more coverage than `validate` actually runs. Use `touchstone init --scaffold-tests` to seed a placeholder smoke test (Python, Node, and Go; Rust and Swift already get tests from `cargo init` / `swift package init`) and `touchstone init --ci github` to add a GitHub Actions workflow that runs the same `validate` path CI-side.
+`touchstone doctor` is where those gaps become visible. It reports per-profile test presence, profile-specific linter availability (`ruff`, `swift-format`), pre-push hook integrity, and unknown profile values — in lock-step with the runner's dispatcher so doctor never claims more coverage than `validate` actually runs. Use `touchstone init --scaffold-tests` to seed a placeholder smoke test (Python, Node, and Go; Rust and Swift already get tests from `cargo init` / `swift package init`) and `touchstone init --ci github` to add a GitHub Actions workflow that runs the same `validate` path CI-side.
 
 ### Keeping projects up to date
 
 When you improve Touchstone (add a principle, fix a script), run:
 
 ```bash
-touchstone sync
+touchstone update-all
 ```
 
 This updates touchstone-owned files across registered projects by creating reviewable update branches and commits. For one project, run `touchstone update --dry-run` to preview, `touchstone update --check` to check staleness, and `touchstone update` from a clean git worktree to create a `chore/touchstone-*` branch with the update committed. If a driving CLI already created a task branch, use `touchstone update --in-place` to commit the Touchstone update there. Project-owned files are never touched by `touchstone update`; use `touchstone diff` to review the core project-owned files against the latest templates.
+
+`touchstone sync` still works as a deprecated alias for `touchstone update-all`.
 
 Projects are auto-registered in `~/.touchstone-projects` when you bootstrap them.
 

--- a/bin/touchstone
+++ b/bin/touchstone
@@ -15,13 +15,15 @@
 #   touchstone update --dry-run           Show what would change without applying
 #   touchstone update --check             Report whether current project needs update
 #   touchstone update --ship              Push, open PR, review, and auto-merge
-#   touchstone sync                       Update all registered projects
-#   touchstone sync --pull-first          Pull latest touchstone, then sync all projects
+#   touchstone update-all                 Update all registered projects
+#   touchstone update-all --pull-first    Pull latest touchstone, then update all projects
+#   touchstone sync                       Deprecated alias for update-all
 #   touchstone status [--json]            Show status of the current project
 #   touchstone status --all               Show version distribution across registered projects
 #   touchstone version                    Show installed version
 #   touchstone --version                  Show installed version
-#   touchstone doctor                     Report conductor-review fail-open trends
+#   touchstone doctor                     Check project or installation health
+#   touchstone review-stats               Report conductor-review fail-open trends
 #   touchstone help                       Show this help
 #
 # Install:
@@ -271,6 +273,10 @@ cmd_update() {
   exec bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh" "$@"
 }
 
+cmd_update_all() {
+  exec bash "$TOUCHSTONE_ROOT/bootstrap/sync-all.sh" "$@"
+}
+
 cmd_migrate_from_toolkit() {
   exec bash "$TOUCHSTONE_ROOT/bootstrap/migrate-from-toolkit.sh" "$@"
 }
@@ -284,7 +290,8 @@ cmd_review() {
 }
 
 cmd_sync() {
-  exec bash "$TOUCHSTONE_ROOT/bootstrap/sync-all.sh" "$@"
+  echo "DEPRECATED: touchstone sync is deprecated; use touchstone update-all." >&2
+  cmd_update_all "$@"
 }
 
 cmd_run() {
@@ -564,7 +571,7 @@ cmd_status() {
 
 cmd_doctor_project() {
   local project_dir issues=0
-  project_dir="$(pwd)"
+  project_dir="$(touchstone_find_project_root 2>/dev/null || pwd)"
 
   tk_header "Touchstone Project Doctor — $(basename "$project_dir")"
 
@@ -679,19 +686,26 @@ cmd_doctor_project() {
     fi
   fi
 
-  # 5. Registered in ~/.touchstone-projects?  Informational — 'touchstone sync'
+  # 5. Registered in ~/.touchstone-projects?  Informational — 'touchstone update-all'
   # and 'touchstone list' depend on it, but the repo is still functionally gated.
   local projects_file="$HOME/.touchstone-projects"
   if [ -f "$projects_file" ] && grep -qxF "$project_dir" "$projects_file" 2>/dev/null; then
     tk_ok "registered in ~/.touchstone-projects"
   else
-    tk_dim "not in ~/.touchstone-projects (touchstone sync won't update this project)"
+    tk_dim "not in ~/.touchstone-projects (touchstone update-all won't update this project)"
     tk_dim "  Fix: echo \"$project_dir\" >> $projects_file"
   fi
 
   # 6. Optional — Codex review config present?
   if [ -f "$project_dir/.codex-review.toml" ]; then
     tk_ok ".codex-review.toml present"
+    if grep -qE '^[[:space:]]*reviewers[[:space:]]*=[[:space:]]*\[' "$project_dir/.codex-review.toml" \
+       || grep -qE '^\[review\.(local|assist)\]' "$project_dir/.codex-review.toml" \
+       || grep -qE '^[[:space:]]*(small|large)_reviewers[[:space:]]*=[[:space:]]*\[' "$project_dir/.codex-review.toml"; then
+      tk_warn ".codex-review.toml uses legacy 1.x review schema"
+      tk_dim "  Fix: touchstone migrate-review-config"
+      issues=$((issues + 1))
+    fi
   else
     tk_dim ".codex-review.toml not found (optional — configures AI review)"
   fi
@@ -1094,14 +1108,17 @@ cmd_doctor() {
   local required_capability=""
 
   if [ "$#" -eq 0 ]; then
-    touchstone_doctor_review_log
-    return $?
+    if touchstone_find_project_root >/dev/null 2>&1 || [ -f "$(pwd)/.touchstone-version" ] || [ -f "$(pwd)/.toolkit-version" ]; then
+      project_mode=true
+    else
+      installation_mode=true
+    fi
   fi
 
   case "${1:-}" in
     --log-path|--threshold)
-      touchstone_doctor_review_log "$@"
-      return $?
+      echo "ERROR: review metrics moved to: touchstone review-stats" >&2
+      return 2
       ;;
   esac
 
@@ -1126,17 +1143,17 @@ cmd_doctor() {
     esac
   done
 
+  if [ "$project_mode" = true ] && [ "$installation_mode" = true ]; then
+    echo "ERROR: use only one of --project or --installation" >&2
+    return 2
+  fi
+
   if [ "$project_mode" = true ]; then
     if [ -n "$required_capability" ]; then
-      status_require_project_capability "$(pwd)" "$required_capability"
+      status_require_project_capability "$(touchstone_find_project_root 2>/dev/null || pwd)" "$required_capability"
       return $?
     fi
     cmd_doctor_project
-    return $?
-  fi
-
-  if [ "$installation_mode" != true ]; then
-    touchstone_doctor_review_log
     return $?
   fi
 
@@ -1210,7 +1227,7 @@ cmd_doctor() {
         if [ "$(_status_behind_count "$proj_version" "$current_id")" = "current" ]; then
           tk_ok "$name — up to date"
         else
-          tk_warn "$name — needs sync (run: touchstone sync)"
+          tk_warn "$name — needs update (run: touchstone update-all)"
           issues=$((issues + 1))
         fi
       else
@@ -1242,10 +1259,17 @@ cmd_doctor() {
   echo ""
   if [ "$issues" -eq 0 ]; then
     tk_ok "All good."
+    echo ""
+    return 0
   else
     tk_warn "$issues issue(s) found."
+    echo ""
+    return 1
   fi
-  echo ""
+}
+
+cmd_review_stats() {
+  touchstone_doctor_review_log "$@"
 }
 
 cmd_list() {
@@ -1271,7 +1295,7 @@ cmd_list() {
       if [ "$(_status_behind_count "$proj_version" "$current_id")" = "current" ]; then
         tk_ok "$name  ${DIM}$project_dir${RESET}"
       else
-        tk_warn "$name  ${DIM}$project_dir${RESET}  ${YELLOW}(needs sync)${RESET}"
+        tk_warn "$name  ${DIM}$project_dir${RESET}  ${YELLOW}(needs update)${RESET}"
       fi
     else
       tk_fail "$name  ${DIM}$project_dir${RESET}  ${RED}(not found)${RESET}"
@@ -1619,9 +1643,10 @@ cmd_help() {
   printf "    ${BOLD}touchstone migrate-from-toolkit${RESET}   One-shot rename of legacy .toolkit-* files (pre-1.0.0 projects)\n"
   printf "    ${BOLD}touchstone migrate-review-config${RESET}  Rewrite .codex-review.toml from 1.x → 2.0 shape (silences migration warnings on push)\n"
   printf "    ${BOLD}touchstone review --dry-run${RESET}      Preview which provider would review the next push, no tokens spent\n"
-  printf "    ${BOLD}touchstone sync${RESET}                   Update all registered projects\n"
-  printf "    ${BOLD}touchstone sync${RESET} --check           Report which projects need sync\n"
-  printf "    ${BOLD}touchstone sync${RESET} --pull-first      Pull latest touchstone first\n"
+  printf "    ${BOLD}touchstone update-all${RESET}             Update all registered projects\n"
+  printf "    ${BOLD}touchstone update-all${RESET} --check     Report which projects need update\n"
+  printf "    ${BOLD}touchstone update-all${RESET} --pull-first Pull latest touchstone first\n"
+  printf "    ${BOLD}touchstone sync${RESET}                   Deprecated alias for update-all\n"
   printf "    ${BOLD}touchstone diff${RESET}                   Compare project files vs templates\n"
   printf "    ${BOLD}touchstone adr${RESET} \"Title\"            Create an Architecture Decision Record\n"
   printf "    ${BOLD}touchstone adr${RESET} list               List all ADRs\n"
@@ -1633,9 +1658,10 @@ cmd_help() {
   printf "    ${BOLD}touchstone status${RESET} --all           Version distribution across registered projects\n"
   echo ""
   echo "  ${BOLD}Touchstone commands:${RESET}"
-  printf "    ${BOLD}touchstone doctor${RESET}                 Report conductor-review fail-open trends\n"
+  printf "    ${BOLD}touchstone doctor${RESET}                 Check project or installation health\n"
   printf "    ${BOLD}touchstone doctor${RESET} --project       Check per-project health (hooks, manifest, registry)\n"
   printf "    ${BOLD}touchstone doctor${RESET} --installation  Check installation health\n"
+  printf "    ${BOLD}touchstone review-stats${RESET}           Report conductor-review fail-open trends\n"
   printf "    ${BOLD}touchstone version${RESET}                Show installed version\n"
   printf "    ${BOLD}touchstone changelog${RESET} [N]          Show last N releases (default 10)\n"
   printf "    ${BOLD}touchstone skills${RESET}                 List Claude Code skills\n"
@@ -1676,6 +1702,7 @@ case "$COMMAND" in
   worker)      cmd_worker "$@" ;;
   detect)       cmd_detect ;;
   update)       cmd_update "$@" ;;
+  update-all)   cmd_update_all "$@" ;;
   migrate-from-toolkit) cmd_migrate_from_toolkit "$@" ;;
   migrate-review-config) cmd_migrate_review_config "$@" ;;
   review)       cmd_review "$@" ;;
@@ -1690,6 +1717,7 @@ case "$COMMAND" in
   release)      cmd_release "$@" ;;
   version|--version) cmd_version ;;
   doctor)       cmd_doctor "$@" ;;
+  review-stats) cmd_review_stats "$@" ;;
   help|-h|--help) cmd_help ;;
   *)
     printf "${RED}Unknown command: $COMMAND${RESET}\n" >&2

--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -16,7 +16,7 @@
 #   2. Copies templates, principles, hooks, and scripts into the project
 #   3. Makes scripts executable
 #   4. Writes .touchstone-version and .touchstone-manifest
-#   5. Registers the project in ~/.touchstone-projects (for sync-all.sh)
+#   5. Registers the project in ~/.touchstone-projects (for update-all)
 #   6. Prints next steps
 #
 # After running, fill in the {{PLACEHOLDERS}} in CLAUDE.md, AGENTS.md, and GEMINI.md.
@@ -1397,7 +1397,7 @@ echo "$TOUCHSTONE_SHA" >"$PROJECT_DIR/.touchstone-version"
 echo ""
 echo "==> Wrote .touchstone-version: $TOUCHSTONE_SHA"
 
-# Register in ~/.touchstone-projects for sync-all.sh.
+# Register in ~/.touchstone-projects for update-all.
 # The write is a silent side effect by default (opt-in stays default for
 # script-compat), so surface every registry outcome with an "==> " line:
 # the path we wrote to, the fact that we were already registered, or the
@@ -1575,7 +1575,7 @@ if [ "$WIZARD_INTERACTIVE" = true ]; then
   # 5. Register in ~/.touchstone-projects.
   if [ "$REGISTER_REQUESTED" = false ]; then
     echo ""
-    if [ "$(prompt_yes_no "Register for touchstone sync (~/.touchstone-projects)?" "true")" = "true" ]; then
+    if [ "$(prompt_yes_no "Register for touchstone update-all (~/.touchstone-projects)?" "true")" = "true" ]; then
       REGISTER=true
     else
       REGISTER=false

--- a/bootstrap/sync-all.sh
+++ b/bootstrap/sync-all.sh
@@ -3,16 +3,16 @@
 # bootstrap/sync-all.sh — update all registered projects to the latest touchstone.
 #
 # Usage:
-#   ~/Repos/touchstone/bootstrap/sync-all.sh              # update all projects
-#   ~/Repos/touchstone/bootstrap/sync-all.sh --dry-run     # show what would change
-#   ~/Repos/touchstone/bootstrap/sync-all.sh --pull-first  # git pull touchstone before syncing
+#   touchstone update-all              # update all projects
+#   touchstone update-all --dry-run    # show what would change
+#   touchstone update-all --pull-first # git pull touchstone before updating projects
 #
 # Reads project paths from ~/.touchstone-projects (one path per line, populated
 # by new-project.sh). Runs update-project.sh in each one.
 #
-# For fully automated sync, add to cron:
+# For fully automated updates, add to cron:
 #   crontab -e
-#   0 9 * * 1  cd ~/Repos/touchstone && git pull && ~/Repos/touchstone/bootstrap/sync-all.sh
+#   0 9 * * 1  touchstone update-all --pull-first
 #
 set -euo pipefail
 
@@ -61,7 +61,7 @@ if [ "$PULL_FIRST" = true ]; then
   echo ""
 fi
 
-# Check-only mode: report which projects need sync, then exit.
+# Check-only mode: report which projects need update, then exit.
 if [ "$CHECK_ONLY" = true ]; then
   CURRENT_ID="$(
     if [ -d "$TOUCHSTONE_ROOT/.git" ]; then
@@ -84,7 +84,7 @@ if [ "$CHECK_ONLY" = true ]; then
     if [ "$proj_id" = "$CURRENT_ID" ]; then
       echo "  ✓ $(basename "$project_dir") — up to date"
     else
-      echo "  ! $(basename "$project_dir") — needs sync"
+      echo "  ! $(basename "$project_dir") — needs update"
       BEHIND=$((BEHIND + 1))
     fi
   done <"$PROJECTS_FILE"
@@ -92,7 +92,7 @@ if [ "$CHECK_ONLY" = true ]; then
   if [ "$BEHIND" -eq 0 ]; then
     echo "All $TOTAL projects are up to date."
   else
-    echo "$BEHIND/$TOTAL projects need sync. Run: touchstone sync"
+    echo "$BEHIND/$TOTAL projects need update. Run: touchstone update-all"
   fi
   exit 0
 fi
@@ -117,7 +117,7 @@ while IFS= read -r project_dir; do
 
   echo ""
   echo "================================================================"
-  echo "==> Syncing: $project_dir"
+  echo "==> Updating: $project_dir"
   echo "================================================================"
 
   if (cd "$project_dir" && bash "$UPDATE_SCRIPT" $DRY_RUN); then
@@ -130,7 +130,7 @@ done <"$PROJECTS_FILE"
 
 echo ""
 echo "================================================================"
-echo "==> Sync complete: $SUCCESS/$TOTAL succeeded, $SKIPPED skipped, $FAILED failed"
+echo "==> Update-all complete: $SUCCESS/$TOTAL succeeded, $SKIPPED skipped, $FAILED failed"
 echo "================================================================"
 
 if [ "$FAILED" -gt 0 ]; then

--- a/bootstrap/update-project.sh
+++ b/bootstrap/update-project.sh
@@ -147,7 +147,7 @@ if [ "$OLD_SHA" = "$CURRENT_SHA" ] && [ "$NEEDS_CODEX_REVIEW_MIGRATION" = true ]
 fi
 
 if [ "$CHECK_ONLY" = true ]; then
-  echo "==> Needs sync."
+  echo "==> Needs update."
   echo "    Run: touchstone update"
   exit 0
 fi

--- a/completions/touchstone.bash
+++ b/completions/touchstone.bash
@@ -3,7 +3,7 @@ _touchstone() {
   COMPREPLY=()
   cur="${COMP_WORDS[COMP_CWORD]}"
   prev="${COMP_WORDS[COMP_CWORD-1]}"
-  commands="init new update sync status doctor version list unregister diff adr release preflight help"
+  commands="init new update update-all sync status doctor review-stats version list unregister diff adr release preflight help"
 
   case "$prev" in
     touchstone)
@@ -15,14 +15,17 @@ _touchstone() {
     update)
       COMPREPLY=( $(compgen -W "--dry-run --check --branch" -- "$cur") )
       ;;
-    sync)
+    update-all|sync)
       COMPREPLY=( $(compgen -W "--pull-first --check --dry-run" -- "$cur") )
       ;;
     status)
       COMPREPLY=( $(compgen -W "--all" -- "$cur") )
       ;;
     doctor)
-      COMPREPLY=( $(compgen -W "--log-path --threshold --project --installation" -- "$cur") )
+      COMPREPLY=( $(compgen -W "--project --installation --require-capability" -- "$cur") )
+      ;;
+    review-stats)
+      COMPREPLY=( $(compgen -W "--log-path --threshold" -- "$cur") )
       ;;
     unregister)
       if [ -f "$HOME/.touchstone-projects" ]; then

--- a/completions/touchstone.zsh
+++ b/completions/touchstone.zsh
@@ -6,9 +6,11 @@ _touchstone() {
     'init:Add touchstone to the current project'
     'new:Bootstrap a new project from scratch'
     'update:Create a branch and commit for touchstone updates'
-    'sync:Update all registered projects'
+    'update-all:Update all registered projects'
+    'sync:Deprecated alias for update-all'
     'status:Show project status (use --all for the registry view)'
-    'doctor:Report conductor-review fail-open trends'
+    'doctor:Check project or installation health'
+    'review-stats:Report conductor-review fail-open trends'
     'preflight:Run deterministic review preflight checks'
     'version:Show installed version'
     'list:Show registered projects'
@@ -69,10 +71,10 @@ _touchstone() {
             '--no-ship[Do not run the shipping flow]' \
             '--branch[Use a specific update branch]:branch name:'
           ;;
-        sync)
+        update-all|sync)
           _arguments \
-            '--pull-first[Pull latest touchstone before syncing]' \
-            '--check[Report which projects need sync]' \
+            '--pull-first[Pull latest touchstone before updating projects]' \
+            '--check[Report which projects need update]' \
             '--dry-run[Preview updates without applying]'
           ;;
         status)
@@ -81,10 +83,14 @@ _touchstone() {
           ;;
         doctor)
           _arguments \
-            '--log-path[Read a fixture or alternate review log]:log path:_files' \
-            '--threshold[Warn when last-7d fail-open rate exceeds this percent]:percent:' \
             '--project[Check per-project health]' \
+            '--require-capability[Require a project-local workflow capability]:capability:' \
             '--installation[Check touchstone installation health]'
+          ;;
+        review-stats)
+          _arguments \
+            '--log-path[Read a fixture or alternate review log]:log path:_files' \
+            '--threshold[Warn when last-7d fail-open rate exceeds this percent]:percent:'
           ;;
         unregister)
           # Complete from registered projects.

--- a/lib/auto-update.sh
+++ b/lib/auto-update.sh
@@ -121,7 +121,7 @@ touchstone_auto_project_sync_command_skips() {
   local command="${1:-}" subcommand="${2:-}"
 
   case "$command" in
-    "" | help | -h | --help | version | --version | status | list | ls | diff | changelog | doctor | detect | skills | update | sync | new | init | migrate-from-toolkit | migrate-review-config | release)
+    "" | help | -h | --help | version | --version | status | list | ls | diff | changelog | doctor | review-stats | detect | skills | update | update-all | sync | new | init | migrate-from-toolkit | migrate-review-config | release)
       return 0
       ;;
   esac

--- a/lib/touchstone-doctor.sh
+++ b/lib/touchstone-doctor.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# lib/touchstone-doctor.sh — review-log health reporting for `touchstone doctor`.
+# lib/touchstone-doctor.sh — review-log reporting for `touchstone review-stats`.
 #
 # Exit-code contract:
 #   0  report completed and the 7-day fail-open rate is within threshold
@@ -22,18 +22,29 @@ TOUCHSTONE_DOCTOR_FAIL_OPEN_CODES="FAIL_OPEN_TIMEOUT FAIL_OPEN_PARSE_ERROR FAIL_
 
 touchstone_doctor_usage() {
   cat <<'EOF'
-Usage: touchstone doctor [--log-path <path>] [--threshold <percent>]
-       touchstone doctor --project
+Usage: touchstone doctor [--project|--installation]
        touchstone doctor --require-capability <name>
-       touchstone doctor --installation
 
-  (no flag)             Report conductor-review fail-open trends from ~/.touchstone-review-log
-  --log-path <path>     Read a fixture or alternate review log (also: TOUCHSTONE_REVIEW_LOG)
-  --threshold <percent> Warn when the last-7d fail-open rate exceeds this value (default 25)
+  (no flag)             Check the current Touchstone project, or installation health outside a project
   --project             Check per-project health (hooks, manifest, registry)
   --require-capability <name>
                         Require a project-local Touchstone workflow capability
   --installation        Check touchstone installation health (CLI, tools, projects)
+
+Exit codes:
+  0  structural checks passed
+  1  broken or incomplete state
+  2  invalid arguments
+EOF
+}
+
+touchstone_review_stats_usage() {
+  cat <<'EOF'
+Usage: touchstone review-stats [--log-path <path>] [--threshold <percent>]
+
+  (no flag)             Report conductor-review fail-open trends from ~/.touchstone-review-log
+  --log-path <path>     Read a fixture or alternate review log (also: TOUCHSTONE_REVIEW_LOG)
+  --threshold <percent> Warn when the last-7d fail-open rate exceeds this value (default 25)
 
 Exit codes:
   0  report completed and no fail-open warning fired
@@ -64,20 +75,20 @@ touchstone_doctor_review_log() {
         threshold="$2"
         shift 2
         ;;
-      -h|--help)
-        touchstone_doctor_usage
+      -h | --help)
+        touchstone_review_stats_usage
         return 0
         ;;
       *)
-        echo "ERROR: unknown doctor argument '$1'" >&2
-        touchstone_doctor_usage >&2
+        echo "ERROR: unknown review-stats argument '$1'" >&2
+        touchstone_review_stats_usage >&2
         return 1
         ;;
     esac
   done
 
   case "$threshold" in
-    ''|*[!0-9]*)
+    '' | *[!0-9]*)
       echo "ERROR: --threshold must be an integer percentage (got '$threshold')" >&2
       return 1
       ;;
@@ -146,7 +157,7 @@ touchstone_doctor_parse_epoch() {
 
 touchstone_doctor_is_fail_open_code() {
   case "$1" in
-    FAIL_OPEN_TIMEOUT|FAIL_OPEN_PARSE_ERROR|FAIL_OPEN_DEPENDENCY_MISSING|FAIL_OPEN_PROVIDER_UNAVAILABLE|FAIL_OPEN_REVIEWER_ERROR)
+    FAIL_OPEN_TIMEOUT | FAIL_OPEN_PARSE_ERROR | FAIL_OPEN_DEPENDENCY_MISSING | FAIL_OPEN_PROVIDER_UNAVAILABLE | FAIL_OPEN_REVIEWER_ERROR)
       return 0
       ;;
     *)
@@ -208,7 +219,7 @@ EOF
       [ "$epoch" -ge "$cutoff_7" ] && total_7=$((total_7 + 1))
       [ "$epoch" -ge "$cutoff_30" ] && total_30=$((total_30 + 1))
     fi
-  done < "$log_path"
+  done <"$log_path"
 
   {
     if touchstone_doctor_rate_exceeds "$fail_7" "$total_7" "$threshold"; then
@@ -221,7 +232,7 @@ EOF
       "$total_7" "$fail_7" "$total_30" "$fail_30" \
       "$recent_timestamp" "$recent_code" "$recent_repo" "$recent_branch" "$recent_sha" "$recent_detail" \
       "$malformed"
-  } > "$report_file"
+  } >"$report_file"
 }
 
 touchstone_doctor_rate_exceeds() {

--- a/setup.sh
+++ b/setup.sh
@@ -5,7 +5,7 @@
 # Run this after cloning the repo:
 #   bash setup.sh
 #
-# Installs all dev tools, syncs touchstone files, sets up hooks, and installs
+# Installs all dev tools, checks touchstone files, sets up hooks, and installs
 # project dependencies. Idempotent — safe to re-run anytime.
 #
 set -euo pipefail
@@ -17,21 +17,27 @@ YELLOW='\033[0;33m'
 BOLD='\033[1m'
 RESET='\033[0m'
 
-info()  { printf "${BOLD}==> %s${RESET}\n" "$*"; }
-ok()    { printf "  ${GREEN}✓${RESET} %s\n" "$*"; }
-warn()  { printf "  ${YELLOW}!${RESET} %s\n" "$*"; }
-fail()  { printf "  ${RED}✗${RESET} %s\n" "$*"; }
+info() { printf "${BOLD}==> %s${RESET}\n" "$*"; }
+ok() { printf "  ${GREEN}✓${RESET} %s\n" "$*"; }
+warn() { printf "  ${YELLOW}!${RESET} %s\n" "$*"; }
+fail() { printf "  ${RED}✗${RESET} %s\n" "$*"; }
 
 DEPS_ONLY=false
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    --deps-only) DEPS_ONLY=true; shift ;;
-    -h|--help)
+    --deps-only)
+      DEPS_ONLY=true
+      shift
+      ;;
+    -h | --help)
       echo "Usage: bash setup.sh [--deps-only]"
       exit 0
       ;;
-    *) fail "Unknown argument: $1"; exit 1 ;;
+    *)
+      fail "Unknown argument: $1"
+      exit 1
+      ;;
   esac
 done
 
@@ -42,253 +48,255 @@ echo ""
 
 if [ "$DEPS_ONLY" = false ]; then
 
-# --------------------------------------------------------------------------
-# 1. Homebrew (required foundation)
-# --------------------------------------------------------------------------
-info "Checking Homebrew"
-if command -v brew >/dev/null 2>&1; then
-  ok "brew installed"
-else
-  fail "Homebrew is required. Install from https://brew.sh"
-  exit 1
-fi
-
-# --------------------------------------------------------------------------
-# 2. Touchstone CLI
-# --------------------------------------------------------------------------
-info "Checking touchstone"
-if command -v touchstone >/dev/null 2>&1; then
-  TOUCHSTONE_VERSION_SUMMARY="$(touchstone version 2>&1 | awk 'NF && !seen { sub(/^touchstone /, ""); print; seen = 1 }')"
-  ok "touchstone ${TOUCHSTONE_VERSION_SUMMARY:-installed}"
-else
-  warn "Installing touchstone..."
-  brew tap autumngarage/touchstone 2>/dev/null || true
-  brew install touchstone
-  ok "touchstone installed"
-fi
-
-# --------------------------------------------------------------------------
-# 3. Dev tools (brew)
-# --------------------------------------------------------------------------
-info "Checking dev tools"
-
-brew_install_if_missing() {
-  local cmd="$1"
-  local formula="${2:-$1}"
-  if command -v "$cmd" >/dev/null 2>&1; then
-    ok "$cmd installed"
+  # --------------------------------------------------------------------------
+  # 1. Homebrew (required foundation)
+  # --------------------------------------------------------------------------
+  info "Checking Homebrew"
+  if command -v brew >/dev/null 2>&1; then
+    ok "brew installed"
   else
-    warn "Installing $formula..."
-    brew install "$formula" 2>/dev/null
-    ok "$cmd installed"
+    fail "Homebrew is required. Install from https://brew.sh"
+    exit 1
   fi
-}
 
-brew_install_if_missing "git"        "git"
-brew_install_if_missing "gh"         "gh"
-brew_install_if_missing "pre-commit" "pre-commit"
-brew_install_if_missing "gitleaks"   "gitleaks"
-brew_install_if_missing "shellcheck" "shellcheck"
-brew_install_if_missing "shfmt"      "shfmt"
+  # --------------------------------------------------------------------------
+  # 2. Touchstone CLI
+  # --------------------------------------------------------------------------
+  info "Checking touchstone"
+  if command -v touchstone >/dev/null 2>&1; then
+    TOUCHSTONE_VERSION_SUMMARY="$(touchstone version 2>&1 | awk 'NF && !seen { sub(/^touchstone /, ""); print; seen = 1 }')"
+    ok "touchstone ${TOUCHSTONE_VERSION_SUMMARY:-installed}"
+  else
+    warn "Installing touchstone..."
+    brew tap autumngarage/touchstone 2>/dev/null || true
+    brew install touchstone
+    ok "touchstone installed"
+  fi
 
-# --------------------------------------------------------------------------
-# 4. AI reviewer CLI (optional)
-# --------------------------------------------------------------------------
-info "Checking AI reviewer"
+  # --------------------------------------------------------------------------
+  # 3. Dev tools (brew)
+  # --------------------------------------------------------------------------
+  info "Checking dev tools"
 
-AI_REVIEW_ENABLED=true
-AI_REVIEWERS=()
-AI_LOCAL_REVIEW_COMMAND=""
-AI_CONDUCTOR_WITH=""
-
-trim_review_value() {
-  local value="$1"
-  value="${value#"${value%%[![:space:]]*}"}"
-  value="${value%"${value##*[![:space:]]}"}"
-  value="${value%,}"
-  value="${value#\"}"; value="${value%\"}"
-  value="${value#\'}"; value="${value%\'}"
-  printf '%s' "$value"
-}
-
-add_reviewers_from_csv() {
-  local csv="$1" item
-  local -a items=()
-  csv="$(trim_review_value "$csv")"
-  csv="${csv#\[}"
-  csv="${csv%\]}"
-  IFS=',' read -r -a items <<< "$csv"
-  for item in "${items[@]}"; do
-    item="$(trim_review_value "$item")"
-    [ -n "$item" ] && AI_REVIEWERS+=("$item")
-  done
-}
-
-load_ai_review_config() {
-  local section="" line key value
-
-  [ -f ".codex-review.toml" ] || {
-    AI_REVIEWERS=("conductor")
-    return 0
+  brew_install_if_missing() {
+    local cmd="$1"
+    local formula="${2:-$1}"
+    if command -v "$cmd" >/dev/null 2>&1; then
+      ok "$cmd installed"
+    else
+      warn "Installing $formula..."
+      brew install "$formula" 2>/dev/null
+      ok "$cmd installed"
+    fi
   }
 
-  while IFS= read -r line || [ -n "$line" ]; do
-    line="${line%%#*}"
-    line="$(trim_review_value "$line")"
-    [ -z "$line" ] && continue
+  brew_install_if_missing "git" "git"
+  brew_install_if_missing "gh" "gh"
+  brew_install_if_missing "pre-commit" "pre-commit"
+  brew_install_if_missing "gitleaks" "gitleaks"
+  brew_install_if_missing "shellcheck" "shellcheck"
+  brew_install_if_missing "shfmt" "shfmt"
 
-    case "$line" in
-      \[*\])
-        section="${line#\[}"
-        section="${section%\]}"
-        continue
-        ;;
-    esac
+  # --------------------------------------------------------------------------
+  # 4. AI reviewer CLI (optional)
+  # --------------------------------------------------------------------------
+  info "Checking AI reviewer"
 
-    case "$line" in *=*) ;; *) continue ;; esac
-    key="$(trim_review_value "${line%%=*}")"
-    value="$(trim_review_value "${line#*=}")"
+  AI_REVIEW_ENABLED=true
+  AI_REVIEWERS=()
+  AI_LOCAL_REVIEW_COMMAND=""
+  AI_CONDUCTOR_WITH=""
 
-    if [ "$section" = "review" ]; then
-      case "$key" in
-        enabled) AI_REVIEW_ENABLED="$value" ;;
-        reviewer) [ -n "$value" ] && AI_REVIEWERS+=("$value") ;;
-        reviewers) add_reviewers_from_csv "${line#*=}" ;;
+  trim_review_value() {
+    local value="$1"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    value="${value%,}"
+    value="${value#\"}"
+    value="${value%\"}"
+    value="${value#\'}"
+    value="${value%\'}"
+    printf '%s' "$value"
+  }
+
+  add_reviewers_from_csv() {
+    local csv="$1" item
+    local -a items=()
+    csv="$(trim_review_value "$csv")"
+    csv="${csv#\[}"
+    csv="${csv%\]}"
+    IFS=',' read -r -a items <<<"$csv"
+    for item in "${items[@]}"; do
+      item="$(trim_review_value "$item")"
+      [ -n "$item" ] && AI_REVIEWERS+=("$item")
+    done
+  }
+
+  load_ai_review_config() {
+    local section="" line key value
+
+    [ -f ".codex-review.toml" ] || {
+      AI_REVIEWERS=("conductor")
+      return 0
+    }
+
+    while IFS= read -r line || [ -n "$line" ]; do
+      line="${line%%#*}"
+      line="$(trim_review_value "$line")"
+      [ -z "$line" ] && continue
+
+      case "$line" in
+        \[*\])
+          section="${line#\[}"
+          section="${section%\]}"
+          continue
+          ;;
       esac
-    elif [ "$section" = "review.conductor" ]; then
-      case "$key" in
-        with) AI_CONDUCTOR_WITH="$value" ;;
-      esac
-    elif [ "$section" = "review.local" ]; then
-      case "$key" in
-        command) AI_LOCAL_REVIEW_COMMAND="$value" ;;
-      esac
+
+      case "$line" in *=*) ;; *) continue ;; esac
+      key="$(trim_review_value "${line%%=*}")"
+      value="$(trim_review_value "${line#*=}")"
+
+      if [ "$section" = "review" ]; then
+        case "$key" in
+          enabled) AI_REVIEW_ENABLED="$value" ;;
+          reviewer) [ -n "$value" ] && AI_REVIEWERS+=("$value") ;;
+          reviewers) add_reviewers_from_csv "${line#*=}" ;;
+        esac
+      elif [ "$section" = "review.conductor" ]; then
+        case "$key" in
+          with) AI_CONDUCTOR_WITH="$value" ;;
+        esac
+      elif [ "$section" = "review.local" ]; then
+        case "$key" in
+          command) AI_LOCAL_REVIEW_COMMAND="$value" ;;
+        esac
+      fi
+    done <".codex-review.toml"
+
+    if [ "${#AI_REVIEWERS[@]}" -eq 0 ] && [ "$AI_REVIEW_ENABLED" != "false" ]; then
+      AI_REVIEWERS=("conductor")
     fi
-  done < ".codex-review.toml"
+  }
 
-  if [ "${#AI_REVIEWERS[@]}" -eq 0 ] && [ "$AI_REVIEW_ENABLED" != "false" ]; then
-    AI_REVIEWERS=("conductor")
-  fi
-}
+  check_ai_reviewer() {
+    local reviewer="$1"
 
-check_ai_reviewer() {
-  local reviewer="$1"
-
-  case "$reviewer" in
-    conductor)
-      if command -v conductor >/dev/null 2>&1; then
-        if conductor doctor --json 2>/dev/null | grep -q '"configured"[[:space:]]*:[[:space:]]*true'; then
-          if [ -n "$AI_CONDUCTOR_WITH" ]; then
-            ok "conductor installed and configured (pinned provider: $AI_CONDUCTOR_WITH)"
+    case "$reviewer" in
+      conductor)
+        if command -v conductor >/dev/null 2>&1; then
+          if conductor doctor --json 2>/dev/null | grep -q '"configured"[[:space:]]*:[[:space:]]*true'; then
+            if [ -n "$AI_CONDUCTOR_WITH" ]; then
+              ok "conductor installed and configured (pinned provider: $AI_CONDUCTOR_WITH)"
+            else
+              ok "conductor installed and configured"
+            fi
           else
-            ok "conductor installed and configured"
+            warn "conductor installed but no provider is configured. Run: conductor init"
           fi
         else
-          warn "conductor installed but no provider is configured. Run: conductor init"
+          warn "conductor reviewer selected, but Conductor CLI is not installed. Run: brew install autumngarage/conductor/conductor && conductor init"
         fi
-      else
-        warn "conductor reviewer selected, but Conductor CLI is not installed. Run: brew install autumngarage/conductor/conductor && conductor init"
-      fi
-      ;;
-    codex)
-      if command -v codex >/dev/null 2>&1; then
-        if codex login status >/dev/null 2>&1; then
-          ok "codex installed and authenticated"
+        ;;
+      codex)
+        if command -v codex >/dev/null 2>&1; then
+          if codex login status >/dev/null 2>&1; then
+            ok "codex installed and authenticated"
+          else
+            warn "codex installed but not logged in. Run: codex login"
+          fi
+        elif command -v npm >/dev/null 2>&1; then
+          warn "Installing Codex CLI..."
+          npm install -g @openai/codex 2>/dev/null && ok "codex installed — run: codex login" || warn "codex install failed. Manual install: npm install -g @openai/codex"
         else
-          warn "codex installed but not logged in. Run: codex login"
+          warn "codex not installed. Install Node.js/npm first, then: npm install -g @openai/codex && codex login"
         fi
-      elif command -v npm >/dev/null 2>&1; then
-        warn "Installing Codex CLI..."
-        npm install -g @openai/codex 2>/dev/null && ok "codex installed — run: codex login" || warn "codex install failed. Manual install: npm install -g @openai/codex"
-      else
-        warn "codex not installed. Install Node.js/npm first, then: npm install -g @openai/codex && codex login"
-      fi
-      ;;
-    claude)
-      if command -v claude >/dev/null 2>&1; then
-        if claude auth status >/dev/null 2>&1; then
-          ok "claude installed and authenticated"
+        ;;
+      claude)
+        if command -v claude >/dev/null 2>&1; then
+          if claude auth status >/dev/null 2>&1; then
+            ok "claude installed and authenticated"
+          else
+            warn "claude installed but auth check failed. Authenticate Claude before relying on review."
+          fi
         else
-          warn "claude installed but auth check failed. Authenticate Claude before relying on review."
+          warn "claude reviewer selected, but Claude CLI is not installed."
         fi
-      else
-        warn "claude reviewer selected, but Claude CLI is not installed."
-      fi
-      ;;
-    gemini)
-      if command -v gemini >/dev/null 2>&1; then
-        if [ -n "${GEMINI_API_KEY:-}" ] || { command -v gcloud >/dev/null 2>&1 && gcloud auth print-access-token >/dev/null 2>&1; }; then
-          ok "gemini installed and authenticated"
+        ;;
+      gemini)
+        if command -v gemini >/dev/null 2>&1; then
+          if [ -n "${GEMINI_API_KEY:-}" ] || { command -v gcloud >/dev/null 2>&1 && gcloud auth print-access-token >/dev/null 2>&1; }; then
+            ok "gemini installed and authenticated"
+          else
+            warn "gemini installed but auth is not configured. Set GEMINI_API_KEY or authenticate gcloud."
+          fi
         else
-          warn "gemini installed but auth is not configured. Set GEMINI_API_KEY or authenticate gcloud."
+          warn "gemini reviewer selected, but Gemini CLI is not installed."
         fi
-      else
-        warn "gemini reviewer selected, but Gemini CLI is not installed."
-      fi
-      ;;
-    local)
-      if [ -n "$AI_LOCAL_REVIEW_COMMAND" ]; then
-        ok "local reviewer configured: $AI_LOCAL_REVIEW_COMMAND"
-      else
-        warn "local reviewer selected, but [review.local].command is empty in .codex-review.toml"
-      fi
-      ;;
-    *)
-      warn "unknown AI reviewer '$reviewer' in .codex-review.toml"
-      ;;
-  esac
-}
+        ;;
+      local)
+        if [ -n "$AI_LOCAL_REVIEW_COMMAND" ]; then
+          ok "local reviewer configured: $AI_LOCAL_REVIEW_COMMAND"
+        else
+          warn "local reviewer selected, but [review.local].command is empty in .codex-review.toml"
+        fi
+        ;;
+      *)
+        warn "unknown AI reviewer '$reviewer' in .codex-review.toml"
+        ;;
+    esac
+  }
 
-load_ai_review_config
-if [ "$AI_REVIEW_ENABLED" = "false" ]; then
-  ok "AI review disabled in .codex-review.toml"
-else
-  for reviewer in "${AI_REVIEWERS[@]}"; do
-    check_ai_reviewer "$reviewer"
-  done
-fi
+  load_ai_review_config
+  if [ "$AI_REVIEW_ENABLED" = "false" ]; then
+    ok "AI review disabled in .codex-review.toml"
+  else
+    for reviewer in "${AI_REVIEWERS[@]}"; do
+      check_ai_reviewer "$reviewer"
+    done
+  fi
 
-# --------------------------------------------------------------------------
-# 5. Sync touchstone files to latest
-# --------------------------------------------------------------------------
-info "Syncing touchstone files"
-# Skip update if this IS the Touchstone repo (it's the source, not a downstream project).
-if [ -f "bin/touchstone" ] && [ -f "lib/auto-update.sh" ]; then
-  ok "this is the Touchstone repo — skipping self-update"
-elif [ -f ".touchstone-version" ]; then
-  touchstone update --check 2>&1 | grep -E "Already|Needs sync|Run: touchstone update" | head -5 | while read -r line; do
-    ok "$line"
-  done
-  ok "touchstone sync status checked"
-else
-  warn "No .touchstone-version found — this project hasn't been bootstrapped."
-  warn "Run: touchstone new $(pwd)"
-fi
+  # --------------------------------------------------------------------------
+  # 5. Sync touchstone files to latest
+  # --------------------------------------------------------------------------
+  info "Checking touchstone files"
+  # Skip update if this IS the Touchstone repo (it's the source, not a downstream project).
+  if [ -f "bin/touchstone" ] && [ -f "lib/auto-update.sh" ]; then
+    ok "this is the Touchstone repo — skipping self-update"
+  elif [ -f ".touchstone-version" ]; then
+    touchstone update --check 2>&1 | grep -E "Already|Needs update|Run: touchstone update" | head -5 | while read -r line; do
+      ok "$line"
+    done
+    ok "touchstone update status checked"
+  else
+    warn "No .touchstone-version found — this project hasn't been bootstrapped."
+    warn "Run: touchstone new $(pwd)"
+  fi
 
-# --------------------------------------------------------------------------
-# 6. Pre-commit hooks
-# --------------------------------------------------------------------------
-info "Setting up git hooks"
-if [ -f ".pre-commit-config.yaml" ]; then
-  # Clear core.hooksPath if set — it conflicts with pre-commit.
-  git config --unset-all core.hooksPath 2>/dev/null || true
-  # Install hook shims (environments install lazily on first run).
-  pre-commit install 2>&1 | tail -1 | while read -r line; do ok "$line"; done
-  pre-commit install --hook-type pre-push 2>&1 | tail -1 | while read -r line; do ok "$line"; done
-  ok "pre-commit hooks installed (pre-commit, pre-push)"
-else
-  warn "No .pre-commit-config.yaml found — skipping hooks"
-fi
+  # --------------------------------------------------------------------------
+  # 6. Pre-commit hooks
+  # --------------------------------------------------------------------------
+  info "Setting up git hooks"
+  if [ -f ".pre-commit-config.yaml" ]; then
+    # Clear core.hooksPath if set — it conflicts with pre-commit.
+    git config --unset-all core.hooksPath 2>/dev/null || true
+    # Install hook shims (environments install lazily on first run).
+    pre-commit install 2>&1 | tail -1 | while read -r line; do ok "$line"; done
+    pre-commit install --hook-type pre-push 2>&1 | tail -1 | while read -r line; do ok "$line"; done
+    ok "pre-commit hooks installed (pre-commit, pre-push)"
+  else
+    warn "No .pre-commit-config.yaml found — skipping hooks"
+  fi
 
-# --------------------------------------------------------------------------
-# 7. gh CLI auth check
-# --------------------------------------------------------------------------
-info "Checking GitHub auth"
-if gh auth status 2>&1 | grep -q "Logged in"; then
-  ok "gh authenticated"
-else
-  warn "gh not authenticated. Run: gh auth login"
-fi
+  # --------------------------------------------------------------------------
+  # 7. gh CLI auth check
+  # --------------------------------------------------------------------------
+  info "Checking GitHub auth"
+  if gh auth status 2>&1 | grep -q "Logged in"; then
+    ok "gh authenticated"
+  else
+    warn "gh not authenticated. Run: gh auth login"
+  fi
 
 fi
 

--- a/templates/setup.sh
+++ b/templates/setup.sh
@@ -19,10 +19,10 @@ RESET='\033[0m'
 
 YES_MODE="${YES_MODE:-false}"
 
-info()  { printf "${BOLD}==> %s${RESET}\n" "$*"; }
-ok()    { printf "  ${GREEN}✓${RESET} %s\n" "$*"; }
-warn()  { printf "  ${YELLOW}!${RESET} %s\n" "$*"; }
-fail()  { printf "  ${RED}✗${RESET} %s\n" "$*"; }
+info() { printf "${BOLD}==> %s${RESET}\n" "$*"; }
+ok() { printf "  ${GREEN}✓${RESET} %s\n" "$*"; }
+warn() { printf "  ${YELLOW}!${RESET} %s\n" "$*"; }
+fail() { printf "  ${RED}✗${RESET} %s\n" "$*"; }
 
 DEPS_ONLY=false
 GIT_WORKFLOW="git"
@@ -34,9 +34,15 @@ fi
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    --deps-only) DEPS_ONLY=true; shift ;;
-    --skip-devtools) SKIP_DEVTOOLS=true; shift ;;
-    -h|--help)
+    --deps-only)
+      DEPS_ONLY=true
+      shift
+      ;;
+    --skip-devtools)
+      SKIP_DEVTOOLS=true
+      shift
+      ;;
+    -h | --help)
       echo "Usage: bash setup.sh [--deps-only] [--skip-devtools]"
       echo ""
       echo "  --deps-only       Reinstall project deps (also refreshes per-profile dev tools)"
@@ -44,7 +50,10 @@ while [ "$#" -gt 0 ]; do
       echo "                    Also honored via TOUCHSTONE_SKIP_DEVTOOLS=1"
       exit 0
       ;;
-    *) fail "Unknown argument: $1"; exit 1 ;;
+    *)
+      fail "Unknown argument: $1"
+      exit 1
+      ;;
   esac
 done
 
@@ -53,14 +62,16 @@ trim_config_value() {
   value="${value#"${value%%[![:space:]]*}"}"
   value="${value%"${value##*[![:space:]]}"}"
   value="${value%,}"
-  value="${value#\"}"; value="${value%\"}"
-  value="${value#\'}"; value="${value%\'}"
+  value="${value#\"}"
+  value="${value%\"}"
+  value="${value#\'}"
+  value="${value%\'}"
   printf '%s' "$value"
 }
 
 truthy() {
   case "$(printf '%s' "${1:-false}" | tr '[:upper:]' '[:lower:]')" in
-    true|1|yes|on) return 0 ;;
+    true | 1 | yes | on) return 0 ;;
     *) return 1 ;;
   esac
 }
@@ -87,7 +98,7 @@ prompt_yes_no() {
   fi
 
   case "$(printf '%s' "$answer" | tr '[:upper:]' '[:lower:]')" in
-    y|yes|true|1|on) return 0 ;;
+    y | yes | true | 1 | on) return 0 ;;
     *) return 1 ;;
   esac
 }
@@ -110,7 +121,7 @@ load_touchstone_config() {
       git_workflow) GIT_WORKFLOW="$value" ;;
       gitbutler_mcp) GITBUTLER_MCP="$value" ;;
     esac
-  done < ".touchstone-config"
+  done <".touchstone-config"
 }
 
 PROJECT_NAME="$(basename "$(pwd)")"
@@ -119,353 +130,355 @@ printf "${BOLD}Setting up ${PROJECT_NAME}${RESET}\n"
 echo ""
 
 if [ "$DEPS_ONLY" = false ]; then
-load_touchstone_config
+  load_touchstone_config
 
-# --------------------------------------------------------------------------
-# 1. Homebrew (required foundation)
-# --------------------------------------------------------------------------
-info "Checking Homebrew"
-if command -v brew >/dev/null 2>&1; then
-  ok "brew installed"
-else
-  fail "Homebrew is required. Install from https://brew.sh"
-  exit 1
-fi
-
-# --------------------------------------------------------------------------
-# 2. Touchstone CLI
-# --------------------------------------------------------------------------
-info "Checking touchstone"
-if command -v touchstone >/dev/null 2>&1; then
-  TOUCHSTONE_VERSION_SUMMARY="$(touchstone version 2>&1 | awk 'NF && !seen { sub(/^touchstone /, ""); print; seen = 1 }')"
-  ok "touchstone ${TOUCHSTONE_VERSION_SUMMARY:-installed}"
-else
-  warn "Installing touchstone..."
-  brew tap autumngarage/touchstone 2>/dev/null || true
-  brew install touchstone
-  ok "touchstone installed"
-fi
-
-# --------------------------------------------------------------------------
-# 3. Dev tools (brew)
-# --------------------------------------------------------------------------
-info "Checking dev tools"
-
-brew_install_if_missing() {
-  local cmd="$1"
-  local formula="${2:-$1}"
-  if command -v "$cmd" >/dev/null 2>&1; then
-    ok "$cmd installed"
+  # --------------------------------------------------------------------------
+  # 1. Homebrew (required foundation)
+  # --------------------------------------------------------------------------
+  info "Checking Homebrew"
+  if command -v brew >/dev/null 2>&1; then
+    ok "brew installed"
   else
-    warn "Installing $formula..."
-    brew install "$formula" 2>/dev/null
-    ok "$cmd installed"
+    fail "Homebrew is required. Install from https://brew.sh"
+    exit 1
   fi
-}
 
-brew_install_if_missing "git"        "git"
-brew_install_if_missing "gh"         "gh"
-brew_install_if_missing "pre-commit" "pre-commit"
-brew_install_if_missing "gitleaks"   "gitleaks"
-brew_install_if_missing "shellcheck" "shellcheck"
-brew_install_if_missing "shfmt"      "shfmt"
+  # --------------------------------------------------------------------------
+  # 2. Touchstone CLI
+  # --------------------------------------------------------------------------
+  info "Checking touchstone"
+  if command -v touchstone >/dev/null 2>&1; then
+    TOUCHSTONE_VERSION_SUMMARY="$(touchstone version 2>&1 | awk 'NF && !seen { sub(/^touchstone /, ""); print; seen = 1 }')"
+    ok "touchstone ${TOUCHSTONE_VERSION_SUMMARY:-installed}"
+  else
+    warn "Installing touchstone..."
+    brew tap autumngarage/touchstone 2>/dev/null || true
+    brew install touchstone
+    ok "touchstone installed"
+  fi
 
-# --------------------------------------------------------------------------
-# 4. AI reviewer CLI (optional)
-# --------------------------------------------------------------------------
-info "Checking AI reviewer"
+  # --------------------------------------------------------------------------
+  # 3. Dev tools (brew)
+  # --------------------------------------------------------------------------
+  info "Checking dev tools"
 
-AI_REVIEW_ENABLED=true
-AI_REVIEWERS=()
-AI_REVIEWERS_CHECKED=""
-AI_LOCAL_REVIEW_COMMAND=""
-AI_CONDUCTOR_WITH=""
-AI_REVIEW_ROUTING_ENABLED=false
-AI_REVIEW_ROUTING_SMALL_MAX=400
-
-trim_review_value() {
-  local value="$1"
-  value="${value#"${value%%[![:space:]]*}"}"
-  value="${value%"${value##*[![:space:]]}"}"
-  value="${value%,}"
-  value="${value#\"}"; value="${value%\"}"
-  value="${value#\'}"; value="${value%\'}"
-  printf '%s' "$value"
-}
-
-add_reviewers_from_csv() {
-  local csv="$1" item
-  local -a items=()
-  csv="$(trim_review_value "$csv")"
-  csv="${csv#\[}"
-  csv="${csv%\]}"
-  IFS=',' read -r -a items <<< "$csv"
-  for item in "${items[@]}"; do
-    item="$(trim_review_value "$item")"
-    [ -n "$item" ] && AI_REVIEWERS+=("$item")
-  done
-}
-
-load_ai_review_config() {
-  local section="" line key value
-
-  [ -f ".codex-review.toml" ] || {
-    AI_REVIEWERS=("conductor")
-    return 0
+  brew_install_if_missing() {
+    local cmd="$1"
+    local formula="${2:-$1}"
+    if command -v "$cmd" >/dev/null 2>&1; then
+      ok "$cmd installed"
+    else
+      warn "Installing $formula..."
+      brew install "$formula" 2>/dev/null
+      ok "$cmd installed"
+    fi
   }
 
-  while IFS= read -r line || [ -n "$line" ]; do
-    line="${line%%#*}"
-    line="$(trim_review_value "$line")"
-    [ -z "$line" ] && continue
+  brew_install_if_missing "git" "git"
+  brew_install_if_missing "gh" "gh"
+  brew_install_if_missing "pre-commit" "pre-commit"
+  brew_install_if_missing "gitleaks" "gitleaks"
+  brew_install_if_missing "shellcheck" "shellcheck"
+  brew_install_if_missing "shfmt" "shfmt"
 
-    case "$line" in
-      \[*\])
-        section="${line#\[}"
-        section="${section%\]}"
-        continue
-        ;;
-    esac
+  # --------------------------------------------------------------------------
+  # 4. AI reviewer CLI (optional)
+  # --------------------------------------------------------------------------
+  info "Checking AI reviewer"
 
-    case "$line" in *=*) ;; *) continue ;; esac
-    key="$(trim_review_value "${line%%=*}")"
-    value="$(trim_review_value "${line#*=}")"
+  AI_REVIEW_ENABLED=true
+  AI_REVIEWERS=()
+  AI_REVIEWERS_CHECKED=""
+  AI_LOCAL_REVIEW_COMMAND=""
+  AI_CONDUCTOR_WITH=""
+  AI_REVIEW_ROUTING_ENABLED=false
+  AI_REVIEW_ROUTING_SMALL_MAX=400
 
-    if [ "$section" = "review" ]; then
-      case "$key" in
-        enabled) AI_REVIEW_ENABLED="$value" ;;
-        reviewer) [ -n "$value" ] && AI_REVIEWERS+=("$value") ;;
-        reviewers) add_reviewers_from_csv "${line#*=}" ;;
+  trim_review_value() {
+    local value="$1"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    value="${value%,}"
+    value="${value#\"}"
+    value="${value%\"}"
+    value="${value#\'}"
+    value="${value%\'}"
+    printf '%s' "$value"
+  }
+
+  add_reviewers_from_csv() {
+    local csv="$1" item
+    local -a items=()
+    csv="$(trim_review_value "$csv")"
+    csv="${csv#\[}"
+    csv="${csv%\]}"
+    IFS=',' read -r -a items <<<"$csv"
+    for item in "${items[@]}"; do
+      item="$(trim_review_value "$item")"
+      [ -n "$item" ] && AI_REVIEWERS+=("$item")
+    done
+  }
+
+  load_ai_review_config() {
+    local section="" line key value
+
+    [ -f ".codex-review.toml" ] || {
+      AI_REVIEWERS=("conductor")
+      return 0
+    }
+
+    while IFS= read -r line || [ -n "$line" ]; do
+      line="${line%%#*}"
+      line="$(trim_review_value "$line")"
+      [ -z "$line" ] && continue
+
+      case "$line" in
+        \[*\])
+          section="${line#\[}"
+          section="${section%\]}"
+          continue
+          ;;
       esac
-    elif [ "$section" = "review.conductor" ]; then
-      case "$key" in
-        with) AI_CONDUCTOR_WITH="$value" ;;
-      esac
-    elif [ "$section" = "review.routing" ]; then
-      case "$key" in
-        enabled) AI_REVIEW_ROUTING_ENABLED="$value" ;;
-        small_max_diff_lines|small_diff_lines) AI_REVIEW_ROUTING_SMALL_MAX="$value" ;;
-        small_reviewers|large_reviewers) add_reviewers_from_csv "${line#*=}" ;;
-      esac
-    elif [ "$section" = "review.local" ]; then
-      case "$key" in
-        command) AI_LOCAL_REVIEW_COMMAND="$value" ;;
-      esac
+
+      case "$line" in *=*) ;; *) continue ;; esac
+      key="$(trim_review_value "${line%%=*}")"
+      value="$(trim_review_value "${line#*=}")"
+
+      if [ "$section" = "review" ]; then
+        case "$key" in
+          enabled) AI_REVIEW_ENABLED="$value" ;;
+          reviewer) [ -n "$value" ] && AI_REVIEWERS+=("$value") ;;
+          reviewers) add_reviewers_from_csv "${line#*=}" ;;
+        esac
+      elif [ "$section" = "review.conductor" ]; then
+        case "$key" in
+          with) AI_CONDUCTOR_WITH="$value" ;;
+        esac
+      elif [ "$section" = "review.routing" ]; then
+        case "$key" in
+          enabled) AI_REVIEW_ROUTING_ENABLED="$value" ;;
+          small_max_diff_lines | small_diff_lines) AI_REVIEW_ROUTING_SMALL_MAX="$value" ;;
+          small_reviewers | large_reviewers) add_reviewers_from_csv "${line#*=}" ;;
+        esac
+      elif [ "$section" = "review.local" ]; then
+        case "$key" in
+          command) AI_LOCAL_REVIEW_COMMAND="$value" ;;
+        esac
+      fi
+    done <".codex-review.toml"
+
+    if [ "${#AI_REVIEWERS[@]}" -eq 0 ] && [ "$AI_REVIEW_ENABLED" != "false" ]; then
+      AI_REVIEWERS=("conductor")
     fi
-  done < ".codex-review.toml"
+  }
 
-  if [ "${#AI_REVIEWERS[@]}" -eq 0 ] && [ "$AI_REVIEW_ENABLED" != "false" ]; then
-    AI_REVIEWERS=("conductor")
-  fi
-}
+  check_ai_reviewer() {
+    local reviewer="$1"
 
-check_ai_reviewer() {
-  local reviewer="$1"
+    case " $AI_REVIEWERS_CHECKED " in
+      *" $reviewer "*) return 0 ;;
+    esac
+    AI_REVIEWERS_CHECKED="$AI_REVIEWERS_CHECKED $reviewer"
 
-  case " $AI_REVIEWERS_CHECKED " in
-    *" $reviewer "*) return 0 ;;
-  esac
-  AI_REVIEWERS_CHECKED="$AI_REVIEWERS_CHECKED $reviewer"
-
-  case "$reviewer" in
-    conductor)
-      if command -v conductor >/dev/null 2>&1; then
-        if conductor doctor --json 2>/dev/null | grep -q '"configured"[[:space:]]*:[[:space:]]*true'; then
-          if [ -n "$AI_CONDUCTOR_WITH" ]; then
-            ok "conductor installed and configured (pinned provider: $AI_CONDUCTOR_WITH)"
+    case "$reviewer" in
+      conductor)
+        if command -v conductor >/dev/null 2>&1; then
+          if conductor doctor --json 2>/dev/null | grep -q '"configured"[[:space:]]*:[[:space:]]*true'; then
+            if [ -n "$AI_CONDUCTOR_WITH" ]; then
+              ok "conductor installed and configured (pinned provider: $AI_CONDUCTOR_WITH)"
+            else
+              ok "conductor installed and configured"
+            fi
           else
-            ok "conductor installed and configured"
+            warn "conductor installed but no provider is configured. Run: conductor init"
           fi
         else
-          warn "conductor installed but no provider is configured. Run: conductor init"
+          warn "conductor reviewer selected, but Conductor CLI is not installed. Run: brew install autumngarage/conductor/conductor && conductor init"
         fi
-      else
-        warn "conductor reviewer selected, but Conductor CLI is not installed. Run: brew install autumngarage/conductor/conductor && conductor init"
-      fi
-      ;;
-    codex)
-      if command -v codex >/dev/null 2>&1; then
-        if codex login status >/dev/null 2>&1; then
-          ok "codex installed and authenticated"
+        ;;
+      codex)
+        if command -v codex >/dev/null 2>&1; then
+          if codex login status >/dev/null 2>&1; then
+            ok "codex installed and authenticated"
+          else
+            warn "codex installed but not logged in. Run: codex login"
+          fi
+        elif command -v npm >/dev/null 2>&1; then
+          warn "Installing Codex CLI..."
+          npm install -g @openai/codex 2>/dev/null && ok "codex installed — run: codex login" || warn "codex install failed. Manual install: npm install -g @openai/codex"
         else
-          warn "codex installed but not logged in. Run: codex login"
+          warn "codex not installed. Install Node.js/npm first, then: npm install -g @openai/codex && codex login"
         fi
-      elif command -v npm >/dev/null 2>&1; then
-        warn "Installing Codex CLI..."
-        npm install -g @openai/codex 2>/dev/null && ok "codex installed — run: codex login" || warn "codex install failed. Manual install: npm install -g @openai/codex"
-      else
-        warn "codex not installed. Install Node.js/npm first, then: npm install -g @openai/codex && codex login"
-      fi
-      ;;
-    claude)
-      if command -v claude >/dev/null 2>&1; then
-        if claude auth status >/dev/null 2>&1; then
-          ok "claude installed and authenticated"
+        ;;
+      claude)
+        if command -v claude >/dev/null 2>&1; then
+          if claude auth status >/dev/null 2>&1; then
+            ok "claude installed and authenticated"
+          else
+            warn "claude installed but auth check failed. Authenticate Claude before relying on review."
+          fi
         else
-          warn "claude installed but auth check failed. Authenticate Claude before relying on review."
+          warn "claude reviewer selected, but Claude CLI is not installed."
         fi
-      else
-        warn "claude reviewer selected, but Claude CLI is not installed."
-      fi
-      ;;
-    gemini)
-      if command -v gemini >/dev/null 2>&1; then
-        if [ -n "${GEMINI_API_KEY:-}" ] || { command -v gcloud >/dev/null 2>&1 && gcloud auth print-access-token >/dev/null 2>&1; }; then
-          ok "gemini installed and authenticated"
+        ;;
+      gemini)
+        if command -v gemini >/dev/null 2>&1; then
+          if [ -n "${GEMINI_API_KEY:-}" ] || { command -v gcloud >/dev/null 2>&1 && gcloud auth print-access-token >/dev/null 2>&1; }; then
+            ok "gemini installed and authenticated"
+          else
+            warn "gemini installed but auth is not configured. Set GEMINI_API_KEY or authenticate gcloud."
+          fi
         else
-          warn "gemini installed but auth is not configured. Set GEMINI_API_KEY or authenticate gcloud."
+          warn "gemini reviewer selected, but Gemini CLI is not installed."
         fi
-      else
-        warn "gemini reviewer selected, but Gemini CLI is not installed."
-      fi
-      ;;
-    local)
-      if [ -n "$AI_LOCAL_REVIEW_COMMAND" ]; then
-        ok "local reviewer configured: $AI_LOCAL_REVIEW_COMMAND"
-      else
-        warn "local reviewer selected, but [review.local].command is empty in .codex-review.toml"
-      fi
-      ;;
-    *)
-      warn "unknown AI reviewer '$reviewer' in .codex-review.toml"
-      ;;
-  esac
-}
+        ;;
+      local)
+        if [ -n "$AI_LOCAL_REVIEW_COMMAND" ]; then
+          ok "local reviewer configured: $AI_LOCAL_REVIEW_COMMAND"
+        else
+          warn "local reviewer selected, but [review.local].command is empty in .codex-review.toml"
+        fi
+        ;;
+      *)
+        warn "unknown AI reviewer '$reviewer' in .codex-review.toml"
+        ;;
+    esac
+  }
 
-load_ai_review_config
-if [ "$AI_REVIEW_ENABLED" = "false" ]; then
-  ok "AI review disabled in .codex-review.toml"
-else
-  if truthy "$AI_REVIEW_ROUTING_ENABLED"; then
-    ok "review routing enabled — local/small-diff routes can use <= ${AI_REVIEW_ROUTING_SMALL_MAX} diff lines"
-  fi
-  for reviewer in "${AI_REVIEWERS[@]}"; do
-    check_ai_reviewer "$reviewer"
-  done
-fi
-
-# --------------------------------------------------------------------------
-# 5. Git workflow helpers (optional)
-# --------------------------------------------------------------------------
-info "Checking Git workflow"
-
-install_gitbutler_cli() {
-  local installer install_status
-
-  if ! command -v curl >/dev/null 2>&1; then
-    warn "curl is required for the official GitButler installer."
-    return 1
-  fi
-
-  installer="$(mktemp -t gitbutler-install.XXXXXX)"
-  if curl -fsSL https://gitbutler.com/install.sh -o "$installer"; then
-    sh "$installer"
-    install_status=$?
-    rm -f "$installer"
-    return "$install_status"
+  load_ai_review_config
+  if [ "$AI_REVIEW_ENABLED" = "false" ]; then
+    ok "AI review disabled in .codex-review.toml"
   else
-    rm -f "$installer"
-    return 1
-  fi
-}
-
-configure_gitbutler_mcp() {
-  if ! truthy "$GITBUTLER_MCP"; then
-    return 0
+    if truthy "$AI_REVIEW_ROUTING_ENABLED"; then
+      ok "review routing enabled — local/small-diff routes can use <= ${AI_REVIEW_ROUTING_SMALL_MAX} diff lines"
+    fi
+    for reviewer in "${AI_REVIEWERS[@]}"; do
+      check_ai_reviewer "$reviewer"
+    done
   fi
 
-  if ! command -v claude >/dev/null 2>&1; then
-    warn "GitButler MCP requested, but Claude Code is not installed. Later: claude mcp add gitbutler but mcp"
-    return 0
-  fi
+  # --------------------------------------------------------------------------
+  # 5. Git workflow helpers (optional)
+  # --------------------------------------------------------------------------
+  info "Checking Git workflow"
 
-  if claude mcp list 2>/dev/null | grep -q '^gitbutler:'; then
-    ok "GitButler MCP already configured for Claude Code"
-    return 0
-  fi
+  install_gitbutler_cli() {
+    local installer install_status
 
-  warn "GitButler MCP lets AI agents ask GitButler to record branches/savepoints."
-  if [ -t 0 ] && prompt_yes_no "Add GitButler MCP to Claude Code now?" "false"; then
-    claude mcp add gitbutler but mcp >/dev/null 2>&1 && ok "GitButler MCP added" || warn "GitButler MCP setup failed. Later: claude mcp add gitbutler but mcp"
-  else
-    warn "Later: claude mcp add gitbutler but mcp"
-  fi
-}
+    if ! command -v curl >/dev/null 2>&1; then
+      warn "curl is required for the official GitButler installer."
+      return 1
+    fi
 
-if [ "$GIT_WORKFLOW" = "gitbutler" ]; then
-  ok "GitButler selected — useful for stacked branches, parallel work, undo history, and AI-agent savepoints"
-  if command -v but >/dev/null 2>&1; then
-    ok "but installed"
-    if [ "$(git config --get touchstone.gitbutlerSetup 2>/dev/null || true)" = "configured" ]; then
-      ok "GitButler setup already recorded for this clone"
-    elif [ -t 0 ]; then
-      warn "Run 'but setup' once to let GitButler manage this repo. Undo later with: but teardown"
-      if prompt_yes_no "Run 'but setup' now?" "false"; then
-        if but setup; then
-          git config touchstone.gitbutlerSetup configured
-          ok "GitButler repo setup complete"
-        else
-          warn "GitButler setup failed. Later: but setup"
-        fi
-      else
-        warn "Later: but setup"
-      fi
+    installer="$(mktemp -t gitbutler-install.XXXXXX)"
+    if curl -fsSL https://gitbutler.com/install.sh -o "$installer"; then
+      sh "$installer"
+      install_status=$?
+      rm -f "$installer"
+      return "$install_status"
     else
-      warn "GitButler selected. Run once when ready: but setup"
+      rm -f "$installer"
+      return 1
     fi
-    configure_gitbutler_mcp
+  }
+
+  configure_gitbutler_mcp() {
+    if ! truthy "$GITBUTLER_MCP"; then
+      return 0
+    fi
+
+    if ! command -v claude >/dev/null 2>&1; then
+      warn "GitButler MCP requested, but Claude Code is not installed. Later: claude mcp add gitbutler but mcp"
+      return 0
+    fi
+
+    if claude mcp list 2>/dev/null | grep -q '^gitbutler:'; then
+      ok "GitButler MCP already configured for Claude Code"
+      return 0
+    fi
+
+    warn "GitButler MCP lets AI agents ask GitButler to record branches/savepoints."
+    if [ -t 0 ] && prompt_yes_no "Add GitButler MCP to Claude Code now?" "false"; then
+      claude mcp add gitbutler but mcp >/dev/null 2>&1 && ok "GitButler MCP added" || warn "GitButler MCP setup failed. Later: claude mcp add gitbutler but mcp"
+    else
+      warn "Later: claude mcp add gitbutler but mcp"
+    fi
+  }
+
+  if [ "$GIT_WORKFLOW" = "gitbutler" ]; then
+    ok "GitButler selected — useful for stacked branches, parallel work, undo history, and AI-agent savepoints"
+    if command -v but >/dev/null 2>&1; then
+      ok "but installed"
+      if [ "$(git config --get touchstone.gitbutlerSetup 2>/dev/null || true)" = "configured" ]; then
+        ok "GitButler setup already recorded for this clone"
+      elif [ -t 0 ]; then
+        warn "Run 'but setup' once to let GitButler manage this repo. Undo later with: but teardown"
+        if prompt_yes_no "Run 'but setup' now?" "false"; then
+          if but setup; then
+            git config touchstone.gitbutlerSetup configured
+            ok "GitButler repo setup complete"
+          else
+            warn "GitButler setup failed. Later: but setup"
+          fi
+        else
+          warn "Later: but setup"
+        fi
+      else
+        warn "GitButler selected. Run once when ready: but setup"
+      fi
+      configure_gitbutler_mcp
+    else
+      warn "GitButler selected, but 'but' CLI is not installed."
+      warn "GitButler CLI install: curl -fsSL https://gitbutler.com/install.sh | sh"
+      if [ -t 0 ] && prompt_yes_no "Run the official GitButler CLI installer now?" "false"; then
+        install_gitbutler_cli && ok "GitButler installer finished" || warn "GitButler install failed"
+      fi
+    fi
   else
-    warn "GitButler selected, but 'but' CLI is not installed."
-    warn "GitButler CLI install: curl -fsSL https://gitbutler.com/install.sh | sh"
-    if [ -t 0 ] && prompt_yes_no "Run the official GitButler CLI installer now?" "false"; then
-      install_gitbutler_cli && ok "GitButler installer finished" || warn "GitButler install failed"
-    fi
+    ok "plain Git workflow selected"
   fi
-else
-  ok "plain Git workflow selected"
-fi
 
-# --------------------------------------------------------------------------
-# 6. Sync touchstone files to latest
-# --------------------------------------------------------------------------
-info "Syncing touchstone files"
-# Skip update if this IS the Touchstone repo (it's the source, not a downstream project).
-if [ -f "bin/touchstone" ] && [ -f "lib/auto-update.sh" ]; then
-  ok "this is the Touchstone repo — skipping self-update"
-elif [ -f ".touchstone-version" ]; then
-  touchstone update --check 2>&1 | grep -E "Already|Needs sync|Run: touchstone update" | head -5 | while read -r line; do
-    ok "$line"
-  done
-  ok "touchstone sync status checked"
-else
-  warn "No .touchstone-version found — this project hasn't been bootstrapped."
-  warn "Run: touchstone new $(pwd)"
-fi
+  # --------------------------------------------------------------------------
+  # 6. Check touchstone files
+  # --------------------------------------------------------------------------
+  info "Checking touchstone files"
+  # Skip update if this IS the Touchstone repo (it's the source, not a downstream project).
+  if [ -f "bin/touchstone" ] && [ -f "lib/auto-update.sh" ]; then
+    ok "this is the Touchstone repo — skipping self-update"
+  elif [ -f ".touchstone-version" ]; then
+    touchstone update --check 2>&1 | grep -E "Already|Needs update|Run: touchstone update" | head -5 | while read -r line; do
+      ok "$line"
+    done
+    ok "touchstone update status checked"
+  else
+    warn "No .touchstone-version found — this project hasn't been bootstrapped."
+    warn "Run: touchstone new $(pwd)"
+  fi
 
-# --------------------------------------------------------------------------
-# 7. Pre-commit hooks
-# --------------------------------------------------------------------------
-info "Setting up git hooks"
-if [ -f ".pre-commit-config.yaml" ]; then
-  # Clear core.hooksPath if set — it conflicts with pre-commit.
-  git config --unset-all core.hooksPath 2>/dev/null || true
-  # Install hook shims (environments install lazily on first run).
-  pre-commit install 2>&1 | tail -1 | while read -r line; do ok "$line"; done
-  pre-commit install --hook-type pre-push 2>&1 | tail -1 | while read -r line; do ok "$line"; done
-  ok "pre-commit hooks installed (pre-commit, pre-push)"
-else
-  warn "No .pre-commit-config.yaml found — skipping hooks"
-fi
+  # --------------------------------------------------------------------------
+  # 7. Pre-commit hooks
+  # --------------------------------------------------------------------------
+  info "Setting up git hooks"
+  if [ -f ".pre-commit-config.yaml" ]; then
+    # Clear core.hooksPath if set — it conflicts with pre-commit.
+    git config --unset-all core.hooksPath 2>/dev/null || true
+    # Install hook shims (environments install lazily on first run).
+    pre-commit install 2>&1 | tail -1 | while read -r line; do ok "$line"; done
+    pre-commit install --hook-type pre-push 2>&1 | tail -1 | while read -r line; do ok "$line"; done
+    ok "pre-commit hooks installed (pre-commit, pre-push)"
+  else
+    warn "No .pre-commit-config.yaml found — skipping hooks"
+  fi
 
-# --------------------------------------------------------------------------
-# 8. gh CLI auth check
-# --------------------------------------------------------------------------
-info "Checking GitHub auth"
-if gh auth status 2>&1 | grep -q "Logged in"; then
-  ok "gh authenticated"
-else
-  warn "gh not authenticated. Run: gh auth login"
-fi
+  # --------------------------------------------------------------------------
+  # 8. gh CLI auth check
+  # --------------------------------------------------------------------------
+  info "Checking GitHub auth"
+  if gh auth status 2>&1 | grep -q "Logged in"; then
+    ok "gh authenticated"
+  else
+    warn "gh not authenticated. Run: gh auth login"
+  fi
 
 fi
 
@@ -605,11 +618,11 @@ load_touchstone_config() {
     key="$(trim "${line%%=*}")"
     value="$(trim "${line#*=}")"
     case "$key" in
-      project_type|profile) CONFIG_PROJECT_TYPE="$value" ;;
+      project_type | profile) CONFIG_PROJECT_TYPE="$value" ;;
       package_manager) CONFIG_PACKAGE_MANAGER="$value" ;;
       targets) CONFIG_TARGETS="$value" ;;
     esac
-  done < ".touchstone-config"
+  done <".touchstone-config"
 }
 
 detect_node_package_manager() {
@@ -694,7 +707,7 @@ install_node_dependencies() {
         warn "$label uses bun, but bun is not installed."
       fi
       ;;
-    npm|*)
+    npm | *)
       if command -v npm >/dev/null 2>&1; then
         (cd "$project_dir" && npm install) 2>&1 | tail -1 | while read -r line; do ok "$label dependencies installed: $line"; done
       else
@@ -776,13 +789,16 @@ install_profile_dependencies() {
   fi
 
   case "$profile" in
-    node|typescript|ts) install_node_dependencies "$label" "$project_dir" "$CONFIG_PACKAGE_MANAGER" ;;
+    node | typescript | ts) install_node_dependencies "$label" "$project_dir" "$CONFIG_PACKAGE_MANAGER" ;;
     python) install_python_dependencies "$label" "$project_dir" ;;
     rust) install_rust_dependencies "$label" "$project_dir" ;;
     swift) install_swift_dependencies "$label" "$project_dir" ;;
     go) install_go_dependencies "$label" "$project_dir" ;;
-    generic|"") return 1 ;;
-    *) warn "Unknown project_type '$profile' in .touchstone-config"; return 1 ;;
+    generic | "") return 1 ;;
+    *)
+      warn "Unknown project_type '$profile' in .touchstone-config"
+      return 1
+      ;;
   esac
 }
 
@@ -794,7 +810,7 @@ install_configured_targets() {
 
   [ -n "$CONFIG_TARGETS" ] || return 1
 
-  IFS=',' read -r -a target_entries <<< "$CONFIG_TARGETS"
+  IFS=',' read -r -a target_entries <<<"$CONFIG_TARGETS"
   for entry in "${target_entries[@]}"; do
     entry="$(trim "$entry")"
     [ -z "$entry" ] && continue
@@ -934,7 +950,7 @@ install_profile_devtools() {
       info "Checking Rust dev tools${label:+ ($label)}"
       install_rust_devtools
       ;;
-    python|node|typescript|ts|generic|"")
+    python | node | typescript | ts | generic | "")
       : # python/node own their ecosystems via requirements.txt / package.json; generic is a no-op.
       ;;
     *)
@@ -949,7 +965,7 @@ install_configured_target_devtools() {
 
   [ -n "$CONFIG_TARGETS" ] || return 0
 
-  IFS=',' read -r -a target_entries <<< "$CONFIG_TARGETS"
+  IFS=',' read -r -a target_entries <<<"$CONFIG_TARGETS"
   for entry in "${target_entries[@]}"; do
     entry="$(trim "$entry")"
     [ -z "$entry" ] && continue

--- a/tests/test-doctor.sh
+++ b/tests/test-doctor.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# tests/test-doctor.sh — fixture tests for conductor-review fail-open trends.
+# tests/test-doctor.sh — fixture tests for doctor semantics and review stats.
 #
 set -euo pipefail
 
@@ -30,13 +30,25 @@ assert_exit() {
   fi
 }
 
-run_doctor() {
+run_touchstone() {
   local fake_home="$1"
   shift
   HOME="$fake_home" \
     NO_COLOR=1 \
     TOUCHSTONE_NO_AUTO_UPDATE=1 \
-    bash "$TOUCHSTONE_BIN" doctor "$@"
+    bash "$TOUCHSTONE_BIN" "$@"
+}
+
+run_review_stats() {
+  local fake_home="$1"
+  shift
+  run_touchstone "$fake_home" review-stats "$@"
+}
+
+run_doctor() {
+  local fake_home="$1"
+  shift
+  run_touchstone "$fake_home" doctor "$@"
 }
 
 timestamp_now() {
@@ -45,20 +57,20 @@ timestamp_now() {
 
 write_row() {
   local file="$1" timestamp="$2" repo="$3" branch="$4" sha="$5" reason="$6" detail="$7"
-  printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$timestamp" "$repo" "$branch" "$sha" "$reason" "$detail" >> "$file"
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$timestamp" "$repo" "$branch" "$sha" "$reason" "$detail" >>"$file"
 }
 
-echo "==> Test: touchstone doctor review-log aggregation"
+echo "==> Test: touchstone doctor and review-stats"
 echo "    Test dir: $TEST_DIR"
 
 FAKE_HOME="$TEST_DIR/home"
 mkdir -p "$FAKE_HOME"
 
 # --------------------------------------------------------------------------
-# Test 1: help preserves project capability option
+# Test 1: doctor help preserves project capability option and omits metrics
 # --------------------------------------------------------------------------
 echo ""
-echo "--- Test 1: help documents project capability option ---"
+echo "--- Test 1: doctor help is structural ---"
 
 HELP_OUT="$TEST_DIR/help.out"
 set +e
@@ -69,16 +81,35 @@ set -e
 assert_exit "$HELP_EXIT" 0 "help"
 assert_contains "$HELP_OUT" "touchstone doctor --require-capability <name>"
 assert_contains "$HELP_OUT" "Require a project-local Touchstone workflow capability"
+if grep -Eq -- "fail-open trends|--log-path|--threshold" "$HELP_OUT"; then
+  echo "FAIL: doctor help should not expose review metrics" >&2
+  ERRORS=$((ERRORS + 1))
+fi
 
 # --------------------------------------------------------------------------
-# Test 2: missing log exits 0 with friendly message
+# Test 2: doctor rejects old metrics flags
 # --------------------------------------------------------------------------
 echo ""
-echo "--- Test 2: missing log ---"
+echo "--- Test 2: doctor metrics moved to review-stats ---"
+
+DOCTOR_METRICS_OUT="$TEST_DIR/doctor-metrics.out"
+set +e
+run_doctor "$FAKE_HOME" --log-path "$TEST_DIR/no-such-log" >"$DOCTOR_METRICS_OUT" 2>&1
+DOCTOR_METRICS_EXIT=$?
+set -e
+
+assert_exit "$DOCTOR_METRICS_EXIT" 2 "doctor metrics flags"
+assert_contains "$DOCTOR_METRICS_OUT" "review metrics moved to: touchstone review-stats"
+
+# --------------------------------------------------------------------------
+# Test 3: review-stats missing log exits 0 with friendly message
+# --------------------------------------------------------------------------
+echo ""
+echo "--- Test 3: review-stats missing log ---"
 
 MISSING_OUT="$TEST_DIR/missing.out"
 set +e
-run_doctor "$FAKE_HOME" --log-path "$TEST_DIR/no-such-log" >"$MISSING_OUT" 2>&1
+run_review_stats "$FAKE_HOME" --log-path "$TEST_DIR/no-such-log" >"$MISSING_OUT" 2>&1
 MISSING_EXIT=$?
 set -e
 
@@ -86,16 +117,16 @@ assert_exit "$MISSING_EXIT" 0 "missing log"
 assert_contains "$MISSING_OUT" "no review log found; conductor review hasn't run on this machine yet"
 
 # --------------------------------------------------------------------------
-# Test 3: empty log exits 0 with the same friendly message
+# Test 4: empty log exits 0 with the same friendly message
 # --------------------------------------------------------------------------
 echo ""
-echo "--- Test 3: empty log ---"
+echo "--- Test 4: review-stats empty log ---"
 
 EMPTY_LOG="$TEST_DIR/empty.log"
-: > "$EMPTY_LOG"
+: >"$EMPTY_LOG"
 EMPTY_OUT="$TEST_DIR/empty.out"
 set +e
-run_doctor "$FAKE_HOME" --log-path "$EMPTY_LOG" >"$EMPTY_OUT" 2>&1
+run_review_stats "$FAKE_HOME" --log-path "$EMPTY_LOG" >"$EMPTY_OUT" 2>&1
 EMPTY_EXIT=$?
 set -e
 
@@ -103,10 +134,10 @@ assert_exit "$EMPTY_EXIT" 0 "empty log"
 assert_contains "$EMPTY_OUT" "no review log found; conductor review hasn't run on this machine yet"
 
 # --------------------------------------------------------------------------
-# Test 4: no fail-opens reports zero rate and exits 0
+# Test 5: no fail-opens reports zero rate and exits 0
 # --------------------------------------------------------------------------
 echo ""
-echo "--- Test 4: no fail-opens ---"
+echo "--- Test 5: review-stats no fail-opens ---"
 
 NOW="$(timestamp_now)"
 NO_FAIL_LOG="$TEST_DIR/no-fail.log"
@@ -115,7 +146,7 @@ write_row "$NO_FAIL_LOG" "$NOW" "/tmp/repo-b" "feat/x" "def5678" "ran" "clean"
 
 NO_FAIL_OUT="$TEST_DIR/no-fail.out"
 set +e
-run_doctor "$FAKE_HOME" --log-path "$NO_FAIL_LOG" >"$NO_FAIL_OUT" 2>&1
+run_review_stats "$FAKE_HOME" --log-path "$NO_FAIL_LOG" >"$NO_FAIL_OUT" 2>&1
 NO_FAIL_EXIT=$?
 set -e
 
@@ -127,10 +158,10 @@ assert_contains "$NO_FAIL_OUT" "FAIL_OPEN_TIMEOUT: 0"
 assert_contains "$NO_FAIL_OUT" "none recorded"
 
 # --------------------------------------------------------------------------
-# Test 5: mixed rows count fail-open codes and ignore disabled/skipped rows
+# Test 6: mixed rows count fail-open codes and ignore disabled/skipped rows
 # --------------------------------------------------------------------------
 echo ""
-echo "--- Test 5: mixed events ---"
+echo "--- Test 6: review-stats mixed events ---"
 
 MIXED_LOG="$TEST_DIR/mixed.log"
 write_row "$MIXED_LOG" "2000-01-01T00:00:00+0000" "/tmp/old" "main" "0000000" "FAIL_OPEN_TIMEOUT" "too-old"
@@ -141,7 +172,7 @@ write_row "$MIXED_LOG" "$NOW" "/tmp/repo-d" "feat/c" "4444444" "config-disabled"
 
 MIXED_OUT="$TEST_DIR/mixed.out"
 set +e
-run_doctor "$FAKE_HOME" --log-path "$MIXED_LOG" --threshold 80 >"$MIXED_OUT" 2>&1
+run_review_stats "$FAKE_HOME" --log-path "$MIXED_LOG" --threshold 80 >"$MIXED_OUT" 2>&1
 MIXED_EXIT=$?
 set -e
 
@@ -154,10 +185,10 @@ assert_contains "$MIXED_OUT" "repo: /tmp/repo-c"
 assert_contains "$MIXED_OUT" "detail: fail-open:malformed sentinel"
 
 # --------------------------------------------------------------------------
-# Test 6: threshold warning exits 2
+# Test 7: threshold warning exits 2
 # --------------------------------------------------------------------------
 echo ""
-echo "--- Test 6: threshold warning ---"
+echo "--- Test 7: review-stats threshold warning ---"
 
 THRESHOLD_LOG="$TEST_DIR/threshold.log"
 write_row "$THRESHOLD_LOG" "$NOW" "/tmp/repo-a" "main" "aaaaaaa" "ran" "clean"
@@ -165,7 +196,7 @@ write_row "$THRESHOLD_LOG" "$NOW" "/tmp/repo-b" "feat/a" "bbbbbbb" "FAIL_OPEN_RE
 
 THRESHOLD_OUT="$TEST_DIR/threshold.out"
 set +e
-run_doctor "$FAKE_HOME" --log-path "$THRESHOLD_LOG" >"$THRESHOLD_OUT" 2>&1
+run_review_stats "$FAKE_HOME" --log-path "$THRESHOLD_LOG" >"$THRESHOLD_OUT" 2>&1
 THRESHOLD_EXIT=$?
 set -e
 
@@ -175,10 +206,10 @@ assert_contains "$THRESHOLD_OUT" "FAIL_OPEN_REVIEWER_ERROR: 1"
 assert_contains "$THRESHOLD_OUT" "exceeds 25%"
 
 # --------------------------------------------------------------------------
-# Test 7: TOUCHSTONE_REVIEW_LOG env override is honored and read-only
+# Test 8: TOUCHSTONE_REVIEW_LOG env override is honored and read-only
 # --------------------------------------------------------------------------
 echo ""
-echo "--- Test 7: env override and read-only behavior ---"
+echo "--- Test 8: review-stats env override and read-only behavior ---"
 
 ENV_LOG="$TEST_DIR/env.log"
 write_row "$ENV_LOG" "$NOW" "/tmp/repo-env" "main" "eeeeeee" "ran" "clean"
@@ -186,7 +217,7 @@ BEFORE_SUM="$(cksum "$ENV_LOG")"
 
 ENV_OUT="$TEST_DIR/env.out"
 set +e
-TOUCHSTONE_REVIEW_LOG="$ENV_LOG" run_doctor "$FAKE_HOME" >"$ENV_OUT" 2>&1
+TOUCHSTONE_REVIEW_LOG="$ENV_LOG" run_review_stats "$FAKE_HOME" >"$ENV_OUT" 2>&1
 ENV_EXIT=$?
 set -e
 AFTER_SUM="$(cksum "$ENV_LOG")"
@@ -197,6 +228,110 @@ if [ "$BEFORE_SUM" != "$AFTER_SUM" ]; then
   echo "FAIL: doctor modified the review log fixture" >&2
   ERRORS=$((ERRORS + 1))
 fi
+
+# --------------------------------------------------------------------------
+# Test 9: --require-capability implies project mode
+# --------------------------------------------------------------------------
+echo ""
+echo "--- Test 9: doctor --require-capability implies project mode ---"
+
+CAPABILITY_PROJECT="$TEST_DIR/capability-project"
+mkdir -p "$CAPABILITY_PROJECT"
+git -C "$TOUCHSTONE_ROOT" rev-parse HEAD >"$CAPABILITY_PROJECT/.touchstone-version"
+
+CAPABILITY_OUT="$TEST_DIR/capability-doctor.out"
+set +e
+(cd "$CAPABILITY_PROJECT" && run_doctor "$FAKE_HOME" --require-capability worktree-lifecycle) >"$CAPABILITY_OUT" 2>&1
+CAPABILITY_EXIT=$?
+set -e
+
+assert_exit "$CAPABILITY_EXIT" 0 "doctor --require-capability"
+assert_contains "$CAPABILITY_OUT" "Capability 'worktree-lifecycle' is available"
+if grep -q -- "Touchstone Doctor" "$CAPABILITY_OUT"; then
+  echo "FAIL: --require-capability should not fall through to installation doctor" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# --------------------------------------------------------------------------
+# Test 10: bare doctor checks structural project state, not installation state
+# --------------------------------------------------------------------------
+echo ""
+echo "--- Test 10: bare doctor recognizes modern project marker ---"
+
+MODERN_PROJECT="$TEST_DIR/modern-project"
+mkdir -p "$MODERN_PROJECT"
+git -C "$TOUCHSTONE_ROOT" rev-parse HEAD >"$MODERN_PROJECT/.touchstone-version"
+
+MODERN_DOCTOR_OUT="$TEST_DIR/modern-doctor.out"
+set +e
+(cd "$MODERN_PROJECT" && run_doctor "$FAKE_HOME") >"$MODERN_DOCTOR_OUT" 2>&1
+MODERN_DOCTOR_EXIT=$?
+set -e
+
+if [ "$MODERN_DOCTOR_EXIT" -eq 0 ]; then
+  echo "FAIL: incomplete project doctor should report missing structural pieces" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+assert_contains "$MODERN_DOCTOR_OUT" "Touchstone Project Doctor"
+assert_contains "$MODERN_DOCTOR_OUT" ".pre-commit-config.yaml is missing"
+assert_contains "$MODERN_DOCTOR_OUT" ".touchstone-manifest missing"
+
+# --------------------------------------------------------------------------
+# Test 11: bare doctor checks structural project state, not metrics
+# --------------------------------------------------------------------------
+echo ""
+echo "--- Test 11: bare doctor surfaces migration debt ---"
+
+LEGACY_PROJECT="$TEST_DIR/legacy-project"
+mkdir -p "$LEGACY_PROJECT"
+printf 'legacy-sha\n' >"$LEGACY_PROJECT/.toolkit-version"
+LEGACY_DOCTOR_OUT="$TEST_DIR/legacy-doctor.out"
+set +e
+(cd "$LEGACY_PROJECT" && run_doctor "$FAKE_HOME") >"$LEGACY_DOCTOR_OUT" 2>&1
+LEGACY_DOCTOR_EXIT=$?
+set -e
+
+if [ "$LEGACY_DOCTOR_EXIT" -eq 0 ]; then
+  echo "FAIL: bare doctor should fail on migration debt" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+assert_contains "$LEGACY_DOCTOR_OUT" "Legacy .toolkit-version found"
+assert_contains "$LEGACY_DOCTOR_OUT" "touchstone migrate-from-toolkit"
+if grep -Eq -- "fail-open|review log" "$LEGACY_DOCTOR_OUT"; then
+  echo "FAIL: bare doctor should not print review metrics" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# --------------------------------------------------------------------------
+# Test 12: doctor surfaces review config migration debt
+# --------------------------------------------------------------------------
+echo ""
+echo "--- Test 12: doctor surfaces review config migration debt ---"
+
+REVIEW_SCHEMA_PROJECT="$TEST_DIR/review-schema-project"
+mkdir -p "$REVIEW_SCHEMA_PROJECT"
+git -C "$REVIEW_SCHEMA_PROJECT" init -q
+git -C "$REVIEW_SCHEMA_PROJECT" config user.email test@example.com
+git -C "$REVIEW_SCHEMA_PROJECT" config user.name "Touchstone Test"
+git -C "$REVIEW_SCHEMA_PROJECT" commit --allow-empty -q -m "initial"
+git -C "$TOUCHSTONE_ROOT" rev-parse HEAD >"$REVIEW_SCHEMA_PROJECT/.touchstone-version"
+cat >"$REVIEW_SCHEMA_PROJECT/.codex-review.toml" <<'EOF_REVIEW_SCHEMA'
+[review]
+reviewers = ["codex", "claude"]
+EOF_REVIEW_SCHEMA
+
+REVIEW_SCHEMA_OUT="$TEST_DIR/review-schema-doctor.out"
+set +e
+(cd "$REVIEW_SCHEMA_PROJECT" && run_doctor "$FAKE_HOME") >"$REVIEW_SCHEMA_OUT" 2>&1
+REVIEW_SCHEMA_EXIT=$?
+set -e
+
+if [ "$REVIEW_SCHEMA_EXIT" -eq 0 ]; then
+  echo "FAIL: doctor should fail on review config migration debt" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+assert_contains "$REVIEW_SCHEMA_OUT" ".codex-review.toml uses legacy 1.x review schema"
+assert_contains "$REVIEW_SCHEMA_OUT" "touchstone migrate-review-config"
 
 if [ "$ERRORS" -ne 0 ]; then
   echo ""

--- a/tests/test-sync-smoke.sh
+++ b/tests/test-sync-smoke.sh
@@ -29,6 +29,7 @@ set -u
 
 TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TEST_DIR="$(mktemp -d -t touchstone-sync-smoke.XXXXXX)"
+TOUCHSTONE_BIN="$TOUCHSTONE_ROOT/bin/touchstone"
 
 REAL_HOME="${HOME:-}"
 REAL_REGISTRY_FILE=""
@@ -55,6 +56,24 @@ cleanup() {
   exit "$status"
 }
 trap cleanup EXIT
+
+assert_contains() {
+  local file="$1" needle="$2"
+  if ! grep -q -- "$needle" "$file"; then
+    echo "FAIL: expected $file to contain '$needle'" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local file="$1" needle="$2"
+  if grep -q -- "$needle" "$file"; then
+    echo "FAIL: expected $file not to contain '$needle'" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
 
 REGISTRY_SOURCE="isolated temp registry"
 if [ "${TOUCHSTONE_PROJECTS_FILE+x}" = "x" ]; then
@@ -107,6 +126,20 @@ if [ "${#PROJECTS[@]}" -eq 0 ]; then
   echo "==> Registry is empty, skipping smoke test."
   exit 0
 fi
+
+CLI_HOME="$TEST_DIR/cli-home"
+mkdir -p "$CLI_HOME"
+cp "$REGISTRY_FILE" "$CLI_HOME/.touchstone-projects"
+
+UPDATE_ALL_CHECK_OUT="$TEST_DIR/update-all-check.out"
+HOME="$CLI_HOME" NO_COLOR=1 TOUCHSTONE_NO_AUTO_UPDATE=1 \
+  bash "$TOUCHSTONE_BIN" update-all --check >"$UPDATE_ALL_CHECK_OUT" 2>&1
+assert_not_contains "$UPDATE_ALL_CHECK_OUT" "DEPRECATED"
+
+SYNC_ALIAS_CHECK_OUT="$TEST_DIR/sync-alias-check.out"
+HOME="$CLI_HOME" NO_COLOR=1 TOUCHSTONE_NO_AUTO_UPDATE=1 \
+  bash "$TOUCHSTONE_BIN" sync --check >"$SYNC_ALIAS_CHECK_OUT" 2>&1
+assert_contains "$SYNC_ALIAS_CHECK_OUT" "DEPRECATED: touchstone sync is deprecated; use touchstone update-all."
 
 TESTED=0
 WARNINGS=0

--- a/tests/test-update.sh
+++ b/tests/test-update.sh
@@ -468,7 +468,7 @@ commit_all "$CHECK_PROJECT" "simulate old check project"
 CHECK_BRANCH="$(git -C "$CHECK_PROJECT" rev-parse --abbrev-ref HEAD)"
 
 (cd "$CHECK_PROJECT" && bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh" --check) >"$TEST_DIR/check-output.txt" 2>&1
-assert_contains "$TEST_DIR/check-output.txt" 'Needs sync'
+assert_contains "$TEST_DIR/check-output.txt" 'Needs update'
 assert_contains "$TEST_DIR/check-output.txt" 'Run: touchstone update'
 
 if [ "$(git -C "$CHECK_PROJECT" rev-parse --abbrev-ref HEAD)" != "$CHECK_BRANCH" ]; then
@@ -477,7 +477,7 @@ if [ "$(git -C "$CHECK_PROJECT" rev-parse --abbrev-ref HEAD)" != "$CHECK_BRANCH"
 fi
 
 (cd "$CHECK_PROJECT" && TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" detect) >"$TEST_DIR/detect-output.txt" 2>&1
-assert_not_contains "$TEST_DIR/detect-output.txt" 'needs sync'
+assert_not_contains "$TEST_DIR/detect-output.txt" 'Needs update'
 
 # --------------------------------------------------------------------------
 # Results


### PR DESCRIPTION
## Linked Issues

Closes #257

## Summary

Adopts the shared `update` / `update-all` / structural `doctor` semantics in the Touchstone CLI. Keeps `sync` as a deprecated alias and moves review-log metrics to `review-stats`.

## Changes

- Add canonical `touchstone update-all` and update user-facing sync wording.
- Make bare `touchstone doctor` run project structural checks in projects and installation checks outside projects.
- Move review fail-open trend reporting to `touchstone review-stats`.
- Surface legacy `.toolkit-version` and legacy `.codex-review.toml` migration debt in project doctor.
- Add regression coverage for update-all smoke, doctor/review-stats behavior, project marker detection, and `--require-capability` project-mode routing.

## Testing

- `bash tests/test-doctor.sh`
- `bash tests/test-sync-smoke.sh`
- `bash tests/test-update.sh`
- `bash tests/test-bootstrap.sh`
- `for test in tests/test-*.sh; do bash "$test" || exit 1; done`
- `pre-commit run --all-files`
- `bash lib/preflight.sh --diff origin/main`

## Review Note

Conductor live review routing is currently unreliable for this PR despite clean deterministic preflight. Tracked upstream in autumngarage/conductor#308.
