### PR TITLE
fix: classify bootstrap review paths

### DIFF
--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -1231,7 +1231,9 @@ write_review_onboarding_config() {
         printf 'large_with = "%s"\n' "$large_with_pin"
       fi
       printf 'large_prefer = "best"\n'
-      printf 'large_effort = "high"\n'
+      printf 'large_effort = "medium"\n'
+      printf 'high_risk_prefer = "best"\n'
+      printf 'high_risk_effort = "high"\n'
     fi
     if [ "$assist" = "true" ]; then
       printf '\n# NOTE: --review-assist requested. Peer review is disabled in Touchstone 2.0.0;\n'

--- a/bootstrap/review.sh
+++ b/bootstrap/review.sh
@@ -130,6 +130,7 @@ GEMINI.md
 .codex-review-context.md
 .github/codex-review-context.md
 .github/workflows/
+bootstrap/
 hooks/codex-review.sh
 hooks/codex-review.config.example.toml
 scripts/codex-review.sh

--- a/bootstrap/review.sh
+++ b/bootstrap/review.sh
@@ -116,8 +116,26 @@ ROUTING_SMALL_EFFORT="minimal"
 ROUTING_SMALL_TAGS=""
 ROUTING_LARGE_WITH=""
 ROUTING_LARGE_PREFER="best"
-ROUTING_LARGE_EFFORT="high"
+ROUTING_LARGE_EFFORT="medium"
 ROUTING_LARGE_TAGS=""
+ROUTING_HIGH_RISK_WITH=""
+ROUTING_HIGH_RISK_PREFER="best"
+ROUTING_HIGH_RISK_EFFORT="high"
+ROUTING_HIGH_RISK_TAGS=""
+UNSAFE_PATHS=""
+ARCHITECTURAL_PATHS="AGENTS.md
+CLAUDE.md
+GEMINI.md
+.codex-review.toml
+.codex-review-context.md
+.github/codex-review-context.md
+.github/workflows/
+hooks/codex-review.sh
+hooks/codex-review.config.example.toml
+scripts/codex-review.sh
+architecture/
+docs/architecture/
+principles/"
 CONFIG_MODE=""
 
 strip_quotes() {
@@ -164,6 +182,7 @@ if [ -f "$CONFIG_FILE" ]; then
       "codex_review" | "")
         case "$key" in
           mode) CONFIG_MODE="$(toml_unquote "$value")" ;;
+          unsafe_paths) UNSAFE_PATHS="$(toml_normalize_array "$value" | tr ',' '\n')" ;;
         esac
         ;;
       "review.conductor")
@@ -190,6 +209,10 @@ if [ -f "$CONFIG_FILE" ]; then
           large_prefer) ROUTING_LARGE_PREFER="$(toml_unquote "$value")" ;;
           large_effort) ROUTING_LARGE_EFFORT="$(toml_unquote "$value")" ;;
           large_tags) ROUTING_LARGE_TAGS="$(toml_normalize_array "$value")" ;;
+          high_risk_with) ROUTING_HIGH_RISK_WITH="$(toml_unquote "$value")" ;;
+          high_risk_prefer) ROUTING_HIGH_RISK_PREFER="$(toml_unquote "$value")" ;;
+          high_risk_effort) ROUTING_HIGH_RISK_EFFORT="$(toml_unquote "$value")" ;;
+          high_risk_tags) ROUTING_HIGH_RISK_TAGS="$(toml_normalize_array "$value")" ;;
         esac
         ;;
     esac
@@ -255,17 +278,91 @@ if git rev-parse --verify "$BASE" >/dev/null 2>&1; then
   DIFF_LINE_COUNT="$(git diff "$BASE"..HEAD 2>/dev/null | wc -l | tr -d ' ')"
   diff_line_count_available=true
 fi
+CHANGED_PATHS="$(git diff --name-only "$BASE"..HEAD 2>/dev/null || true)"
+
+path_matches_pattern() {
+  local path="$1"
+  local pattern="$2"
+
+  [ -n "$path" ] || return 1
+  [ -n "$pattern" ] || return 1
+
+  case "$pattern" in
+    */)
+      [[ "$path" == "$pattern"* ]] && return 0
+      ;;
+    *\** | *\?* | *\[*)
+      # shellcheck disable=SC2053 # Configured patterns intentionally use globs.
+      [[ "$path" == $pattern ]] && return 0
+      ;;
+    *)
+      if [ "$path" = "$pattern" ] || [[ "$path" == "$pattern/"* ]]; then
+        return 0
+      fi
+      ;;
+  esac
+
+  return 1
+}
+
+find_path_matching_patterns() {
+  local paths="$1"
+  local patterns="$2"
+  local path pattern
+
+  [ -n "$paths" ] || return 1
+  [ -n "$patterns" ] || return 1
+
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    while IFS= read -r pattern; do
+      [ -n "$pattern" ] || continue
+      if path_matches_pattern "$path" "$pattern"; then
+        printf '%s (matched %s)' "$path" "$pattern"
+        return 0
+      fi
+    done <<<"$patterns"
+  done <<<"$paths"
+
+  return 1
+}
+
+find_high_risk_reason() {
+  local match
+
+  match="$(find_path_matching_patterns "$CHANGED_PATHS" "$UNSAFE_PATHS" || true)"
+  if [ -n "$match" ]; then
+    printf 'high-risk path %s' "$match"
+    return 0
+  fi
+
+  match="$(find_path_matching_patterns "$CHANGED_PATHS" "$ARCHITECTURAL_PATHS" || true)"
+  if [ -n "$match" ]; then
+    printf 'architectural path %s' "$match"
+    return 0
+  fi
+
+  return 1
+}
 
 routing_decision="default"
 routing_reason="review.routing.enabled=false"
 if [ "$ROUTING_ENABLED" = true ]; then
   routing_reason="diff line count unavailable for base $BASE"
+  risk_reason="$(find_high_risk_reason || true)"
   case "$ROUTING_SMALL_MAX_DIFF_LINES" in
     '' | *[!0-9]*)
       routing_reason="invalid review.routing.small_max_diff_lines='$ROUTING_SMALL_MAX_DIFF_LINES'"
       ;;
     *)
-      if [ "$diff_line_count_available" = true ] && [ "$DIFF_LINE_COUNT" -le "$ROUTING_SMALL_MAX_DIFF_LINES" ] 2>/dev/null; then
+      if [ "$diff_line_count_available" = true ] && [ -n "$risk_reason" ]; then
+        routing_decision="high-risk"
+        routing_reason="$risk_reason; $DIFF_LINE_COUNT diff lines"
+        [ -n "$ROUTING_HIGH_RISK_WITH" ] && CONDUCTOR_WITH="${TOUCHSTONE_CONDUCTOR_WITH:-$ROUTING_HIGH_RISK_WITH}"
+        [ -n "$ROUTING_HIGH_RISK_PREFER" ] && CONDUCTOR_PREFER="${TOUCHSTONE_CONDUCTOR_PREFER:-$ROUTING_HIGH_RISK_PREFER}"
+        [ -n "$ROUTING_HIGH_RISK_EFFORT" ] && CONDUCTOR_EFFORT="${TOUCHSTONE_CONDUCTOR_EFFORT:-$ROUTING_HIGH_RISK_EFFORT}"
+        [ -n "$ROUTING_HIGH_RISK_TAGS" ] && CONDUCTOR_TAGS="${TOUCHSTONE_CONDUCTOR_TAGS:-$ROUTING_HIGH_RISK_TAGS}"
+      elif [ "$diff_line_count_available" = true ] && [ "$DIFF_LINE_COUNT" -le "$ROUTING_SMALL_MAX_DIFF_LINES" ] 2>/dev/null; then
         routing_decision="small"
         routing_reason="$DIFF_LINE_COUNT <= $ROUTING_SMALL_MAX_DIFF_LINES diff lines"
         [ -n "$ROUTING_SMALL_WITH" ] && CONDUCTOR_WITH="${TOUCHSTONE_CONDUCTOR_WITH:-$ROUTING_SMALL_WITH}"
