### PR TITLE
docs(journal): auto-draft pr-merged entry for #335

### DIFF
--- a/.cortex/journal/2026-05-12-pr-merged-1050.md
+++ b/.cortex/journal/2026-05-12-pr-merged-1050.md
@@ -1,0 +1,49 @@
+# PR #335 merged — feat: add conductor review naming
+
+**Date:** 2026-05-12
+**Type:** pr-merged
+**Trigger:** T1.9
+**Cites:** journal/2026-05-11-pr-merged-1321
+**Merge-commit:** ba25c9ba1b4ed5a6b5b4c43ca2a770179c27942e
+**Branch:** feat/conductor-review-naming-265
+
+> feat: add conductor review naming.
+
+## What shipped
+
+- [ ] Tests pass locally
+- [ ] No new silent failures (no `except: pass`, no swallowed errors)
+- [ ] No new code paths that diverge between environments
+- [ ] Low risk — isolated change, no shared state affected
+- [ ] Medium risk — touches shared infrastructure or data paths
+- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)
+
+## Closes / advances
+
+- **Plans:** _(none recorded — fill on edit)_
+- **Doctrine:** _(none recorded — fill on edit)_
+- **Journal linkage:** _(none recorded — fill on edit)_
+
+## Follow-ups (deferred to future work)
+
+_None._
+
+(Per SPEC § 4.2, deferred items must resolve to another Plan, Journal entry, or Doctrine entry in the same commit as the merge note.)
+
+
+<!--
+Context auto-pulled at draft time. Remove this block before saving.
+
+Recent commits:
+- ba25c9b feat: add conductor review naming (#335)
+- 5afff2e v2.11.11
+- 2ec22d6 fix(cortex): bypass hooks for direct journal push (#332)
+- 237b80d docs(journal): auto-draft pr-merged entry for #310 (#311)
+- 20c107a fix(test): stop test-bootstrap leaking a real GitHub repo (#245)
+
+Active-branch PR: (no open PR for this branch)
+-->
+
+## Triggers fired
+
+- T1.1 — diff touches `.cortex/doctrine/`, `.cortex/plans/`, `principles/`, or `SPEC.md` (files: principles/agent-swarms.md, principles/git-workflow.md)

--- a/.cortex/state.md
+++ b/.cortex/state.md
@@ -1,10 +1,10 @@
 ---
-Generated: 2026-05-11T16:39:41-04:00
+Generated: 2026-05-12T10:50:42-04:00
 Generator: cortex refresh-state v1.6.2
 Sources:
-  - HEAD sha: 20c107a3a2bb219d254b1f68ed9175cab4ba926b
+  - HEAD sha: ba25c9ba1b4ed5a6b5b4c43ca2a770179c27942e
   - .cortex/plans/*.md (2 files)
-  - .cortex/journal/*.md (14 entries, 2026-05-05..2026-05-11)
+  - .cortex/journal/*.md (15 entries, 2026-05-05..2026-05-12)
   - .cortex/doctrine/*.md (1 entries)
   - .cortex/templates/**/*.md (12 templates)
   - docs/case-studies/*.md (0 case studies)
@@ -26,6 +26,7 @@ Sources-hash:
   .cortex/journal/2026-05-11-pr-merged-0833.md: a29e827ab893b759799ab48b08ef70a0cf20c1fce83871b0d5679afa32562b0b
   .cortex/journal/2026-05-11-pr-merged-1124.md: d1d50e2bff02a0cbd2ed6529f54fe8a238c5eff4566a6d6d4e9d3b2bacbc7e74
   .cortex/journal/2026-05-11-pr-merged-1321.md: 5180c6a3d1a5c9aa66d1f3651ca6560fd65f2b6c6912ff79532f6ac74d300f1d
+  .cortex/journal/2026-05-12-pr-merged-1050.md: 5e34ff3ad9230e082fd9c5abc911d65d5b06f9da9a8d46eaaebcacee7847bd4b
   .cortex/plans/touchstone-conductor-integration.md: be3f8211b7c19e32e0c4c858c35678c1d85418fe12c5d22b29cc0a7831f8a54c
   .cortex/plans/touchstone-cortex-metadata.md: 0e23c4e06b91c1e8da358b3928750798975eed88815502fb8e7ddfbdbd0187f5
   .cortex/templates/README.md: 695aa2e623bd7f4e698dae471bded0cde354da0c1d8589266660ceb1be8efad1
@@ -40,7 +41,7 @@ Sources-hash:
   .cortex/templates/journal/release.md: 9a6bc59219156e48b419fb170c7c50ff557767def8672ef20568df3e14eadbd0
   .cortex/templates/journal/sentinel-cycle.md: 2945e2d94af4ec9848584b4b3e9cea7060d2968dd42e78faf21fb6f859137476
   .cortex/templates/plans/template.md: d8156cfa3b86acd2a1fbb36cff07cae37d99f3adee7f72b14b7b16e645c51b44
-Corpus: 14 Journal entries, 2 Plans, 1 Doctrine entries, 12 Templates, 0 Case studies
+Corpus: 15 Journal entries, 2 Plans, 1 Doctrine entries, 12 Templates, 0 Case studies
 Omitted:
   []
 Incomplete:
@@ -69,6 +70,7 @@ Spec: 0.5.0
 - **2026-05-11** — PR #310 merged — docs(workflow): require issue reconciliation (`.cortex/journal/2026-05-11-pr-merged-0833.md`, Type: pr-merged)
 - **2026-05-11** — PR #321 merged — docs: steer agents to file delivery friction (`.cortex/journal/2026-05-11-pr-merged-1124.md`, Type: pr-merged)
 - **2026-05-11** — PR #328 merged — fix(sync): tighten auto project sync policy (`.cortex/journal/2026-05-11-pr-merged-1321.md`, Type: pr-merged)
+- **2026-05-12** — PR #335 merged — feat: add conductor review naming (`.cortex/journal/2026-05-12-pr-merged-1050.md`, Type: pr-merged)
 
 ## Stale-now / handle-later
 


### PR DESCRIPTION
Auto-drafted Cortex journal entry for merged PR #335.

This PR keeps the T1.9 journal artifact off the local default branch and lets normal repository policy merge it.
