### PR TITLE
fix: run merge review fix loop

### DIFF
--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -978,8 +978,8 @@ fi
 # Mode resolution
 # --------------------------------------------------------------------------
 # Modes: review-only, fix, diff-only, no-tests
-#   review-only — read + bash, no edits, no git ops (default for merge review)
-#   fix         — full access, auto-fix + commit (default for pre-push)
+#   review-only — read + bash, no edits, no git ops
+#   fix         — full access, auto-fix + commit (default)
 #   diff-only   — read-only, no bash, no edits
 #   no-tests    — edit + commit, no bash (skip test execution)
 

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -978,8 +978,8 @@ fi
 # Mode resolution
 # --------------------------------------------------------------------------
 # Modes: review-only, fix, diff-only, no-tests
-#   review-only — read + bash, no edits, no git ops (default for merge review)
-#   fix         — full access, auto-fix + commit (default for pre-push)
+#   review-only — read + bash, no edits, no git ops
+#   fix         — full access, auto-fix + commit (default)
 #   diff-only   — read-only, no bash, no edits
 #   no-tests    — edit + commit, no bash (skip test execution)
 

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -537,8 +537,78 @@ print_failed_checks_and_exit() {
   exit 1
 }
 
+wait_for_clean_merge_state() {
+  local sleep_seconds
+
+  echo "==> Checking merge state for PR #$PR_NUMBER ..."
+  STATE=""
+  MERGEABLE=""
+  MERGE_STATE_RETRY_DELAYS=(1 2 5 10 30 30 30 30 30)
+  for attempt in 1 2 3 4 5 6 7 8 9 10; do
+    MERGE_STATE="$(gh pr view "$PR_NUMBER" --json mergeStateStatus,mergeable --template '{{.mergeStateStatus}} {{.mergeable}}' 2>/dev/null || echo '')"
+    STATE="${MERGE_STATE%% *}"
+    MERGEABLE="${MERGE_STATE#* }"
+    [ -n "$STATE" ] || STATE="UNKNOWN"
+    [ -n "$MERGEABLE" ] || MERGEABLE="UNKNOWN"
+    echo "    attempt $attempt: mergeStateStatus=$STATE mergeable=$MERGEABLE"
+    if [ "$STATE" = "CLEAN" ] && [ "$MERGEABLE" = "MERGEABLE" ]; then
+      return 0
+    fi
+    FAILED_CHECKS="$(failed_checks)"
+    if [ -n "$FAILED_CHECKS" ]; then
+      print_failed_checks_and_exit "$FAILED_CHECKS"
+    fi
+    if [ "$MERGEABLE" = "CONFLICTING" ] || [ "$STATE" = "DIRTY" ] || [ "$STATE" = "BEHIND" ] || [ "$STATE" = "CONFLICTING" ]; then
+      echo "ERROR: PR #$PR_NUMBER is $STATE — has conflicts or is out of date with base." >&2
+      echo "       Final merge state: mergeStateStatus=$STATE mergeable=$MERGEABLE." >&2
+      echo "       Rebase or resolve conflicts on the PR branch before merging." >&2
+      TOUCHSTONE_MERGE_FAILURE_REASON="not-mergeable"
+      exit 1
+    fi
+    if [ "$attempt" -lt 10 ]; then
+      sleep_seconds="${MERGE_STATE_RETRY_DELAYS[$((attempt - 1))]}"
+      # Tests may set MERGE_PR_SLEEP_OVERRIDE=0 to exercise retry behavior
+      # without waiting for the production backoff schedule.
+      if [ -n "${MERGE_PR_SLEEP_OVERRIDE+x}" ]; then
+        sleep_seconds="$MERGE_PR_SLEEP_OVERRIDE"
+      fi
+      sleep "$sleep_seconds"
+    fi
+  done
+
+  echo "ERROR: PR #$PR_NUMBER is not cleanly mergeable (state=$STATE mergeable=$MERGEABLE)." >&2
+  echo "       Inspect manually: gh pr view $PR_NUMBER --web" >&2
+  TOUCHSTONE_MERGE_FAILURE_REASON="not-mergeable"
+  exit 1
+}
+
+wait_for_pr_head() {
+  local expected_head="$1"
+  local actual_head sleep_seconds
+
+  for attempt in 1 2 3 4 5; do
+    actual_head="$(gh pr view "$PR_NUMBER" --json headRefOid --jq '.headRefOid' 2>/dev/null || echo "")"
+    if [ "$actual_head" = "$expected_head" ]; then
+      return 0
+    fi
+    echo "    waiting for PR head update (attempt $attempt): ${actual_head:-unknown}"
+    if [ "$attempt" -lt 5 ]; then
+      sleep_seconds="${MERGE_PR_SLEEP_OVERRIDE:-2}"
+      sleep "$sleep_seconds"
+    fi
+  done
+
+  echo "ERROR: PR #$PR_NUMBER head did not update to reviewed commit $expected_head." >&2
+  echo "       Last observed head: ${actual_head:-unknown}" >&2
+  TOUCHSTONE_MERGE_FAILURE_REASON="head-not-updated"
+  exit 1
+}
+
 run_preflight_gate() {
   local base_ref="$1"
+  local label="${2:-before merge review}"
+  local event_mode="${3:-merge}"
+  local head_sha
 
   if ! truthy "$PREFLIGHT_REQUIRED"; then
     echo "==> Preflight disabled by [review].preflight_required=false."
@@ -553,16 +623,18 @@ run_preflight_gate() {
     return 0
   fi
 
-  echo "==> Running deterministic preflight before merge review (diff vs $base_ref) ..."
-  touchstone_emit_event preflight_started pr_number="$PR_NUMBER" mode=merge
+  echo "==> Running deterministic preflight $label (diff vs $base_ref) ..."
+  touchstone_emit_event preflight_started pr_number="$PR_NUMBER" mode="$event_mode"
   if touchstone_preflight_main_sanitized --diff "$base_ref" "$(git rev-parse --show-toplevel)"; then
-    touchstone_emit_event preflight_clean pr_number="$PR_NUMBER" head_sha="$pr_head_oid"
+    head_sha="$(git rev-parse HEAD 2>/dev/null || echo "")"
+    touchstone_emit_event preflight_clean pr_number="$PR_NUMBER" head_sha="$head_sha"
     return 0
   fi
 
   echo "ERROR: Deterministic preflight failed; refusing to spend provider tokens on review." >&2
   echo "       Fix the preflight failure or set TOUCHSTONE_NO_PREFLIGHT=1 for an emergency bypass." >&2
-  touchstone_emit_event preflight_blocked pr_number="$PR_NUMBER" head_sha="$pr_head_oid"
+  head_sha="$(git rev-parse HEAD 2>/dev/null || echo "")"
+  touchstone_emit_event preflight_blocked pr_number="$PR_NUMBER" head_sha="$head_sha"
   TOUCHSTONE_MERGE_FAILURE_REASON="preflight-blocked"
   return 1
 }
@@ -699,23 +771,24 @@ run_merge_review() {
     exit 1
   fi
 
-  run_preflight_gate "$default_base_ref" || return $?
+  run_preflight_gate "$default_base_ref" "before merge review" "merge" || return $?
 
   echo "==> Running merge review ..."
   local review_rc=0
   local review_output_file
+  local reviewed_head_after
   review_output_file="$(mktemp -t touchstone-merge-review.XXXXXX.txt)"
   REVIEW_SUMMARY_FILE="$(git rev-parse --git-path "touchstone/review-summary-pr-${PR_NUMBER}.json" 2>/dev/null || echo "")"
   if [ -n "$REVIEW_SUMMARY_FILE" ]; then
     mkdir -p "$(dirname "$REVIEW_SUMMARY_FILE")" 2>/dev/null || true
     rm -f "$REVIEW_SUMMARY_FILE" 2>/dev/null || true
   fi
-  touchstone_emit_event review_started pr_number="$PR_NUMBER" mode=review-only
+  touchstone_emit_event review_started pr_number="$PR_NUMBER" mode=fix
   set +e
   CODEX_REVIEW_BASE="$default_base_ref" \
     CODEX_REVIEW_BRANCH_NAME="$pr_head_branch" \
     CODEX_REVIEW_FORCE=1 \
-    CODEX_REVIEW_MODE=review-only \
+    CODEX_REVIEW_MODE=fix \
     CODEX_REVIEW_ON_ERROR=fail-closed \
     TOUCHSTONE_PREFLIGHT_ALREADY_RAN=1 \
     CODEX_REVIEW_SUMMARY_FILE="$REVIEW_SUMMARY_FILE" \
@@ -725,7 +798,29 @@ run_merge_review() {
 
   if [ "$review_rc" -eq 0 ]; then
     rm -f "$review_output_file"
-    touchstone_emit_event review_clean pr_number="$PR_NUMBER" head_sha="$pr_head_oid"
+    reviewed_head_after="$(git rev-parse HEAD 2>/dev/null || echo "")"
+    if [ -z "$reviewed_head_after" ]; then
+      echo "ERROR: Could not resolve reviewed HEAD after merge review." >&2
+      TOUCHSTONE_MERGE_FAILURE_REASON="missing-reviewed-head"
+      return 1
+    fi
+    REVIEWED_HEAD_OID="$reviewed_head_after"
+    if [ "$reviewed_head_after" != "$pr_head_oid" ]; then
+      echo "==> Merge review changed HEAD:"
+      echo "    before: $pr_head_oid"
+      echo "    after:  $reviewed_head_after"
+      echo "==> Running deterministic postflight after review fixes ..."
+      run_preflight_gate "$default_base_ref" "after review fixes" "post-review" || return $?
+      echo "==> Pushing review fix commit(s) to PR branch $pr_head_branch ..."
+      if ! git push origin "HEAD:refs/heads/$pr_head_branch"; then
+        echo "ERROR: Failed to push review fix commit(s) to PR branch $pr_head_branch." >&2
+        TOUCHSTONE_MERGE_FAILURE_REASON="push-review-fixes"
+        return 1
+      fi
+      wait_for_pr_head "$reviewed_head_after"
+      wait_for_clean_merge_state
+    fi
+    touchstone_emit_event review_clean pr_number="$PR_NUMBER" head_sha="$reviewed_head_after"
     return 0
   fi
 
@@ -755,48 +850,7 @@ if [ "$PR_STATE" != "OPEN" ]; then
 fi
 
 # 2. Check mergeability with retries (GitHub's status can lag after a push).
-echo "==> Checking merge state for PR #$PR_NUMBER ..."
-STATE=""
-MERGEABLE=""
-MERGE_STATE_RETRY_DELAYS=(1 2 5 10 30 30 30 30 30)
-for attempt in 1 2 3 4 5 6 7 8 9 10; do
-  MERGE_STATE="$(gh pr view "$PR_NUMBER" --json mergeStateStatus,mergeable --template '{{.mergeStateStatus}} {{.mergeable}}' 2>/dev/null || echo '')"
-  STATE="${MERGE_STATE%% *}"
-  MERGEABLE="${MERGE_STATE#* }"
-  [ -n "$STATE" ] || STATE="UNKNOWN"
-  [ -n "$MERGEABLE" ] || MERGEABLE="UNKNOWN"
-  echo "    attempt $attempt: mergeStateStatus=$STATE mergeable=$MERGEABLE"
-  if [ "$STATE" = "CLEAN" ] && [ "$MERGEABLE" = "MERGEABLE" ]; then
-    break
-  fi
-  FAILED_CHECKS="$(failed_checks)"
-  if [ -n "$FAILED_CHECKS" ]; then
-    print_failed_checks_and_exit "$FAILED_CHECKS"
-  fi
-  if [ "$MERGEABLE" = "CONFLICTING" ] || [ "$STATE" = "DIRTY" ] || [ "$STATE" = "BEHIND" ] || [ "$STATE" = "CONFLICTING" ]; then
-    echo "ERROR: PR #$PR_NUMBER is $STATE — has conflicts or is out of date with base." >&2
-    echo "       Final merge state: mergeStateStatus=$STATE mergeable=$MERGEABLE." >&2
-    echo "       Rebase or resolve conflicts on the PR branch before merging." >&2
-    TOUCHSTONE_MERGE_FAILURE_REASON="not-mergeable"
-    exit 1
-  fi
-  if [ "$attempt" -lt 10 ]; then
-    sleep_seconds="${MERGE_STATE_RETRY_DELAYS[$((attempt - 1))]}"
-    # Tests may set MERGE_PR_SLEEP_OVERRIDE=0 to exercise retry behavior
-    # without waiting for the production backoff schedule.
-    if [ -n "${MERGE_PR_SLEEP_OVERRIDE+x}" ]; then
-      sleep_seconds="$MERGE_PR_SLEEP_OVERRIDE"
-    fi
-    sleep "$sleep_seconds"
-  fi
-done
-
-if [ "$STATE" != "CLEAN" ] || [ "$MERGEABLE" != "MERGEABLE" ]; then
-  echo "ERROR: PR #$PR_NUMBER is not cleanly mergeable (state=$STATE mergeable=$MERGEABLE)." >&2
-  echo "       Inspect manually: gh pr view $PR_NUMBER --web" >&2
-  TOUCHSTONE_MERGE_FAILURE_REASON="not-mergeable"
-  exit 1
-fi
+wait_for_clean_merge_state
 
 # 3. Run AI review as the merge gate.
 run_merge_review

--- a/tests/test-merge-pr-dirty-tree-narrow.sh
+++ b/tests/test-merge-pr-dirty-tree-narrow.sh
@@ -209,7 +209,7 @@ tests/test-merge-pr.sh" \
 if grep -q '==> Working tree has uncommitted changes outside PR #123' "$TEST_DIR/output-outside.txt" \
   && grep -q '==> Running merge review' "$TEST_DIR/output-outside.txt" \
   && grep -q '^CODEX_REVIEW_BASE=origin/main$' "$TEST_DIR/codex-review.log" \
-  && grep -q '^CODEX_REVIEW_MODE=review-only$' "$TEST_DIR/codex-review.log" \
+  && grep -q '^CODEX_REVIEW_MODE=fix$' "$TEST_DIR/codex-review.log" \
   && grep -q '==> Done\.' "$TEST_DIR/output-outside.txt" \
   && ! grep -q 'refusing to run review' "$TEST_DIR/output-outside.txt"; then
   echo "==> PASS: unrelated dirty path does not block the review"

--- a/tests/test-merge-pr.sh
+++ b/tests/test-merge-pr.sh
@@ -27,6 +27,9 @@ set -euo pipefail
 if [ -n "${CODEX_REVIEW_STUB_OUTPUT:-}" ]; then
   printf '%s\n' "$CODEX_REVIEW_STUB_OUTPUT"
 fi
+if [ -n "${CODEX_REVIEW_MUTATE_HEAD:-}" ]; then
+  printf '%s\n' "$CODEX_REVIEW_MUTATE_HEAD" > "$GIT_REVIEW_HEAD_FILE"
+fi
 exit "${CODEX_REVIEW_EXIT:-0}"
 EOF
 chmod +x "$MERGE_SCRIPT_DIR/merge-pr.sh" "$MERGE_SCRIPT_DIR/codex-review.sh"
@@ -49,7 +52,13 @@ case "${1:-} ${2:-}" in
         fi
         ;;
       headRefName) echo "feature/test" ;;
-      headRefOid) echo "pr-head-oid" ;;
+      headRefOid)
+        if [ -f "${GH_HEAD_REF_FILE:-/dev/null/never}" ]; then
+          cat "$GH_HEAD_REF_FILE"
+        else
+          echo "pr-head-oid"
+        fi
+        ;;
       mergeStateStatus,mergeable) echo "${GH_MERGE_STATE:-CLEAN MERGEABLE}" ;;
       *)
         echo "unexpected gh pr view args: $*" >&2