@@ -273,8 +370,8 @@ if [ "$ROUTING_ENABLED" = true ]; then
         [ -n "$ROUTING_SMALL_EFFORT" ] && CONDUCTOR_EFFORT="${TOUCHSTONE_CONDUCTOR_EFFORT:-$ROUTING_SMALL_EFFORT}"
         [ -n "$ROUTING_SMALL_TAGS" ] && CONDUCTOR_TAGS="${TOUCHSTONE_CONDUCTOR_TAGS:-$ROUTING_SMALL_TAGS}"
       elif [ "$diff_line_count_available" = true ]; then
-        routing_decision="large"
-        routing_reason="$DIFF_LINE_COUNT > $ROUTING_SMALL_MAX_DIFF_LINES diff lines"
+        routing_decision="large-low-risk"
+        routing_reason="$DIFF_LINE_COUNT > $ROUTING_SMALL_MAX_DIFF_LINES diff lines; no high-risk paths"
         [ -n "$ROUTING_LARGE_WITH" ] && CONDUCTOR_WITH="${TOUCHSTONE_CONDUCTOR_WITH:-$ROUTING_LARGE_WITH}"
         [ -n "$ROUTING_LARGE_PREFER" ] && CONDUCTOR_PREFER="${TOUCHSTONE_CONDUCTOR_PREFER:-$ROUTING_LARGE_PREFER}"
         [ -n "$ROUTING_LARGE_EFFORT" ] && CONDUCTOR_EFFORT="${TOUCHSTONE_CONDUCTOR_EFFORT:-$ROUTING_LARGE_EFFORT}"

--- a/bootstrap/review.sh
+++ b/bootstrap/review.sh
@@ -137,6 +137,7 @@ scripts/codex-review.sh
 architecture/
 docs/architecture/
 principles/"
+FULL_CONTEXT_PATHS=""
 CONFIG_MODE=""
 
 strip_quotes() {
@@ -214,6 +215,11 @@ if [ -f "$CONFIG_FILE" ]; then
           high_risk_prefer) ROUTING_HIGH_RISK_PREFER="$(toml_unquote "$value")" ;;
           high_risk_effort) ROUTING_HIGH_RISK_EFFORT="$(toml_unquote "$value")" ;;
           high_risk_tags) ROUTING_HIGH_RISK_TAGS="$(toml_normalize_array "$value")" ;;
+        esac
+        ;;
+      "review.context")
+        case "$key" in
+          full_context_paths | full_context_patterns) FULL_CONTEXT_PATHS="$(toml_normalize_array "$value" | tr ',' '\n')" ;;
         esac
         ;;
     esac
@@ -340,6 +346,12 @@ find_high_risk_reason() {
   match="$(find_path_matching_patterns "$CHANGED_PATHS" "$ARCHITECTURAL_PATHS" || true)"
   if [ -n "$match" ]; then
     printf 'architectural path %s' "$match"
+    return 0
+  fi
+
+  match="$(find_path_matching_patterns "$CHANGED_PATHS" "$FULL_CONTEXT_PATHS" || true)"
+  if [ -n "$match" ]; then
+    printf 'configured full-context path %s' "$match"
     return 0
   fi
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -84,25 +84,27 @@ Conductor logs its route decision (provider, cost estimate, token count, wall-cl
 | `[review.conductor].with` | unset | Pin a specific provider (bypasses auto-routing) |
 | `[review.conductor].exclude` | `["ollama"]` | Exclude providers from auto-routing; set `exclude = []` to opt local providers back in |
 | `[review.routing].enabled` | true | Route by diff size |
-| `[review.routing].small_max_diff_lines` | 400 | Diffs ≤ this use the `small_*` knobs; diffs above use the `large_*` knobs |
+| `[review.routing].small_max_diff_lines` | 400 | Diffs ≤ this use the `small_*` knobs unless high-risk paths are touched |
 | `[review.routing].small_prefer` | `"cheapest"` | Routing preference for small diffs |
 | `[review.routing].small_effort` | `"minimal"` | Thinking effort for small diffs |
 | `[review.routing].small_with` | unset | Pin provider for small diffs |
 | `[review.routing].small_tags` | unset | e.g. `"code-review"` for small diffs |
 | `[review.routing].large_prefer` | `"best"` | Routing preference for larger low-risk diffs |
 | `[review.routing].large_effort` | `"medium"` | Thinking effort for larger low-risk diffs |
+| `[review.routing].large_with` | unset | Pin provider for larger low-risk diffs |
+| `[review.routing].large_tags` | unset | e.g. `"code-review,long-context"` for larger low-risk diffs |
 | `[review.routing].high_risk_prefer` | `"best"` | Routing preference when unsafe or architectural paths are touched |
 | `[review.routing].high_risk_effort` | `"high"` | Thinking effort when unsafe or architectural paths are touched |
-| `[review.routing].large_with` | unset | Pin provider for larger diffs |
-| `[review.routing].large_tags` | unset | e.g. `"code-review,long-context"` |
+| `[review.routing].high_risk_with` | unset | Pin provider when unsafe, architectural, or configured full-context paths are touched |
+| `[review.routing].high_risk_tags` | unset | e.g. `"code-review,long-context"` for high-risk diffs |
 | `[review.context].mode` | `"auto"` | `auto` prunes low-risk diffs; `full` always loads full project context |
 | `[review.context].small_max_diff_lines` | 400 | Max diff lines for bounded prompt context |
 | `[review.context].small_max_files` | 4 | Max changed files for bounded prompt context |
 | `[review.context].full_context_paths` | [] | Extra path patterns that always require full `AGENTS.md`/`CLAUDE.md` context |
 
-Routing uses a single cutoff (`small_max_diff_lines`): diffs at or below it go through the `small_*` bucket, everything else through the `large_*` bucket. There is no separate `large_max_diff_lines`. The default route is `cheapest`/`minimal` for diffs up to 400 lines and `best`/`high` above that. Use `TOUCHSTONE_CONDUCTOR_EFFORT=max` when release-level scrutiny is worth the extra latency. Explicit `TOUCHSTONE_CONDUCTOR_*` environment variables still win over bucket defaults.
+Routing uses a single cutoff (`small_max_diff_lines`) plus path risk. Diffs at or below the cutoff use the `small_*` bucket unless they touch `unsafe_paths`, built-in architectural paths, or configured `full_context_paths`; those use `high_risk_*`. Diffs above the cutoff use `large_*` only when they are low-risk. The default route is `cheapest`/`minimal` for small low-risk diffs, `best`/`medium` for larger low-risk diffs, and `best`/`high` for high-risk diffs. There is no separate `large_max_diff_lines`. Use `TOUCHSTONE_CONDUCTOR_EFFORT=max` when release-level scrutiny is worth the extra latency. Explicit `TOUCHSTONE_CONDUCTOR_*` environment variables still win over bucket defaults.
 
-Prompt-context pruning is separate from provider routing. In `auto` mode, the hook uses bounded context only when the diff stays within both small limits and avoids `unsafe_paths`, built-in architectural files, and configured `full_context_paths`. The prompt states when full context was intentionally omitted and why.
+Prompt-context pruning is separate from provider routing, but uses the same path-risk checks. In `auto` mode, the hook uses bounded context for low-risk diffs, including large or broad diffs, and uses full context for `unsafe_paths`, built-in architectural files, and configured `full_context_paths`. The prompt states when full context was intentionally omitted and why.
 
 ### Retired in 2.0
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -89,11 +89,13 @@ Conductor logs its route decision (provider, cost estimate, token count, wall-cl
 | `[review.routing].small_effort` | `"minimal"` | Thinking effort for small diffs |
 | `[review.routing].small_with` | unset | Pin provider for small diffs |
 | `[review.routing].small_tags` | unset | e.g. `"code-review"` for small diffs |
-| `[review.routing].large_prefer` | `"best"` | Routing preference for larger diffs |
-| `[review.routing].large_effort` | `"high"` | Thinking effort for larger diffs |
+| `[review.routing].large_prefer` | `"best"` | Routing preference for larger low-risk diffs |
+| `[review.routing].large_effort` | `"medium"` | Thinking effort for larger low-risk diffs |
+| `[review.routing].high_risk_prefer` | `"best"` | Routing preference when unsafe or architectural paths are touched |
+| `[review.routing].high_risk_effort` | `"high"` | Thinking effort when unsafe or architectural paths are touched |
 | `[review.routing].large_with` | unset | Pin provider for larger diffs |
 | `[review.routing].large_tags` | unset | e.g. `"code-review,long-context"` |
-| `[review.context].mode` | `"auto"` | `auto` prunes small/simple diffs; `full` always loads full project context |
+| `[review.context].mode` | `"auto"` | `auto` prunes low-risk diffs; `full` always loads full project context |
 | `[review.context].small_max_diff_lines` | 400 | Max diff lines for bounded prompt context |
 | `[review.context].small_max_files` | 4 | Max changed files for bounded prompt context |
 | `[review.context].full_context_paths` | [] | Extra path patterns that always require full `AGENTS.md`/`CLAUDE.md` context |

--- a/hooks/codex-review.config.example.toml
+++ b/hooks/codex-review.config.example.toml
@@ -113,16 +113,17 @@ exclude = ["ollama"]
 # --------------------------------------------------------------------------
 # Routing by diff size (default)
 # --------------------------------------------------------------------------
-# Touchstone defaults to cheap + shallow review for small diffs and high-effort
-# review for larger changes. Use TOUCHSTONE_CONDUCTOR_EFFORT=max for
-# release-level scrutiny when the extra latency is intentional. Explicit
+# Touchstone defaults to cheap + shallow review for small diffs, bounded
+# medium-effort review for low-risk large diffs, and high-effort review when
+# high-risk or architectural paths are touched. Use TOUCHSTONE_CONDUCTOR_EFFORT=max
+# for release-level scrutiny when the extra latency is intentional. Explicit
 # TOUCHSTONE_CONDUCTOR_* env vars still win at invocation time, and enabled =
 # false opts out.
 #
-# Routing uses a single cutoff (small_max_diff_lines): diffs at or below it
-# go through the small_* bucket, everything above through the large_* bucket.
-# There is no separate large_max_diff_lines — setting one would be silently
-# ignored by the parser.
+# Routing uses a single cutoff (small_max_diff_lines): diffs at or below it go
+# through the small_* bucket. Any diff touching unsafe paths, built-in
+# architectural paths, or configured full-context paths uses high_risk_*.
+# Larger low-risk diffs use large_*.
 #
 # [review.routing]
 # enabled = true
@@ -130,19 +131,21 @@ exclude = ["ollama"]
 # small_prefer = "cheapest"
 # small_effort = "minimal"
 # large_prefer = "best"
-# large_effort = "high"
+# large_effort = "medium"
+# high_risk_prefer = "best"
+# high_risk_effort = "high"
 # # Optional: pin or retag either bucket.
 # # small_with = "ollama"
-# # large_tags = "code-review,long-context"
+# # high_risk_tags = "code-review,long-context"
 
 # --------------------------------------------------------------------------
 # Prompt context pruning (optional)
 # --------------------------------------------------------------------------
-# By default, small/simple diffs use a bounded prompt context instead of asking
-# the reviewer to load full AGENTS.md and CLAUDE.md. Full context is still used
-# for large diffs, broad diffs, unsafe_paths, built-in architectural files
-# (AGENTS.md, CLAUDE.md, .codex-review.toml, .github/workflows/, etc.), and
-# any project patterns listed below.
+# By default, low-risk diffs use a bounded prompt context instead of asking the
+# reviewer to load full AGENTS.md and CLAUDE.md, even when the diff is large or
+# broad. Full context is still used for unsafe_paths, built-in architectural
+# files (AGENTS.md, CLAUDE.md, .codex-review.toml, .github/workflows/, etc.),
+# and any project patterns listed below.
 #
 # [review.context]
 # mode = "auto"                  # auto | full | bounded

--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -399,8 +399,12 @@ ROUTING_SMALL_EFFORT="minimal"
 ROUTING_SMALL_TAGS=""
 ROUTING_LARGE_WITH=""
 ROUTING_LARGE_PREFER="best"
-ROUTING_LARGE_EFFORT="high"
+ROUTING_LARGE_EFFORT="medium"
 ROUTING_LARGE_TAGS=""
+ROUTING_HIGH_RISK_WITH=""
+ROUTING_HIGH_RISK_PREFER="best"
+ROUTING_HIGH_RISK_EFFORT="high"
+ROUTING_HIGH_RISK_TAGS=""
 ROUTING_DECISION="default"
 PROMPT_CONTEXT_MODE="${CODEX_REVIEW_CONTEXT_MODE:-auto}"
 PROMPT_CONTEXT_SMALL_MAX_DIFF_LINES="${CODEX_REVIEW_CONTEXT_SMALL_MAX_DIFF_LINES:-400}"
@@ -771,6 +775,10 @@ if [ -f "$CONFIG_FILE" ]; then
           large_prefer) ROUTING_LARGE_PREFER="$(toml_unquote "$value")" ;;
           large_effort) ROUTING_LARGE_EFFORT="$(toml_unquote "$value")" ;;
           large_tags) ROUTING_LARGE_TAGS="$(toml_unquote "$value")" ;;
