### PR TITLE
fix: detect installed review hook scope

### DIFF
--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -1253,7 +1253,14 @@ is_touchstone_source_repo() {
 
   repo_root_physical="$(cd "$REPO_ROOT" 2>/dev/null && pwd -P)" || return 1
   touchstone_root_physical="$(cd "$TOUCHSTONE_ROOT" 2>/dev/null && pwd -P)" || return 1
-  [ "$repo_root_physical" = "$touchstone_root_physical" ]
+  [ "$repo_root_physical" = "$touchstone_root_physical" ] || return 1
+
+  # In downstream projects the installed hook runs from scripts/codex-review.sh,
+  # so TOUCHSTONE_ROOT intentionally resolves to the project root. Only disable
+  # sync-slice elision in the actual Touchstone source checkout.
+  [ -f "$repo_root_physical/bootstrap/update-project.sh" ] \
+    && [ -f "$repo_root_physical/hooks/codex-review.sh" ] \
+    && [ -f "$repo_root_physical/bin/touchstone" ]
 }
 
 manifest_paths_at_ref() {

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -1253,7 +1253,14 @@ is_touchstone_source_repo() {
 
   repo_root_physical="$(cd "$REPO_ROOT" 2>/dev/null && pwd -P)" || return 1
   touchstone_root_physical="$(cd "$TOUCHSTONE_ROOT" 2>/dev/null && pwd -P)" || return 1
-  [ "$repo_root_physical" = "$touchstone_root_physical" ]
+  [ "$repo_root_physical" = "$touchstone_root_physical" ] || return 1
+
+  # In downstream projects the installed hook runs from scripts/codex-review.sh,
+  # so TOUCHSTONE_ROOT intentionally resolves to the project root. Only disable
+  # sync-slice elision in the actual Touchstone source checkout.
+  [ -f "$repo_root_physical/bootstrap/update-project.sh" ] \
+    && [ -f "$repo_root_physical/hooks/codex-review.sh" ] \
+    && [ -f "$repo_root_physical/bin/touchstone" ]
 }
 
 manifest_paths_at_ref() {

--- a/tests/test-review-hook.sh
+++ b/tests/test-review-hook.sh
@@ -2544,11 +2544,13 @@ SCOPED_BIN="$TEST_DIR/scoped-large-bin"
 SCOPED_PROMPT="$TEST_DIR/scoped-large-prompt.txt"
 SCOPED_OUTPUT="$TEST_DIR/scoped-large-output.txt"
 SCOPED_SUBCOMMAND="$TEST_DIR/scoped-large-subcommand.txt"
-mkdir -p "$SCOPED_REPO/managed" "$SCOPED_BIN"
+mkdir -p "$SCOPED_REPO/managed" "$SCOPED_REPO/scripts" "$SCOPED_REPO/lib" "$SCOPED_BIN"
 git -C "$SCOPED_REPO" init -q >/dev/null 2>&1
 git -C "$SCOPED_REPO" config user.name "Touchstone Test"
 git -C "$SCOPED_REPO" config user.email "touchstone@example.com"
 cp "$TOUCHSTONE_ROOT/.codex-review.toml" "$SCOPED_REPO/.codex-review.toml"
+cp "$TOUCHSTONE_ROOT/scripts/codex-review.sh" "$SCOPED_REPO/scripts/codex-review.sh"
+cp -r "$TOUCHSTONE_ROOT/lib/"* "$SCOPED_REPO/lib/"
 cat >"$SCOPED_REPO/.touchstone-manifest" <<'EOF'
 # Managed by touchstone.
 .touchstone-manifest
@@ -2590,7 +2592,7 @@ if (
     CODEX_REVIEW_DISABLE_CACHE=1 \
     CODEX_REVIEW_MAX_DIFF_LINES=20 \
     TOUCHSTONE_NO_PREFLIGHT=1 \
-    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$SCOPED_OUTPUT" 2>&1
+    bash "$SCOPED_REPO/scripts/codex-review.sh" >"$SCOPED_OUTPUT" 2>&1
 ); then
   if [ "$(cat "$SCOPED_SUBCOMMAND" 2>/dev/null || true)" = "call" ] \
     && grep -q 'Large-diff scoped review boundary' "$SCOPED_PROMPT" \


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