@@ -83,7 +92,8 @@ case "${1:-} ${2:-}" in
     ;;
   "pr merge")
     printf '%s\n' "$*" > "$GH_MERGE_ARGS_FILE"
-    if [ "${4:-} ${5:-} ${6:-} ${7:-}" != "--squash --delete-branch --match-head-commit pr-head-oid" ]; then
+    expected_head="${GH_EXPECT_MERGE_HEAD:-pr-head-oid}"
+    if [ "${4:-} ${5:-} ${6:-} ${7:-}" != "--squash --delete-branch --match-head-commit $expected_head" ]; then
       echo "unexpected gh pr merge args: $*" >&2
       exit 1
     fi
@@ -142,6 +152,8 @@ case "$*" in
       echo "main-oid"
     elif [ -f "$GIT_DETACHED_DEFAULT_FILE" ]; then
       echo "main-oid"
+    elif [ -f "$GIT_REVIEW_HEAD_FILE" ]; then
+      cat "$GIT_REVIEW_HEAD_FILE"
     elif [ -f "$GH_CHECKOUT_FILE" ]; then
       echo "pr-head-oid"
     else
@@ -192,6 +204,11 @@ case "$*" in
   "pull --rebase")
     echo "Already up to date."
     ;;
+  "push origin HEAD:refs/heads/feature/test")
+    git rev-parse HEAD > "$GIT_PUSH_HEAD_FILE"
+    cp "$GIT_PUSH_HEAD_FILE" "$GH_HEAD_REF_FILE"
+    echo "pushed"
+    ;;
   "branch -D feature/test")
     echo "deleted feature/test" > "$GIT_BRANCH_DELETED_FILE"
     echo "Deleted branch feature/test (was pr-head-oid)."