+          high_risk_with) ROUTING_HIGH_RISK_WITH="$(toml_unquote "$value")" ;;
+          high_risk_prefer) ROUTING_HIGH_RISK_PREFER="$(toml_unquote "$value")" ;;
+          high_risk_effort) ROUTING_HIGH_RISK_EFFORT="$(toml_unquote "$value")" ;;
+          high_risk_tags) ROUTING_HIGH_RISK_TAGS="$(toml_unquote "$value")" ;;
           small_reviewers)
             if [[ "$value" == "["* ]]; then
               append_routing_small_reviewers_csv "$(toml_normalize_array "$value")"
@@ -1089,10 +1097,35 @@ find_path_matching_context_patterns() {
   return 1
 }
 
+find_full_context_reason() {
+  local changed_paths="$1"
+  local match
+
+  match="$(find_path_matching_context_patterns "$changed_paths" "$UNSAFE_PATHS" || true)"
+  if [ -n "$match" ]; then
+    printf 'high-risk path %s' "$match"
+    return 0
+  fi
+
+  match="$(find_path_matching_context_patterns "$changed_paths" "$PROMPT_CONTEXT_ARCHITECTURAL_PATHS" || true)"
+  if [ -n "$match" ]; then
+    printf 'architectural path %s' "$match"
+    return 0
+  fi
+
+  match="$(find_path_matching_context_patterns "$changed_paths" "$PROMPT_CONTEXT_FULL_PATHS" || true)"
+  if [ -n "$match" ]; then
+    printf 'configured full-context path %s' "$match"
+    return 0
+  fi
+
+  return 1
+}
+
 select_prompt_context_mode() {
   local diff_lines="$1"
   local changed_paths="$2"
-  local requested match
+  local requested full_reason size_reason
 
   PROMPT_CONTEXT_CHANGED_FILES="$(printf '%s\n' "$changed_paths" | sed '/^$/d' | wc -l | tr -d ' ')"
   requested="$(printf '%s' "${PROMPT_CONTEXT_MODE:-auto}" | tr '[:upper:]' '[:lower:]')"
@@ -1127,41 +1160,26 @@ select_prompt_context_mode() {
       ;;
   esac
 
-  match="$(find_path_matching_context_patterns "$changed_paths" "$UNSAFE_PATHS" || true)"
-  if [ -n "$match" ]; then
+  full_reason="$(find_full_context_reason "$changed_paths" || true)"
+  if [ -n "$full_reason" ]; then
     PROMPT_CONTEXT_DECISION="full"
-    PROMPT_CONTEXT_REASON="high-risk path $match"
+    PROMPT_CONTEXT_REASON="$full_reason"
     return 0
   fi
 
-  match="$(find_path_matching_context_patterns "$changed_paths" "$PROMPT_CONTEXT_ARCHITECTURAL_PATHS" || true)"
-  if [ -n "$match" ]; then
-    PROMPT_CONTEXT_DECISION="full"
-    PROMPT_CONTEXT_REASON="architectural path $match"
-    return 0
-  fi
-
-  match="$(find_path_matching_context_patterns "$changed_paths" "$PROMPT_CONTEXT_FULL_PATHS" || true)"
-  if [ -n "$match" ]; then
-    PROMPT_CONTEXT_DECISION="full"
-    PROMPT_CONTEXT_REASON="configured full-context path $match"
-    return 0
-  fi
-
-  if [ "$diff_lines" -gt "$PROMPT_CONTEXT_SMALL_MAX_DIFF_LINES" ] 2>/dev/null; then
-    PROMPT_CONTEXT_DECISION="full"
-    PROMPT_CONTEXT_REASON="large diff ($diff_lines > $PROMPT_CONTEXT_SMALL_MAX_DIFF_LINES lines)"
-    return 0
-  fi
-
-  if [ "$PROMPT_CONTEXT_CHANGED_FILES" -gt "$PROMPT_CONTEXT_SMALL_MAX_FILES" ] 2>/dev/null; then
-    PROMPT_CONTEXT_DECISION="full"
-    PROMPT_CONTEXT_REASON="broad diff ($PROMPT_CONTEXT_CHANGED_FILES > $PROMPT_CONTEXT_SMALL_MAX_FILES files)"
-    return 0
+  if [ "$diff_lines" -gt "$PROMPT_CONTEXT_SMALL_MAX_DIFF_LINES" ] 2>/dev/null \
+    && [ "$PROMPT_CONTEXT_CHANGED_FILES" -gt "$PROMPT_CONTEXT_SMALL_MAX_FILES" ] 2>/dev/null; then
+    size_reason="low-risk large/broad diff ($diff_lines > $PROMPT_CONTEXT_SMALL_MAX_DIFF_LINES lines, $PROMPT_CONTEXT_CHANGED_FILES > $PROMPT_CONTEXT_SMALL_MAX_FILES files)"
+  elif [ "$diff_lines" -gt "$PROMPT_CONTEXT_SMALL_MAX_DIFF_LINES" ] 2>/dev/null; then
+    size_reason="low-risk large diff ($diff_lines > $PROMPT_CONTEXT_SMALL_MAX_DIFF_LINES lines)"
+  elif [ "$PROMPT_CONTEXT_CHANGED_FILES" -gt "$PROMPT_CONTEXT_SMALL_MAX_FILES" ] 2>/dev/null; then
+    size_reason="low-risk broad diff ($PROMPT_CONTEXT_CHANGED_FILES > $PROMPT_CONTEXT_SMALL_MAX_FILES files)"
+  else
+    size_reason="small/simple diff ($diff_lines <= $PROMPT_CONTEXT_SMALL_MAX_DIFF_LINES lines, $PROMPT_CONTEXT_CHANGED_FILES <= $PROMPT_CONTEXT_SMALL_MAX_FILES files)"
   fi
 
   PROMPT_CONTEXT_DECISION="bounded"
-  PROMPT_CONTEXT_REASON="small/simple diff ($diff_lines <= $PROMPT_CONTEXT_SMALL_MAX_DIFF_LINES lines, $PROMPT_CONTEXT_CHANGED_FILES <= $PROMPT_CONTEXT_SMALL_MAX_FILES files) with no high-risk, architectural, or configured full-context path matches"
+  PROMPT_CONTEXT_REASON="$size_reason with no high-risk, architectural, or configured full-context path matches"
 }
 
 build_prompt_context_instructions() {
@@ -1170,7 +1188,7 @@ build_prompt_context_instructions() {
 ## Project context mode
 
 Full AGENTS.md and CLAUDE.md context was intentionally omitted because this is a $PROMPT_CONTEXT_REASON.
-Use the bounded project review context below. Do not spend context loading AGENTS.md or CLAUDE.md for this small/simple review.
+Use the bounded project review context below. Do not spend context loading AGENTS.md or CLAUDE.md unless the diff itself makes that necessary.
 
 Bounded project review context:
 - Review only concrete correctness, safety, compatibility, and test-coverage risks in this diff.
@@ -1480,6 +1498,8 @@ resolve_assist_reviewer() {
 
 apply_review_routing() {
   local diff_lines="$1"
+  local changed_paths="${2:-}"
+  local risk_reason
 
   is_truthy "$ROUTING_ENABLED" || return 0
   [ -z "${TOUCHSTONE_REVIEWER:-}" ] || return 0
@@ -1502,7 +1522,17 @@ apply_review_routing() {
     ROUTING_LARGE_REVIEWERS=("${REVIEWER_CASCADE[@]}")
   fi
 
-  if [ "$diff_lines" -le "$ROUTING_SMALL_MAX_DIFF_LINES" ] 2>/dev/null; then
+  risk_reason="$(find_full_context_reason "$changed_paths" || true)"
+
+  if [ -n "$risk_reason" ]; then
+    REVIEWER_CASCADE=("${ROUTING_LARGE_REVIEWERS[@]}")
+    ROUTING_DECISION="high-risk"
+    [ -n "$ROUTING_HIGH_RISK_WITH" ] && CONDUCTOR_WITH="${TOUCHSTONE_CONDUCTOR_WITH:-$ROUTING_HIGH_RISK_WITH}"
+    [ -n "$ROUTING_HIGH_RISK_PREFER" ] && CONDUCTOR_PREFER="${TOUCHSTONE_CONDUCTOR_PREFER:-$ROUTING_HIGH_RISK_PREFER}"
+    [ -n "$ROUTING_HIGH_RISK_EFFORT" ] && CONDUCTOR_EFFORT="${TOUCHSTONE_CONDUCTOR_EFFORT:-$ROUTING_HIGH_RISK_EFFORT}"
+    [ -n "$ROUTING_HIGH_RISK_TAGS" ] && CONDUCTOR_TAGS="${TOUCHSTONE_CONDUCTOR_TAGS:-$ROUTING_HIGH_RISK_TAGS}"
+    echo "==> Review routing: high-risk diff ($risk_reason; $diff_lines lines) — with=${CONDUCTOR_WITH:-auto} prefer=$CONDUCTOR_PREFER effort=$CONDUCTOR_EFFORT"
+  elif [ "$diff_lines" -le "$ROUTING_SMALL_MAX_DIFF_LINES" ] 2>/dev/null; then
     REVIEWER_CASCADE=("${ROUTING_SMALL_REVIEWERS[@]}")
     ROUTING_DECISION="small"
     # Apply 2.0 small-bucket overrides. Non-empty fields win; env still
@@ -1515,12 +1545,12 @@ apply_review_routing() {
     echo "==> Review routing: small diff ($diff_lines <= $ROUTING_SMALL_MAX_DIFF_LINES) — with=${CONDUCTOR_WITH:-auto} prefer=$CONDUCTOR_PREFER effort=$CONDUCTOR_EFFORT"
   else
     REVIEWER_CASCADE=("${ROUTING_LARGE_REVIEWERS[@]}")
-    ROUTING_DECISION="large"
+    ROUTING_DECISION="large-low-risk"
     [ -n "$ROUTING_LARGE_WITH" ] && CONDUCTOR_WITH="${TOUCHSTONE_CONDUCTOR_WITH:-$ROUTING_LARGE_WITH}"
     [ -n "$ROUTING_LARGE_PREFER" ] && CONDUCTOR_PREFER="${TOUCHSTONE_CONDUCTOR_PREFER:-$ROUTING_LARGE_PREFER}"
     [ -n "$ROUTING_LARGE_EFFORT" ] && CONDUCTOR_EFFORT="${TOUCHSTONE_CONDUCTOR_EFFORT:-$ROUTING_LARGE_EFFORT}"
     [ -n "$ROUTING_LARGE_TAGS" ] && CONDUCTOR_TAGS="${TOUCHSTONE_CONDUCTOR_TAGS:-$ROUTING_LARGE_TAGS}"
-    echo "==> Review routing: larger diff ($diff_lines > $ROUTING_SMALL_MAX_DIFF_LINES) — with=${CONDUCTOR_WITH:-auto} prefer=$CONDUCTOR_PREFER effort=$CONDUCTOR_EFFORT"
+    echo "==> Review routing: larger low-risk diff ($diff_lines > $ROUTING_SMALL_MAX_DIFF_LINES) — with=${CONDUCTOR_WITH:-auto} prefer=$CONDUCTOR_PREFER effort=$CONDUCTOR_EFFORT"
   fi
 }
 
@@ -1878,7 +1908,8 @@ if [ -n "$(git status --porcelain)" ]; then
 fi
 
 ROUTING_DIFF_LINE_COUNT="$(git diff "$MERGE_BASE"..HEAD | wc -l | tr -d ' ')"
-apply_review_routing "$ROUTING_DIFF_LINE_COUNT"
+PROMPT_CONTEXT_CHANGED_PATHS="$(git diff --name-only "$MERGE_BASE"..HEAD 2>/dev/null || true)"
+apply_review_routing "$ROUTING_DIFF_LINE_COUNT" "$PROMPT_CONTEXT_CHANGED_PATHS"
 
 # Resolve which reviewer to use from the cascade.
 if ! resolve_reviewer; then
@@ -1906,7 +1937,6 @@ if ! resolve_reviewer; then
   exit 0
 fi
 REVIEWER_LABEL="$(reviewer_label)"
-PROMPT_CONTEXT_CHANGED_PATHS="$(git diff --name-only "$MERGE_BASE"..HEAD 2>/dev/null || true)"
 select_prompt_context_mode "$ROUTING_DIFF_LINE_COUNT" "$PROMPT_CONTEXT_CHANGED_PATHS"
 echo "==> Using reviewer: $REVIEWER_LABEL"
 echo "==> Prompt context: $PROMPT_CONTEXT_DECISION ($PROMPT_CONTEXT_REASON)"
@@ -2868,6 +2898,7 @@ print_summary() {
   fi
   printf "  ${C_DIM}mode:           %s${C_RESET}\n" "$REVIEW_MODE"
   printf "  ${C_DIM}context:        %s${C_RESET}\n" "$PROMPT_CONTEXT_DECISION"
+  printf "  ${C_DIM}budget:         prefer=%s effort=%s${C_RESET}\n" "${CONDUCTOR_PREFER:-auto}" "${CONDUCTOR_EFFORT:-default}"
   printf "  ${C_DIM}files:          %s${C_RESET}\n" "$REVIEW_FILES_INSPECTED"
   printf "  ${C_DIM}diff lines:     %s${C_RESET}\n" "$DIFF_LINE_COUNT"
   printf "  ${C_DIM}iterations:     %s/%s${C_RESET}\n" "${iter:-0}" "$MAX_ITERATIONS"
@@ -2879,8 +2910,8 @@ print_summary() {
   printf "  ${C_DIM}──────────────────────────────────────────${C_RESET}\n"
 
   if [ -n "${CODEX_REVIEW_SUMMARY_FILE:-}" ]; then
-    printf '{"reviewer":"%s","provider":"%s","model":"%s","peer_provider":"%s","route":"%s","mode":"%s","files":%d,"diff_lines":%d,"iterations":%d,"fix_commits":%d,"peer_assists":%d,"findings":%d,"exit_reason":"%s","elapsed_seconds":%d}\n' \
-      "$REVIEWER_LABEL" "$provider" "$model" "$peer_provider" "$ROUTING_DECISION" "$REVIEW_MODE" "$REVIEW_FILES_INSPECTED" "$DIFF_LINE_COUNT" \
+    printf '{"reviewer":"%s","provider":"%s","model":"%s","peer_provider":"%s","route":"%s","mode":"%s","context":"%s","prefer":"%s","effort":"%s","files":%d,"diff_lines":%d,"iterations":%d,"fix_commits":%d,"peer_assists":%d,"findings":%d,"exit_reason":"%s","elapsed_seconds":%d}\n' \
+      "$REVIEWER_LABEL" "$provider" "$model" "$peer_provider" "$ROUTING_DECISION" "$REVIEW_MODE" "$PROMPT_CONTEXT_DECISION" "${CONDUCTOR_PREFER:-auto}" "${CONDUCTOR_EFFORT:-default}" "$REVIEW_FILES_INSPECTED" "$DIFF_LINE_COUNT" \
       "${iter:-0}" "$FIX_COMMITS" "$ASSIST_ROUNDS" "$findings" "$REVIEW_EXIT_REASON" "$elapsed" \
       >"$CODEX_REVIEW_SUMMARY_FILE" 2>/dev/null || true
   fi

--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -417,6 +417,7 @@ GEMINI.md
 .codex-review-context.md
 .github/codex-review-context.md
 .github/workflows/
+bootstrap/
 hooks/codex-review.sh
 hooks/codex-review.config.example.toml
 scripts/codex-review.sh

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -399,8 +399,12 @@ ROUTING_SMALL_EFFORT="minimal"
 ROUTING_SMALL_TAGS=""
 ROUTING_LARGE_WITH=""
 ROUTING_LARGE_PREFER="best"
-ROUTING_LARGE_EFFORT="high"
+ROUTING_LARGE_EFFORT="medium"
 ROUTING_LARGE_TAGS=""
+ROUTING_HIGH_RISK_WITH=""
+ROUTING_HIGH_RISK_PREFER="best"
+ROUTING_HIGH_RISK_EFFORT="high"
+ROUTING_HIGH_RISK_TAGS=""
 ROUTING_DECISION="default"
 PROMPT_CONTEXT_MODE="${CODEX_REVIEW_CONTEXT_MODE:-auto}"
 PROMPT_CONTEXT_SMALL_MAX_DIFF_LINES="${CODEX_REVIEW_CONTEXT_SMALL_MAX_DIFF_LINES:-400}"
@@ -771,6 +775,10 @@ if [ -f "$CONFIG_FILE" ]; then
           large_prefer) ROUTING_LARGE_PREFER="$(toml_unquote "$value")" ;;
           large_effort) ROUTING_LARGE_EFFORT="$(toml_unquote "$value")" ;;
           large_tags) ROUTING_LARGE_TAGS="$(toml_unquote "$value")" ;;
+          high_risk_with) ROUTING_HIGH_RISK_WITH="$(toml_unquote "$value")" ;;
+          high_risk_prefer) ROUTING_HIGH_RISK_PREFER="$(toml_unquote "$value")" ;;
+          high_risk_effort) ROUTING_HIGH_RISK_EFFORT="$(toml_unquote "$value")" ;;
+          high_risk_tags) ROUTING_HIGH_RISK_TAGS="$(toml_unquote "$value")" ;;
           small_reviewers)
             if [[ "$value" == "["* ]]; then
               append_routing_small_reviewers_csv "$(toml_normalize_array "$value")"
