### PR TITLE
fix: force-stage managed update paths

### DIFF
--- a/bootstrap/update-project.sh
+++ b/bootstrap/update-project.sh
@@ -608,6 +608,25 @@ write_touchstone_manifest() {
   } >"$manifest"
 }
 
+stage_touchstone_manifest_paths() {
+  local manifest="$PROJECT_DIR/.touchstone-manifest"
+  local rel_path
+
+  if [ ! -f "$manifest" ]; then
+    echo "ERROR: expected .touchstone-manifest before staging update" >&2
+    return 1
+  fi
+
+  while IFS= read -r rel_path; do
+    case "$rel_path" in
+      "" | \#*) continue ;;
+    esac
+    if [ -e "$PROJECT_DIR/$rel_path" ] || [ -L "$PROJECT_DIR/$rel_path" ]; then
+      git -C "$PROJECT_DIR" add -f -- "$rel_path"
+    fi
+  done <"$manifest"
+}
+
 # Ensure scripts are executable and write touchstone metadata.
 if [ "$DRY_RUN" = false ]; then
   if [ -d "$PROJECT_DIR/scripts" ]; then
@@ -634,8 +653,7 @@ fi
 if [ "$DRY_RUN" = false ]; then
   echo ""
   echo "==> Committing touchstone update..."
-  git -C "$PROJECT_DIR" add -A -- TOUCHSTONE.md principles scripts lib .touchstone-manifest
-  git -C "$PROJECT_DIR" add -f -- .touchstone-version
+  stage_touchstone_manifest_paths
   # If the early auto-migration rewrote .codex-review.toml, stage it so
   # the rewrite ships in the same update commit instead of dangling as
   # an unstaged diff.

--- a/tests/test-update.sh
+++ b/tests/test-update.sh
@@ -242,6 +242,40 @@ else
 fi
 
 # --------------------------------------------------------------------------
+# Test 2c: project .gitignore rules must not prevent Touchstone-owned files
+# from being staged. Downstream repos may legitimately ignore generic names
+# like lib/ for their own build artifacts; managed Touchstone files still need
+# to ship as exact manifest entries.
+# --------------------------------------------------------------------------
+echo ""
+echo "--- Step 3c: Ignored Touchstone-owned paths are force-staged ---"
+
+IGNORED_MANAGED_PROJECT="$TEST_DIR/ignored-managed-project"
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$IGNORED_MANAGED_PROJECT" --no-register >/dev/null
+configure_git "$IGNORED_MANAGED_PROJECT"
+commit_all "$IGNORED_MANAGED_PROJECT" "initial ignored-managed test project"
+printf '\nlib/\n' >>"$IGNORED_MANAGED_PROJECT/.gitignore"
+git -C "$IGNORED_MANAGED_PROJECT" rm --cached -r lib >/dev/null
+echo "0000000000000000000000000000000000000005" >"$IGNORED_MANAGED_PROJECT/.touchstone-version"
+commit_all "$IGNORED_MANAGED_PROJECT" "simulate repo ignoring Touchstone lib files"
+
+(cd "$IGNORED_MANAGED_PROJECT" && bash "$TOUCHSTONE_ROOT/bootstrap/update-project.sh") >"$TEST_DIR/update-ignored-managed-output.txt" 2>&1
+
+assert_contains "$TEST_DIR/update-ignored-managed-output.txt" 'Committed: chore: update touchstone to'
+if git -C "$IGNORED_MANAGED_PROJECT" ls-files --error-unmatch lib/preflight.sh >/dev/null 2>&1; then
+  echo "    PASS: ignored managed lib/preflight.sh was force-staged"
+else
+  echo "FAIL: ignored managed lib/preflight.sh was not tracked by update commit" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+if [ -n "$(git -C "$IGNORED_MANAGED_PROJECT" status --porcelain)" ]; then
+  echo "FAIL: ignored managed update should leave a clean worktree after committing" >&2
+  git -C "$IGNORED_MANAGED_PROJECT" status --short >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# --------------------------------------------------------------------------
 # Test 3: project-owned files are NOT touched.
 # --------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Linked Issues

Closes #279

Fixes #279

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