@@ -211,7 +228,9 @@ reset_case_files() {
     "$TEST_DIR"/gh-merge-args* "$TEST_DIR"/gh-merge-body* \
     "$TEST_DIR"/gh-comment* "$TEST_DIR"/git-checkout-main* \
     "$TEST_DIR"/git-detached-default* "$TEST_DIR"/git-branch-deleted* \
-    "$TEST_DIR"/git-sibling-pull* "$TEST_DIR"/gh-merged-marker*
+    "$TEST_DIR"/git-sibling-pull* "$TEST_DIR"/gh-merged-marker* \
+    "$TEST_DIR"/git-review-head* "$TEST_DIR"/git-push-head* \
+    "$TEST_DIR"/gh-head-ref* "$TEST_DIR"/preflight-calls*
   rm -rf "$GIT_PATH_ROOT"
   mkdir -p "$GIT_PATH_ROOT"
   unset GIT_WORKTREE_LIST
@@ -222,7 +241,9 @@ reset_case_files() {
   unset GH_FAILED_CHECKS
   unset CODEX_REVIEW_EXIT
   unset CODEX_REVIEW_STUB_OUTPUT
+  unset CODEX_REVIEW_MUTATE_HEAD
   unset GIT_LOCAL_BRANCH_HEAD
+  unset GH_EXPECT_MERGE_HEAD
 }
 
 run_merge_pr() {
@@ -236,7 +257,9 @@ run_merge_pr() {
     GH_MERGE_ARGS_FILE="$TEST_DIR/gh-merge-args" \
     GH_MERGE_BODY_FILE="$TEST_DIR/gh-merge-body" \
     GH_COMMENT_FILE="$TEST_DIR/gh-comment" \
+    GH_HEAD_REF_FILE="$TEST_DIR/gh-head-ref" \
     GH_MERGED_MARKER="$TEST_DIR/gh-merged-marker" \
+    GH_EXPECT_MERGE_HEAD="${GH_EXPECT_MERGE_HEAD:-pr-head-oid}" \
     GH_PR_MERGE_FAIL_LOCAL="${GH_PR_MERGE_FAIL_LOCAL:-false}" \
     GH_MERGE_STATE="${GH_MERGE_STATE:-CLEAN MERGEABLE}" \
     GH_FAILED_CHECKS="${GH_FAILED_CHECKS:-}" \
@@ -244,11 +267,15 @@ run_merge_pr() {
     GIT_DETACHED_DEFAULT_FILE="$TEST_DIR/git-detached-default" \
     GIT_BRANCH_DELETED_FILE="$TEST_DIR/git-branch-deleted" \
     GIT_SIBLING_PULL_FILE="$TEST_DIR/git-sibling-pull" \
+    GIT_REVIEW_HEAD_FILE="$TEST_DIR/git-review-head" \
+    GIT_PUSH_HEAD_FILE="$TEST_DIR/git-push-head" \
     GIT_WORKTREE_LIST="${GIT_WORKTREE_LIST:-}" \
     GIT_SIBLING_PULL_FAIL="${GIT_SIBLING_PULL_FAIL:-false}" \
     CODEX_REVIEW_EXIT="${CODEX_REVIEW_EXIT:-0}" \
     CODEX_REVIEW_STUB_OUTPUT="${CODEX_REVIEW_STUB_OUTPUT:-}" \
+    CODEX_REVIEW_MUTATE_HEAD="${CODEX_REVIEW_MUTATE_HEAD:-}" \
     GIT_LOCAL_BRANCH_HEAD="${GIT_LOCAL_BRANCH_HEAD:-pr-head-oid}" \
+    PREFLIGHT_CALLS_FILE="${PREFLIGHT_CALLS_FILE:-}" \
     TEST_CURRENT_WORKTREE="${TEST_CURRENT_WORKTREE:-/tmp/touchstone-feature-worktree}" \
     bash "$MERGE_SCRIPT_DIR/merge-pr.sh" "$@" >"$output_file" 2>&1
 }
@@ -317,7 +344,7 @@ if grep -q 'attempt 1: mergeStateStatus=CLEAN mergeable=MERGEABLE' "$TEST_DIR/ou
   && grep -q '^pr-head-oid$' "$TEST_DIR/gh-merge-head" \
   && grep -q '^CODEX_REVIEW_BASE=origin/main$' "$TEST_DIR/codex-review.log" \
   && grep -q '^CODEX_REVIEW_FORCE=1$' "$TEST_DIR/codex-review.log" \
-  && grep -q '^CODEX_REVIEW_MODE=review-only$' "$TEST_DIR/codex-review.log" \
+  && grep -q '^CODEX_REVIEW_MODE=fix$' "$TEST_DIR/codex-review.log" \
   && grep -q '^CODEX_REVIEW_ON_ERROR=fail-closed$' "$TEST_DIR/codex-review.log" \
   && grep -q '^CODEX_REVIEW_BRANCH_NAME=feature/test$' "$TEST_DIR/codex-review.log" \
   && grep -q "==> Deleting local branch 'feature/test' after verified squash merge of pr-head-oid" "$TEST_DIR/output-normal.txt" \
@@ -326,6 +353,40 @@ if grep -q 'attempt 1: mergeStateStatus=CLEAN mergeable=MERGEABLE' "$TEST_DIR/ou
 else
   echo "FAIL: merge-pr.sh output did not show a successful jq-free merge path" >&2
   cat "$TEST_DIR/output-normal.txt" >&2
+  exit 1
+fi
+
+echo "==> Test: review fix commits are postflighted, pushed, and merged by exact head"
+reset_case_files
+mkdir -p "$TEST_DIR/lib"
+cat >"$TEST_DIR/lib/preflight.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+touchstone_preflight_main_sanitized() {
+  printf '%s\n' "$*" >> "$PREFLIGHT_CALLS_FILE"
+}
+
+touchstone_preflight_main() {
+  touchstone_preflight_main_sanitized "$@"
+}
+EOF
+CODEX_REVIEW_MUTATE_HEAD="review-fixed-head" \
+  GH_EXPECT_MERGE_HEAD="review-fixed-head" \
+  PREFLIGHT_CALLS_FILE="$TEST_DIR/preflight-calls" \
+  run_merge_pr "$TEST_DIR/output-review-fix.txt" 123
+rm -rf "${TEST_DIR:?}/lib"
+if grep -q '==> Merge review changed HEAD:' "$TEST_DIR/output-review-fix.txt" \
+  && grep -q '==> Running deterministic postflight after review fixes' "$TEST_DIR/output-review-fix.txt" \
+  && grep -q '==> Pushing review fix commit(s) to PR branch feature/test' "$TEST_DIR/output-review-fix.txt" \
+  && grep -q '^review-fixed-head$' "$TEST_DIR/git-push-head" \
+  && grep -q '^review-fixed-head$' "$TEST_DIR/gh-merge-head" \
+  && [ "$(wc -l <"$TEST_DIR/preflight-calls" | tr -d ' ')" = "2" ]; then
+  echo "==> PASS: review fix loop pushes the postflighted head before merge"
+else
+  echo "FAIL: review fix commits were not postflighted/pushed/merged correctly" >&2
+  cat "$TEST_DIR/output-review-fix.txt" >&2
+  [ ! -f "$TEST_DIR/preflight-calls" ] || cat "$TEST_DIR/preflight-calls" >&2
   exit 1
 fi
 

--- a/tests/test-review-comment.sh
+++ b/tests/test-review-comment.sh
@@ -92,6 +92,7 @@ case "$*" in
   "rev-parse feature/test") echo "pr-head-oid" ;;
   "rev-parse --verify --quiet origin/main^{commit}") echo "base-oid" ;;
   "rev-parse --git-path touchstone/reviewer-clean") printf '%s\n' "$TEST_REPO_ROOT/.git/touchstone/reviewer-clean" ;;