@@ -1089,10 +1097,35 @@ find_path_matching_context_patterns() {
   return 1
 }
 
+find_full_context_reason() {
+  local changed_paths="$1"
+  local match
+
+  match="$(find_path_matching_context_patterns "$changed_paths" "$UNSAFE_PATHS" || true)"
+  if [ -n "$match" ]; then
+    printf 'high-risk path %s' "$match"
+    return 0
+  fi
+
+  match="$(find_path_matching_context_patterns "$changed_paths" "$PROMPT_CONTEXT_ARCHITECTURAL_PATHS" || true)"
+  if [ -n "$match" ]; then
+    printf 'architectural path %s' "$match"
+    return 0
+  fi
+
+  match="$(find_path_matching_context_patterns "$changed_paths" "$PROMPT_CONTEXT_FULL_PATHS" || true)"
+  if [ -n "$match" ]; then
+    printf 'configured full-context path %s' "$match"
+    return 0
+  fi
+
+  return 1
+}
+
 select_prompt_context_mode() {
   local diff_lines="$1"
   local changed_paths="$2"
-  local requested match
+  local requested full_reason size_reason
 
   PROMPT_CONTEXT_CHANGED_FILES="$(printf '%s\n' "$changed_paths" | sed '/^$/d' | wc -l | tr -d ' ')"
   requested="$(printf '%s' "${PROMPT_CONTEXT_MODE:-auto}" | tr '[:upper:]' '[:lower:]')"
@@ -1127,41 +1160,26 @@ select_prompt_context_mode() {
       ;;
   esac
 
-  match="$(find_path_matching_context_patterns "$changed_paths" "$UNSAFE_PATHS" || true)"
-  if [ -n "$match" ]; then
+  full_reason="$(find_full_context_reason "$changed_paths" || true)"
+  if [ -n "$full_reason" ]; then
     PROMPT_CONTEXT_DECISION="full"
-    PROMPT_CONTEXT_REASON="high-risk path $match"
+    PROMPT_CONTEXT_REASON="$full_reason"
     return 0
   fi
 
-  match="$(find_path_matching_context_patterns "$changed_paths" "$PROMPT_CONTEXT_ARCHITECTURAL_PATHS" || true)"
-  if [ -n "$match" ]; then
-    PROMPT_CONTEXT_DECISION="full"
-    PROMPT_CONTEXT_REASON="architectural path $match"
-    return 0
-  fi
-
-  match="$(find_path_matching_context_patterns "$changed_paths" "$PROMPT_CONTEXT_FULL_PATHS" || true)"
-  if [ -n "$match" ]; then
-    PROMPT_CONTEXT_DECISION="full"
-    PROMPT_CONTEXT_REASON="configured full-context path $match"
-    return 0
-  fi
-
-  if [ "$diff_lines" -gt "$PROMPT_CONTEXT_SMALL_MAX_DIFF_LINES" ] 2>/dev/null; then
-    PROMPT_CONTEXT_DECISION="full"
-    PROMPT_CONTEXT_REASON="large diff ($diff_lines > $PROMPT_CONTEXT_SMALL_MAX_DIFF_LINES lines)"
-    return 0
-  fi
-
-  if [ "$PROMPT_CONTEXT_CHANGED_FILES" -gt "$PROMPT_CONTEXT_SMALL_MAX_FILES" ] 2>/dev/null; then
-    PROMPT_CONTEXT_DECISION="full"
-    PROMPT_CONTEXT_REASON="broad diff ($PROMPT_CONTEXT_CHANGED_FILES > $PROMPT_CONTEXT_SMALL_MAX_FILES files)"
-    return 0
+  if [ "$diff_lines" -gt "$PROMPT_CONTEXT_SMALL_MAX_DIFF_LINES" ] 2>/dev/null \
+    && [ "$PROMPT_CONTEXT_CHANGED_FILES" -gt "$PROMPT_CONTEXT_SMALL_MAX_FILES" ] 2>/dev/null; then
+    size_reason="low-risk large/broad diff ($diff_lines > $PROMPT_CONTEXT_SMALL_MAX_DIFF_LINES lines, $PROMPT_CONTEXT_CHANGED_FILES > $PROMPT_CONTEXT_SMALL_MAX_FILES files)"
+  elif [ "$diff_lines" -gt "$PROMPT_CONTEXT_SMALL_MAX_DIFF_LINES" ] 2>/dev/null; then
+    size_reason="low-risk large diff ($diff_lines > $PROMPT_CONTEXT_SMALL_MAX_DIFF_LINES lines)"
+  elif [ "$PROMPT_CONTEXT_CHANGED_FILES" -gt "$PROMPT_CONTEXT_SMALL_MAX_FILES" ] 2>/dev/null; then
+    size_reason="low-risk broad diff ($PROMPT_CONTEXT_CHANGED_FILES > $PROMPT_CONTEXT_SMALL_MAX_FILES files)"
+  else
+    size_reason="small/simple diff ($diff_lines <= $PROMPT_CONTEXT_SMALL_MAX_DIFF_LINES lines, $PROMPT_CONTEXT_CHANGED_FILES <= $PROMPT_CONTEXT_SMALL_MAX_FILES files)"
   fi
 
   PROMPT_CONTEXT_DECISION="bounded"
-  PROMPT_CONTEXT_REASON="small/simple diff ($diff_lines <= $PROMPT_CONTEXT_SMALL_MAX_DIFF_LINES lines, $PROMPT_CONTEXT_CHANGED_FILES <= $PROMPT_CONTEXT_SMALL_MAX_FILES files) with no high-risk, architectural, or configured full-context path matches"
+  PROMPT_CONTEXT_REASON="$size_reason with no high-risk, architectural, or configured full-context path matches"
 }
 
 build_prompt_context_instructions() {
@@ -1170,7 +1188,7 @@ build_prompt_context_instructions() {
 ## Project context mode
 
 Full AGENTS.md and CLAUDE.md context was intentionally omitted because this is a $PROMPT_CONTEXT_REASON.
-Use the bounded project review context below. Do not spend context loading AGENTS.md or CLAUDE.md for this small/simple review.
+Use the bounded project review context below. Do not spend context loading AGENTS.md or CLAUDE.md unless the diff itself makes that necessary.
 
 Bounded project review context:
 - Review only concrete correctness, safety, compatibility, and test-coverage risks in this diff.
@@ -1480,6 +1498,8 @@ resolve_assist_reviewer() {
 
 apply_review_routing() {
   local diff_lines="$1"
+  local changed_paths="${2:-}"
+  local risk_reason
 
   is_truthy "$ROUTING_ENABLED" || return 0
   [ -z "${TOUCHSTONE_REVIEWER:-}" ] || return 0
@@ -1502,7 +1522,17 @@ apply_review_routing() {
     ROUTING_LARGE_REVIEWERS=("${REVIEWER_CASCADE[@]}")
   fi
 
-  if [ "$diff_lines" -le "$ROUTING_SMALL_MAX_DIFF_LINES" ] 2>/dev/null; then
+  risk_reason="$(find_full_context_reason "$changed_paths" || true)"
+
+  if [ -n "$risk_reason" ]; then
+    REVIEWER_CASCADE=("${ROUTING_LARGE_REVIEWERS[@]}")
+    ROUTING_DECISION="high-risk"
+    [ -n "$ROUTING_HIGH_RISK_WITH" ] && CONDUCTOR_WITH="${TOUCHSTONE_CONDUCTOR_WITH:-$ROUTING_HIGH_RISK_WITH}"
+    [ -n "$ROUTING_HIGH_RISK_PREFER" ] && CONDUCTOR_PREFER="${TOUCHSTONE_CONDUCTOR_PREFER:-$ROUTING_HIGH_RISK_PREFER}"
+    [ -n "$ROUTING_HIGH_RISK_EFFORT" ] && CONDUCTOR_EFFORT="${TOUCHSTONE_CONDUCTOR_EFFORT:-$ROUTING_HIGH_RISK_EFFORT}"
+    [ -n "$ROUTING_HIGH_RISK_TAGS" ] && CONDUCTOR_TAGS="${TOUCHSTONE_CONDUCTOR_TAGS:-$ROUTING_HIGH_RISK_TAGS}"
+    echo "==> Review routing: high-risk diff ($risk_reason; $diff_lines lines) — with=${CONDUCTOR_WITH:-auto} prefer=$CONDUCTOR_PREFER effort=$CONDUCTOR_EFFORT"
+  elif [ "$diff_lines" -le "$ROUTING_SMALL_MAX_DIFF_LINES" ] 2>/dev/null; then
     REVIEWER_CASCADE=("${ROUTING_SMALL_REVIEWERS[@]}")
     ROUTING_DECISION="small"
     # Apply 2.0 small-bucket overrides. Non-empty fields win; env still
@@ -1515,12 +1545,12 @@ apply_review_routing() {
     echo "==> Review routing: small diff ($diff_lines <= $ROUTING_SMALL_MAX_DIFF_LINES) — with=${CONDUCTOR_WITH:-auto} prefer=$CONDUCTOR_PREFER effort=$CONDUCTOR_EFFORT"
   else
     REVIEWER_CASCADE=("${ROUTING_LARGE_REVIEWERS[@]}")
-    ROUTING_DECISION="large"
+    ROUTING_DECISION="large-low-risk"
     [ -n "$ROUTING_LARGE_WITH" ] && CONDUCTOR_WITH="${TOUCHSTONE_CONDUCTOR_WITH:-$ROUTING_LARGE_WITH}"
     [ -n "$ROUTING_LARGE_PREFER" ] && CONDUCTOR_PREFER="${TOUCHSTONE_CONDUCTOR_PREFER:-$ROUTING_LARGE_PREFER}"
     [ -n "$ROUTING_LARGE_EFFORT" ] && CONDUCTOR_EFFORT="${TOUCHSTONE_CONDUCTOR_EFFORT:-$ROUTING_LARGE_EFFORT}"
     [ -n "$ROUTING_LARGE_TAGS" ] && CONDUCTOR_TAGS="${TOUCHSTONE_CONDUCTOR_TAGS:-$ROUTING_LARGE_TAGS}"
-    echo "==> Review routing: larger diff ($diff_lines > $ROUTING_SMALL_MAX_DIFF_LINES) — with=${CONDUCTOR_WITH:-auto} prefer=$CONDUCTOR_PREFER effort=$CONDUCTOR_EFFORT"
+    echo "==> Review routing: larger low-risk diff ($diff_lines > $ROUTING_SMALL_MAX_DIFF_LINES) — with=${CONDUCTOR_WITH:-auto} prefer=$CONDUCTOR_PREFER effort=$CONDUCTOR_EFFORT"
   fi
 }
 
@@ -1878,7 +1908,8 @@ if [ -n "$(git status --porcelain)" ]; then
 fi
 
 ROUTING_DIFF_LINE_COUNT="$(git diff "$MERGE_BASE"..HEAD | wc -l | tr -d ' ')"
-apply_review_routing "$ROUTING_DIFF_LINE_COUNT"
+PROMPT_CONTEXT_CHANGED_PATHS="$(git diff --name-only "$MERGE_BASE"..HEAD 2>/dev/null || true)"
+apply_review_routing "$ROUTING_DIFF_LINE_COUNT" "$PROMPT_CONTEXT_CHANGED_PATHS"
 
 # Resolve which reviewer to use from the cascade.
 if ! resolve_reviewer; then
@@ -1906,7 +1937,6 @@ if ! resolve_reviewer; then
   exit 0
 fi
 REVIEWER_LABEL="$(reviewer_label)"
-PROMPT_CONTEXT_CHANGED_PATHS="$(git diff --name-only "$MERGE_BASE"..HEAD 2>/dev/null || true)"
 select_prompt_context_mode "$ROUTING_DIFF_LINE_COUNT" "$PROMPT_CONTEXT_CHANGED_PATHS"
 echo "==> Using reviewer: $REVIEWER_LABEL"
 echo "==> Prompt context: $PROMPT_CONTEXT_DECISION ($PROMPT_CONTEXT_REASON)"
@@ -2868,6 +2898,7 @@ print_summary() {
   fi
   printf "  ${C_DIM}mode:           %s${C_RESET}\n" "$REVIEW_MODE"
   printf "  ${C_DIM}context:        %s${C_RESET}\n" "$PROMPT_CONTEXT_DECISION"
+  printf "  ${C_DIM}budget:         prefer=%s effort=%s${C_RESET}\n" "${CONDUCTOR_PREFER:-auto}" "${CONDUCTOR_EFFORT:-default}"
   printf "  ${C_DIM}files:          %s${C_RESET}\n" "$REVIEW_FILES_INSPECTED"
   printf "  ${C_DIM}diff lines:     %s${C_RESET}\n" "$DIFF_LINE_COUNT"
   printf "  ${C_DIM}iterations:     %s/%s${C_RESET}\n" "${iter:-0}" "$MAX_ITERATIONS"
@@ -2879,8 +2910,8 @@ print_summary() {
   printf "  ${C_DIM}──────────────────────────────────────────${C_RESET}\n"
 
   if [ -n "${CODEX_REVIEW_SUMMARY_FILE:-}" ]; then
-    printf '{"reviewer":"%s","provider":"%s","model":"%s","peer_provider":"%s","route":"%s","mode":"%s","files":%d,"diff_lines":%d,"iterations":%d,"fix_commits":%d,"peer_assists":%d,"findings":%d,"exit_reason":"%s","elapsed_seconds":%d}\n' \
-      "$REVIEWER_LABEL" "$provider" "$model" "$peer_provider" "$ROUTING_DECISION" "$REVIEW_MODE" "$REVIEW_FILES_INSPECTED" "$DIFF_LINE_COUNT" \
+    printf '{"reviewer":"%s","provider":"%s","model":"%s","peer_provider":"%s","route":"%s","mode":"%s","context":"%s","prefer":"%s","effort":"%s","files":%d,"diff_lines":%d,"iterations":%d,"fix_commits":%d,"peer_assists":%d,"findings":%d,"exit_reason":"%s","elapsed_seconds":%d}\n' \
+      "$REVIEWER_LABEL" "$provider" "$model" "$peer_provider" "$ROUTING_DECISION" "$REVIEW_MODE" "$PROMPT_CONTEXT_DECISION" "${CONDUCTOR_PREFER:-auto}" "${CONDUCTOR_EFFORT:-default}" "$REVIEW_FILES_INSPECTED" "$DIFF_LINE_COUNT" \
       "${iter:-0}" "$FIX_COMMITS" "$ASSIST_ROUNDS" "$findings" "$REVIEW_EXIT_REASON" "$elapsed" \
       >"$CODEX_REVIEW_SUMMARY_FILE" 2>/dev/null || true
   fi

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -417,6 +417,7 @@ GEMINI.md
 .codex-review-context.md
 .github/codex-review-context.md
 .github/workflows/
+bootstrap/
 hooks/codex-review.sh
 hooks/codex-review.config.example.toml
 scripts/codex-review.sh

--- a/tests/test-review-dry-run.sh
+++ b/tests/test-review-dry-run.sh
@@ -190,6 +190,27 @@ else
 fi
 
 # ----------------------------------------------------------------------------
+echo "==> Test: built-in bootstrap path keeps best/high"
+REPO_BOOTSTRAP="$TEST_DIR/repo-bootstrap-risk"
+new_repo "$REPO_BOOTSTRAP"
+mkdir -p "$REPO_BOOTSTRAP/bootstrap"
+commit_new_file_with_diff_lines "$REPO_BOOTSTRAP" 401 bootstrap/new-project.sh
+
+: >"$ARGS_FILE"
+out="$(run_review "$REPO_BOOTSTRAP" --dry-run --base HEAD~1 2>&1)"
+
+if grep -q '\-\-prefer best' "$ARGS_FILE" \
+  && grep -q '\-\-effort high' "$ARGS_FILE" \
+  && echo "$out" | grep -q 'routing:     high-risk (architectural path bootstrap/new-project.sh'; then
+  echo "==> PASS: built-in bootstrap path kept best/high bucket"
+else
+  echo "FAIL: built-in bootstrap path should use high-risk routing bucket" >&2
+  echo "args: $(cat "$ARGS_FILE")" >&2
+  echo "out: $out" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ----------------------------------------------------------------------------
 echo "==> Test: explicit routing opt-out preserves global conductor config"
 REPO_DISABLED="$TEST_DIR/repo-routing-disabled"
 new_repo "$REPO_DISABLED"

--- a/tests/test-review-dry-run.sh
+++ b/tests/test-review-dry-run.sh
@@ -143,7 +143,7 @@ else
 fi
 
 # ----------------------------------------------------------------------------
-echo "==> Test: large default route uses best/high"
+echo "==> Test: low-risk large default route uses best/medium"
 REPO_LARGE="$TEST_DIR/repo-large"
 new_repo "$REPO_LARGE"
 commit_new_file_with_diff_lines "$REPO_LARGE" 401 large.txt
@@ -152,11 +152,38 @@ commit_new_file_with_diff_lines "$REPO_LARGE" 401 large.txt
 out="$(run_review "$REPO_LARGE" --dry-run --base HEAD~1 2>&1)"
 
 if grep -q '\-\-prefer best' "$ARGS_FILE" \
-  && grep -q '\-\-effort high' "$ARGS_FILE" \
-  && echo "$out" | grep -q 'routing:     large (401 > 400 diff lines)'; then
-  echo "==> PASS: 401-line diff used large best/high bucket"
+  && grep -q '\-\-effort medium' "$ARGS_FILE" \
+  && echo "$out" | grep -q 'routing:     large-low-risk (401 > 400 diff lines; no high-risk paths)'; then
+  echo "==> PASS: 401-line low-risk diff used large best/medium bucket"
 else
-  echo "FAIL: large diff should use large routing bucket" >&2
+  echo "FAIL: low-risk large diff should use bounded large routing bucket" >&2
+  echo "args: $(cat "$ARGS_FILE")" >&2
+  echo "out: $out" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ----------------------------------------------------------------------------
+echo "==> Test: high-risk large default route keeps best/high"
+REPO_HIGH_RISK="$TEST_DIR/repo-high-risk-large"
+new_repo "$REPO_HIGH_RISK"
+cat >"$REPO_HIGH_RISK/.codex-review.toml" <<'EOF'
+[codex_review]
+unsafe_paths = ["critical/"]
+EOF
+git -C "$REPO_HIGH_RISK" add .codex-review.toml
+git -C "$REPO_HIGH_RISK" commit -qm cfg
+mkdir -p "$REPO_HIGH_RISK/critical"
+commit_new_file_with_diff_lines "$REPO_HIGH_RISK" 401 critical/large.txt
+
+: >"$ARGS_FILE"
+out="$(run_review "$REPO_HIGH_RISK" --dry-run --base HEAD~1 2>&1)"
+
+if grep -q '\-\-prefer best' "$ARGS_FILE" \
+  && grep -q '\-\-effort high' "$ARGS_FILE" \
+  && echo "$out" | grep -q 'routing:     high-risk (high-risk path critical/large.txt'; then
+  echo "==> PASS: 401-line high-risk diff kept best/high bucket"
+else
+  echo "FAIL: high-risk large diff should use high-risk routing bucket" >&2
   echo "args: $(cat "$ARGS_FILE")" >&2
   echo "out: $out" >&2
   ERRORS=$((ERRORS + 1))

--- a/tests/test-review-dry-run.sh
+++ b/tests/test-review-dry-run.sh
@@ -211,6 +211,35 @@ else
 fi
 
 # ----------------------------------------------------------------------------
+echo "==> Test: configured full-context path keeps best/high"
+REPO_FULL_CONTEXT="$TEST_DIR/repo-full-context-risk"
+new_repo "$REPO_FULL_CONTEXT"
+cat >"$REPO_FULL_CONTEXT/.codex-review.toml" <<'EOF'
+[review.context]
+full_context_paths = ["docs/"]
+EOF
+git -C "$REPO_FULL_CONTEXT" add .codex-review.toml
+git -C "$REPO_FULL_CONTEXT" commit -qm cfg
+mkdir -p "$REPO_FULL_CONTEXT/docs"
+printf 'doc change\n' >"$REPO_FULL_CONTEXT/docs/note.md"
+git -C "$REPO_FULL_CONTEXT" add docs/note.md
+git -C "$REPO_FULL_CONTEXT" commit -qm "touch docs"
+
+: >"$ARGS_FILE"
+out="$(run_review "$REPO_FULL_CONTEXT" --dry-run --base HEAD~1 2>&1)"
+
+if grep -q '\-\-prefer best' "$ARGS_FILE" \
+  && grep -q '\-\-effort high' "$ARGS_FILE" \
+  && echo "$out" | grep -q 'routing:     high-risk (configured full-context path docs/note.md'; then
+  echo "==> PASS: configured full-context path kept best/high bucket"
+else
+  echo "FAIL: configured full-context path should use high-risk routing bucket" >&2
+  echo "args: $(cat "$ARGS_FILE")" >&2
+  echo "out: $out" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ----------------------------------------------------------------------------
 echo "==> Test: explicit routing opt-out preserves global conductor config"
 REPO_DISABLED="$TEST_DIR/repo-routing-disabled"
 new_repo "$REPO_DISABLED"

--- a/tests/test-review-hook.sh
+++ b/tests/test-review-hook.sh
@@ -1333,9 +1333,16 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
-echo "==> Test: large diffs keep full AGENTS/CLAUDE context"
+echo "==> Test: low-risk large diffs use bounded prompt context"
 setup_ctx_repo
 setup_ctx_bin
+printf 'AGENTS_FULL_CONTEXT_MARKER\n' >"$CTX_REPO/AGENTS.md"
+printf 'CLAUDE_FULL_CONTEXT_MARKER\n' >"$CTX_REPO/CLAUDE.md"
+git -C "$CTX_REPO" add AGENTS.md CLAUDE.md
+git -C "$CTX_REPO" commit -m "add steering before large diff" >/dev/null 2>&1
+printf 'large prompt context change\n' >>"$CTX_REPO/example.txt"
+git -C "$CTX_REPO" add example.txt
+git -C "$CTX_REPO" commit -m "large prompt context change" >/dev/null 2>&1
 (
   cd "$CTX_REPO"
   PATH="$CTX_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
@@ -1346,12 +1353,13 @@ setup_ctx_bin
     bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$CTX_OUTPUT" 2>&1
 )
 
-if grep -q 'Full project context is required because large diff' "$CTX_PROMPT" \
-  && grep -q 'Read AGENTS.md at the repo root' "$CTX_PROMPT" \
-  && grep -q 'Prompt context: full' "$CTX_OUTPUT"; then
-  echo "==> PASS: large diff kept full prompt context"
+if grep -q 'low-risk large diff' "$CTX_PROMPT" \
+  && grep -q 'Bounded project review context' "$CTX_PROMPT" \
+  && ! grep -q 'Read AGENTS.md at the repo root' "$CTX_PROMPT" \
+  && grep -q 'Prompt context: bounded' "$CTX_OUTPUT"; then
+  echo "==> PASS: low-risk large diff used bounded prompt context"
 else
-  echo "FAIL: expected full prompt context for large diff" >&2
+  echo "FAIL: expected bounded prompt context for low-risk large diff" >&2
   sed -n '1,80p' "$CTX_PROMPT" >&2
   cat "$CTX_OUTPUT" >&2
   ERRORS=$((ERRORS + 1))

--- a/tests/test-review-hook.sh
+++ b/tests/test-review-hook.sh
@@ -1390,6 +1390,38 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
+echo "==> Test: bootstrap scripts keep full AGENTS/CLAUDE context"
+setup_ctx_repo
+setup_ctx_bin
+mkdir -p "$CTX_REPO/bootstrap"
+cat >"$CTX_REPO/bootstrap/new-project.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'bootstrap review guidance\n'
+EOF
+git -C "$CTX_REPO" add bootstrap/new-project.sh
+git -C "$CTX_REPO" commit -m "touch bootstrap script" >/dev/null 2>&1
+
+(
+  cd "$CTX_REPO"
+  PATH="$CTX_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CTX_PROMPT="$CTX_PROMPT" \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    TOUCHSTONE_NO_PREFLIGHT=1 \
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$CTX_OUTPUT" 2>&1
+)
+
+if grep -q 'Full project context is required because architectural path bootstrap/new-project.sh' "$CTX_PROMPT" \
+  && grep -q 'Prompt context: full' "$CTX_OUTPUT"; then
+  echo "==> PASS: bootstrap script kept full prompt context"
+else
+  echo "FAIL: expected full prompt context for bootstrap script" >&2
+  sed -n '1,80p' "$CTX_PROMPT" >&2
+  cat "$CTX_OUTPUT" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
 echo "==> Test: unsafe paths keep full AGENTS/CLAUDE context"
 setup_ctx_repo
 setup_ctx_bin


### PR DESCRIPTION
## Linked Issues

Closes #274

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
