### PR TITLE
fix: quiet review hook shellcheck warning

### DIFF
--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -2826,7 +2826,7 @@ parse_primary_provider() {
     return
   fi
 
-  local stderr_file="${1:-$REVIEW_STDERR_FILE}"
+  local stderr_file="$REVIEW_STDERR_FILE"
   [ -f "$stderr_file" ] || {
     printf ''
     return

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -2826,7 +2826,7 @@ parse_primary_provider() {
     return
   fi
 
-  local stderr_file="${1:-$REVIEW_STDERR_FILE}"
+  local stderr_file="$REVIEW_STDERR_FILE"
   [ -f "$stderr_file" ] || {
     printf ''
     return


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
