### PR TITLE
fix(merge): skip primary checkout worktree cleanup

### DIFF
--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -858,7 +858,7 @@ run_preflight_gate() {
 }
 
 run_merge_review() {
-  local current_branch default_base_ref local_head pr_head_branch pr_head_oid
+  local current_branch current_worktree default_base_ref default_worktree local_head pr_head_branch pr_head_oid
 
   if ! pr_head_branch="$(gh pr view "$PR_NUMBER" --json headRefName --jq '.headRefName' 2>/dev/null)"; then
     echo "ERROR: Failed to resolve PR #$PR_NUMBER head branch." >&2
@@ -881,7 +881,11 @@ run_merge_review() {
   REVIEWED_HEAD_OID="$pr_head_oid"
   current_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")"
   if [ "$current_branch" = "$PR_HEAD_BRANCH" ]; then
-    PR_WORKTREE_PATH="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+    current_worktree="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+    default_worktree="$(worktree_path_for_branch "$DEFAULT_BRANCH" | head -n 1)"
+    if [ -n "$current_worktree" ] && [ -n "$default_worktree" ] && [ "$current_worktree" != "$default_worktree" ]; then
+      PR_WORKTREE_PATH="$current_worktree"
+    fi
   else
     PR_WORKTREE_PATH="$(worktree_path_for_branch "$PR_HEAD_BRANCH" | head -n 1)"
   fi

--- a/tests/test-merge-pr.sh
+++ b/tests/test-merge-pr.sh
@@ -833,6 +833,23 @@ else
   exit 1
 fi
 
+echo "==> Test: primary checkout is not treated as removable feature worktree"
+reset_case_files
+PRIMARY_WORKTREE="$TEST_DIR/primary-checkout"
+mkdir -p "$PRIMARY_WORKTREE"
+TEST_CURRENT_WORKTREE="$PRIMARY_WORKTREE"
+run_merge_pr "$TEST_DIR/output-primary-checkout.txt" 123
+if grep -q "==> Local branch 'feature/test' deleted." "$TEST_DIR/output-primary-checkout.txt" \
+  && ! grep -q "No separate default-branch worktree is available" "$TEST_DIR/output-primary-checkout.txt" \
+  && ! grep -q "Removing merged PR worktree" "$TEST_DIR/output-primary-checkout.txt" \
+  && [ ! -f "$TEST_DIR/git-worktree-remove" ]; then
+  echo "==> PASS: primary checkout was left in place without worktree cleanup warning"
+else
+  echo "FAIL: primary checkout should not be treated as removable feature worktree" >&2
+  cat "$TEST_DIR/output-primary-checkout.txt" >&2
+  exit 1
+fi
+
 echo "==> Test: merged feature worktree is removed from sibling default worktree"
 reset_case_files
 MERGE_MAIN_WORKTREE="$TEST_DIR/merge-main-worktree"


### PR DESCRIPTION
Refs #188

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