+  "rev-parse --git-path touchstone/reviewer-findings-history") printf '%s\n' "$TEST_REPO_ROOT/.git/touchstone/reviewer-findings-history" ;;
   "rev-parse --git-path touchstone/squash-map.jsonl") printf '%s\n' "$TEST_REPO_ROOT/.git/touchstone/squash-map.jsonl" ;;
   rev-parse\ --git-path\ touchstone/review-summary-pr-123.json) printf '%s\n' "$TEST_REPO_ROOT/.git/touchstone/review-summary-pr-123.json" ;;
   "fetch origin +refs/heads/main:refs/remotes/origin/main") echo fetched ;;
@@ -139,7 +140,7 @@ echo "==> Test: clean merge review posts a one-line PR comment"
 reset_fixture
 printf '[review]\ncomment_on_clean = true\n' >"$MERGE_DIR/repo/.codex-review.toml"
 run_merge "$TEST_DIR/merge-clean.txt" 123
-if grep -q '^Conductor review clean - provider: claude, model: claude-opus-4-1, peer: none, iterations: 1, mode: review-only, findings: 0$' "$TEST_DIR/comments" \
+if grep -q '^Conductor review clean - provider: claude, model: claude-opus-4-1, peer: none, iterations: 1, mode: fix, findings: 0$' "$TEST_DIR/comments" \
   && grep -q '==> Posted clean-review PR comment\.' "$TEST_DIR/merge-clean.txt"; then
   echo "==> PASS: clean review comment posted"
 else


### PR DESCRIPTION
Run the merge-gate reviewer in fix mode, postflight any reviewer-produced commits, push the reviewed fixed head back to the PR branch, and merge only that exact head.\n\nCloses-issue: #287

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
