### PR TITLE
fix: wait longer for pending PR checks

### DIFF
--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -690,13 +690,18 @@ print_failed_checks_and_exit() {
 }
 
 wait_for_clean_merge_state() {
-  local sleep_seconds
+  local attempt max_attempts sleep_seconds
 
   echo "==> Checking merge state for PR #$PR_NUMBER ..."
   STATE=""
   MERGEABLE=""
   MERGE_STATE_RETRY_DELAYS=(1 2 5 10 30 30 30 30 30)
-  for attempt in 1 2 3 4 5 6 7 8 9 10; do
+  max_attempts="${MERGE_PR_STATE_MAX_ATTEMPTS:-30}"
+  if ! [[ "$max_attempts" =~ ^[0-9]+$ ]] || [ "$max_attempts" -lt 1 ]; then
+    max_attempts=30
+  fi
+  attempt=1
+  while [ "$attempt" -le "$max_attempts" ]; do
     MERGE_STATE="$(gh pr view "$PR_NUMBER" --json mergeStateStatus,mergeable --template '{{.mergeStateStatus}} {{.mergeable}}' 2>/dev/null || echo '')"
     STATE="${MERGE_STATE%% *}"
     MERGEABLE="${MERGE_STATE#* }"
@@ -717,8 +722,8 @@ wait_for_clean_merge_state() {
       TOUCHSTONE_MERGE_FAILURE_REASON="not-mergeable"
       exit 1
     fi
-    if [ "$attempt" -lt 10 ]; then
-      sleep_seconds="${MERGE_STATE_RETRY_DELAYS[$((attempt - 1))]}"
+    if [ "$attempt" -lt "$max_attempts" ]; then
+      sleep_seconds="${MERGE_STATE_RETRY_DELAYS[$((attempt - 1))]:-30}"
       # Tests may set MERGE_PR_SLEEP_OVERRIDE=0 to exercise retry behavior
       # without waiting for the production backoff schedule.
       if [ -n "${MERGE_PR_SLEEP_OVERRIDE+x}" ]; then
@@ -726,9 +731,11 @@ wait_for_clean_merge_state() {
       fi
       sleep "$sleep_seconds"
     fi
+    attempt=$((attempt + 1))
   done
 
   echo "ERROR: PR #$PR_NUMBER is not cleanly mergeable (state=$STATE mergeable=$MERGEABLE)." >&2
+  echo "       Required checks may still be pending; waited $max_attempts merge-state attempts." >&2
   echo "       Inspect manually: gh pr view $PR_NUMBER --web" >&2
   TOUCHSTONE_MERGE_FAILURE_REASON="not-mergeable"
   exit 1

--- a/tests/test-merge-pr-merge-state-retry.sh
+++ b/tests/test-merge-pr-merge-state-retry.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # tests/test-merge-pr-merge-state-retry.sh — verify merge-pr.sh waits through
-# transient UNKNOWN mergeability while fast-failing definite conflict states.
+# transient/pending mergeability while fast-failing definite conflict states.
 #
 set -euo pipefail
 
@@ -52,6 +52,8 @@ case "${1:-} ${2:-}" in
         printf '%s\n' "$attempt" > "$GH_MERGE_ATTEMPTS_FILE"
         if [ -n "${GH_MERGE_STATE_IMMEDIATE:-}" ]; then
           echo "$GH_MERGE_STATE_IMMEDIATE"
+        elif [ "$attempt" -le "${GH_MERGE_STATE_PENDING_ATTEMPTS:-0}" ]; then
+          echo "${GH_MERGE_STATE_PENDING_VALUE:-UNSTABLE MERGEABLE}"
         elif [ "$attempt" -le "${GH_MERGE_STATE_UNKNOWN_ATTEMPTS:-0}" ]; then
           echo "UNKNOWN UNKNOWN"
         else
@@ -178,6 +180,8 @@ reset_case_files() {
   rm -rf "$GIT_PATH_ROOT"
   mkdir -p "$GIT_PATH_ROOT"
   unset GH_MERGE_STATE_UNKNOWN_ATTEMPTS
+  unset GH_MERGE_STATE_PENDING_ATTEMPTS
+  unset GH_MERGE_STATE_PENDING_VALUE
   unset GH_MERGE_STATE_IMMEDIATE
 }
 
@@ -194,6 +198,8 @@ run_merge_pr() {
     GH_MERGED_MARKER="$TEST_DIR/gh-merged-marker" \
     GH_MERGE_ATTEMPTS_FILE="$TEST_DIR/merge-attempts" \
     GH_MERGE_STATE_UNKNOWN_ATTEMPTS="${GH_MERGE_STATE_UNKNOWN_ATTEMPTS:-0}" \
+    GH_MERGE_STATE_PENDING_ATTEMPTS="${GH_MERGE_STATE_PENDING_ATTEMPTS:-0}" \
+    GH_MERGE_STATE_PENDING_VALUE="${GH_MERGE_STATE_PENDING_VALUE:-}" \
     GH_MERGE_STATE_IMMEDIATE="${GH_MERGE_STATE_IMMEDIATE:-}" \
     GIT_CHECKOUT_MAIN_FILE="$TEST_DIR/git-checkout-main" \
     GIT_BRANCH_DELETED_FILE="$TEST_DIR/git-branch-deleted" \
@@ -214,6 +220,22 @@ if [ "$attempt_count" -eq 7 ] \
 else
   echo "FAIL: UNKNOWN state did not retry past the old five-attempt budget" >&2
   cat "$TEST_DIR/output-unknown-then-clean.txt" >&2
+  exit 1
+fi
+
+echo "==> Test: pending CI UNSTABLE state waits past the old short budget"
+reset_case_files
+GH_MERGE_STATE_PENDING_ATTEMPTS=12 run_merge_pr "$TEST_DIR/output-unstable-then-clean.txt" 123
+attempt_count="$(grep -c 'attempt [0-9][0-9]*: mergeStateStatus=' "$TEST_DIR/output-unstable-then-clean.txt")"
+if [ "$attempt_count" -eq 13 ] \
+  && grep -q 'attempt 10: mergeStateStatus=UNSTABLE mergeable=MERGEABLE' "$TEST_DIR/output-unstable-then-clean.txt" \
+  && grep -q 'attempt 13: mergeStateStatus=CLEAN mergeable=MERGEABLE' "$TEST_DIR/output-unstable-then-clean.txt" \
+  && grep -q '==> Done\.' "$TEST_DIR/output-unstable-then-clean.txt" \
+  && grep -q '^pr-head-oid$' "$TEST_DIR/gh-merge-head"; then
+  echo "==> PASS: pending CI state waits long enough to merge when checks go clean"
+else
+  echo "FAIL: pending CI state timed out before checks became clean" >&2
+  cat "$TEST_DIR/output-unstable-then-clean.txt" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Linked Issues

Closes #204

Closes-issue: #204

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
