### PR TITLE
fix(sync): guard stale workflow scripts

### DIFF
--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -1088,6 +1088,7 @@ write_touchstone_manifest() {
     printf 'lib/toml.sh\n'
     printf 'lib/events.sh\n'
     printf 'lib/worker-state.sh\n'
+    printf 'lib/script-sync-guard.sh\n'
     printf 'lib/preflight.sh\n'
     printf 'lib/preflight-scope.sh\n'
     printf 'lib/review-comment.sh\n'
@@ -1354,6 +1355,7 @@ mkdir -p "$PROJECT_DIR/lib"
 copy_file_force "$TOUCHSTONE_ROOT/lib/toml.sh" "$PROJECT_DIR/lib/toml.sh"
 copy_file_force "$TOUCHSTONE_ROOT/lib/events.sh" "$PROJECT_DIR/lib/events.sh"
 copy_file_force "$TOUCHSTONE_ROOT/lib/worker-state.sh" "$PROJECT_DIR/lib/worker-state.sh"
+copy_file_force "$TOUCHSTONE_ROOT/lib/script-sync-guard.sh" "$PROJECT_DIR/lib/script-sync-guard.sh"
 copy_file_force "$TOUCHSTONE_ROOT/lib/preflight.sh" "$PROJECT_DIR/lib/preflight.sh"
 copy_file_force "$TOUCHSTONE_ROOT/lib/preflight-scope.sh" "$PROJECT_DIR/lib/preflight-scope.sh"
 copy_file_force "$TOUCHSTONE_ROOT/lib/review-comment.sh" "$PROJECT_DIR/lib/review-comment.sh"

--- a/bootstrap/update-project.sh
+++ b/bootstrap/update-project.sh
@@ -450,6 +450,7 @@ update_file "$TOUCHSTONE_ROOT/scripts/worker.sh" "$PROJECT_DIR/scripts/worker.sh
 update_file "$TOUCHSTONE_ROOT/lib/toml.sh" "$PROJECT_DIR/lib/toml.sh"
 update_file "$TOUCHSTONE_ROOT/lib/events.sh" "$PROJECT_DIR/lib/events.sh"
 update_file "$TOUCHSTONE_ROOT/lib/worker-state.sh" "$PROJECT_DIR/lib/worker-state.sh"
+update_file "$TOUCHSTONE_ROOT/lib/script-sync-guard.sh" "$PROJECT_DIR/lib/script-sync-guard.sh"
 update_file "$TOUCHSTONE_ROOT/lib/preflight.sh" "$PROJECT_DIR/lib/preflight.sh"
 update_file "$TOUCHSTONE_ROOT/lib/preflight-scope.sh" "$PROJECT_DIR/lib/preflight-scope.sh"
 update_file "$TOUCHSTONE_ROOT/lib/review-comment.sh" "$PROJECT_DIR/lib/review-comment.sh"
@@ -600,6 +601,7 @@ write_touchstone_manifest() {
     printf 'lib/toml.sh\n'
     printf 'lib/events.sh\n'
     printf 'lib/worker-state.sh\n'
+    printf 'lib/script-sync-guard.sh\n'
     printf 'lib/preflight.sh\n'
     printf 'lib/preflight-scope.sh\n'
     printf 'lib/review-comment.sh\n'

--- a/lib/script-sync-guard.sh
+++ b/lib/script-sync-guard.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# lib/script-sync-guard.sh — keep project-local workflow scripts current.
+#
+# This guard is sourced by high-risk project-local scripts before they do PR
+# work. If the project was bootstrapped from an older Touchstone install, it
+# updates the Touchstone-owned files on the current feature branch and re-execs
+# the script so the current run uses the refreshed copy.
+
+touchstone_script_sync_guard_truthy() {
+  case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" in
+    1 | true | yes | on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+touchstone_script_sync_guard_resolve_script() {
+  local script_path="$1"
+  local script_dir script_name
+
+  case "$script_path" in
+    /*) ;;
+    *)
+      script_dir="$(dirname "$script_path")"
+      script_name="$(basename "$script_path")"
+      script_dir="$(cd "$script_dir" 2>/dev/null && pwd -P)" || return 1
+      script_path="$script_dir/$script_name"
+      ;;
+  esac
+
+  printf '%s\n' "$script_path"
+}
+
+touchstone_script_sync_guard_default_branch() {
+  local project_dir="$1"
+  local default_branch=""
+
+  default_branch="$(git -C "$project_dir" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null \
+    | sed 's#^origin/##' || true)"
+  if [ -z "$default_branch" ]; then
+    if git -C "$project_dir" show-ref --verify --quiet refs/heads/main; then
+      default_branch="main"
+    elif git -C "$project_dir" show-ref --verify --quiet refs/heads/master; then
+      default_branch="master"
+    fi
+  fi
+
+  printf '%s\n' "$default_branch"
+}
+
+touchstone_script_sync_guard() {
+  local script_path="${1:-}"
+  shift || true
+
+  if [ -z "$script_path" ]; then
+    return 0
+  fi
+  if touchstone_script_sync_guard_truthy "${TOUCHSTONE_NO_SCRIPT_SYNC:-}" \
+    || touchstone_script_sync_guard_truthy "${TOUCHSTONE_SCRIPT_SYNC_GUARD_DISABLE:-}" \
+    || touchstone_script_sync_guard_truthy "${TOUCHSTONE_NO_AUTO_UPDATE:-}" \
+    || touchstone_script_sync_guard_truthy "${TOUCHSTONE_NO_AUTO_PROJECT_SYNC:-}" \
+    || touchstone_script_sync_guard_truthy "${TOUCHSTONE_SCRIPT_SYNC_GUARD_DONE:-}"; then
+    return 0
+  fi
+  if ! command -v touchstone >/dev/null 2>&1; then
+    return 0
+  fi
+
+  local resolved_script script_dir project_dir
+  resolved_script="$(touchstone_script_sync_guard_resolve_script "$script_path")" || return 0
+  script_dir="$(cd "$(dirname "$resolved_script")" 2>/dev/null && pwd -P)" || return 0
+  project_dir="$(cd "$script_dir/.." 2>/dev/null && pwd -P)" || return 0
+  [ -f "$project_dir/.touchstone-version" ] || return 0
+
+  if ! git -C "$project_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    return 0
+  fi
+
+  local check_output check_file
+  check_file="$(mktemp -t touchstone-script-sync-check.XXXXXX)"
+  if ! (cd "$project_dir" && touchstone update --check) >"$check_file" 2>&1; then
+    echo "ERROR: Touchstone script sync check failed before running $resolved_script:" >&2
+    sed 's/^/       /' "$check_file" >&2
+    rm -f "$check_file"
+    exit 2
+  fi
+  check_output="$(cat "$check_file")"
+  rm -f "$check_file"
+
+  case "$check_output" in
+    *"Already up to date."*) return 0 ;;
+    *"Needs update."*) ;;
+    *) return 0 ;;
+  esac
+
+  local current_branch default_branch update_file
+  current_branch="$(git -C "$project_dir" branch --show-current 2>/dev/null || true)"
+  default_branch="$(touchstone_script_sync_guard_default_branch "$project_dir")"
+  if [ -n "$current_branch" ] \
+    && { [ "$current_branch" = "$default_branch" ] || [ "$current_branch" = "main" ] || [ "$current_branch" = "master" ]; }; then
+    echo "ERROR: Touchstone project files are stale, but $resolved_script is running on default branch '$current_branch'." >&2
+    echo "       Refusing to create a Touchstone update commit on the default branch." >&2
+    echo "       Run: touchstone update --ship" >&2
+    echo "       Then rerun this command." >&2
+    exit 2
+  fi
+  if [ -z "$current_branch" ]; then
+    echo "ERROR: Touchstone project files are stale, but $resolved_script is running from a detached HEAD." >&2
+    echo "       Check out a feature branch, run touchstone update --in-place, then rerun this command." >&2
+    exit 2
+  fi
+
+  update_file="$(mktemp -t touchstone-script-sync-update.XXXXXX)"
+  echo "==> Touchstone script sync: project-local workflow files are stale; updating before continuing." >&2
+  if ! (cd "$project_dir" && touchstone update --in-place) >"$update_file" 2>&1; then
+    echo "ERROR: Touchstone script sync update failed before running $resolved_script:" >&2
+    sed 's/^/       /' "$update_file" >&2
+    rm -f "$update_file"
+    exit 2
+  fi
+  sed 's/^/    /' "$update_file" >&2
+  rm -f "$update_file"
+
+  echo "==> Touchstone script sync: restarting $resolved_script" >&2
+  TOUCHSTONE_SCRIPT_SYNC_GUARD_DONE=1 exec bash "$resolved_script" "$@"
+}

--- a/lib/sync-discipline.sh
+++ b/lib/sync-discipline.sh
@@ -42,6 +42,7 @@ touchstone_sync_planned_write_paths() {
     printf 'lib/toml.sh\n'
     printf 'lib/events.sh\n'
     printf 'lib/worker-state.sh\n'
+    printf 'lib/script-sync-guard.sh\n'
     printf 'lib/preflight.sh\n'
     printf 'lib/preflight-scope.sh\n'
     printf 'lib/review-comment.sh\n'

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -24,6 +24,12 @@ set -euo pipefail
 PR_NUMBER=""
 BYPASS_REASON=""
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_SYNC_GUARD="$SCRIPT_DIR/../lib/script-sync-guard.sh"
+if [ -f "$SCRIPT_SYNC_GUARD" ]; then
+  # shellcheck source=../lib/script-sync-guard.sh
+  source "$SCRIPT_SYNC_GUARD"
+  touchstone_script_sync_guard "$0" "$@"
+fi
 REVIEW_SCRIPT="$SCRIPT_DIR/conductor-review.sh"
 if [ ! -f "$REVIEW_SCRIPT" ]; then
   REVIEW_SCRIPT="$SCRIPT_DIR/codex-review.sh"

--- a/scripts/open-pr.sh
+++ b/scripts/open-pr.sh
@@ -42,6 +42,12 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_SYNC_GUARD="$SCRIPT_DIR/../lib/script-sync-guard.sh"
+if [ -f "$SCRIPT_SYNC_GUARD" ]; then
+  # shellcheck source=../lib/script-sync-guard.sh
+  source "$SCRIPT_SYNC_GUARD"
+  touchstone_script_sync_guard "$0" "$@"
+fi
 PREFLIGHT_SCRIPT="$SCRIPT_DIR/../lib/preflight.sh"
 REVIEW_COMMENT_SCRIPT="$SCRIPT_DIR/../lib/review-comment.sh"
 ISSUE_CLAIM_CHECK_SCRIPT="$SCRIPT_DIR/issue-claim-check.sh"

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -180,6 +180,7 @@ assert_exists "$PROJECT/principles/README.md"
 assert_exists "$PROJECT/scripts/conductor-review.sh"
 assert_exists "$PROJECT/scripts/codex-review.sh"
 assert_exists "$PROJECT/lib/toml.sh"
+assert_exists "$PROJECT/lib/script-sync-guard.sh"
 assert_exists "$PROJECT/lib/preflight.sh"
 assert_exists "$PROJECT/lib/review-comment.sh"
 assert_exists "$PROJECT/scripts/touchstone-run.sh"
@@ -224,6 +225,7 @@ assert_contains "$PROJECT/.touchstone-manifest" '^scripts/issue-claim-check.sh$'
 assert_contains "$PROJECT/.touchstone-manifest" '^scripts/spawn-worktree.sh$'
 assert_contains "$PROJECT/.touchstone-manifest" '^scripts/cleanup-worktrees.sh$'
 assert_contains "$PROJECT/.touchstone-manifest" '^lib/toml\.sh$'
+assert_contains "$PROJECT/.touchstone-manifest" '^lib/script-sync-guard\.sh$'
 assert_contains "$PROJECT/.touchstone-manifest" '^lib/preflight\.sh$'
 assert_contains "$PROJECT/.touchstone-manifest" '^lib/review-comment\.sh$'
 if grep -q '^\.touchstone-config$' "$PROJECT/.gitignore"; then

--- a/tests/test-sync-scope-aware.sh
+++ b/tests/test-sync-scope-aware.sh
@@ -87,6 +87,7 @@ assert_contains "$TEST_DIR/planned.out" "TOUCHSTONE.md"
 assert_contains "$TEST_DIR/planned.out" ".github/workflows/issue-claim-check.yml"
 assert_contains "$TEST_DIR/planned.out" "scripts/claim-issue.sh"
 assert_contains "$TEST_DIR/planned.out" "scripts/issue-claim-check.sh"
+assert_contains "$TEST_DIR/planned.out" "lib/script-sync-guard.sh"
 assert_contains "$TEST_DIR/planned.out" "lib/preflight-scope.sh"
 
 echo ""

--- a/tests/test-update.sh
+++ b/tests/test-update.sh
@@ -138,6 +138,7 @@ assert_exists "$PROJECT/scripts/spawn-worktree.sh"
 assert_exists "$PROJECT/scripts/cleanup-worktrees.sh"
 assert_exists "$PROJECT/lib/toml.sh"
 assert_exists "$PROJECT/lib/events.sh"
+assert_exists "$PROJECT/lib/script-sync-guard.sh"
 assert_exists "$PROJECT/lib/preflight.sh"
 assert_exists "$PROJECT/lib/review-comment.sh"
 assert_exists "$PROJECT/.touchstone-manifest"
@@ -150,6 +151,7 @@ assert_contains "$PROJECT/.touchstone-manifest" '^scripts/spawn-worktree.sh$'
 assert_contains "$PROJECT/.touchstone-manifest" '^scripts/cleanup-worktrees.sh$'
 assert_contains "$PROJECT/.touchstone-manifest" '^lib/toml\.sh$'
 assert_contains "$PROJECT/.touchstone-manifest" '^lib/events\.sh$'
+assert_contains "$PROJECT/.touchstone-manifest" '^lib/script-sync-guard\.sh$'
 assert_contains "$PROJECT/.touchstone-manifest" '^lib/preflight\.sh$'
 assert_contains "$PROJECT/.touchstone-manifest" '^lib/review-comment\.sh$'
 assert_not_exists "$PROJECT/principles/engineering-principles.md.bak"
@@ -238,6 +240,7 @@ assert_exists "$IN_PLACE_PROJECT/.github/workflows/issue-claim-check.yml"
 assert_exists "$IN_PLACE_PROJECT/scripts/touchstone-run.sh"
 assert_exists "$IN_PLACE_PROJECT/scripts/claim-issue.sh"
 assert_exists "$IN_PLACE_PROJECT/scripts/issue-claim-check.sh"
+assert_exists "$IN_PLACE_PROJECT/lib/script-sync-guard.sh"
 assert_not_exists "$IN_PLACE_PROJECT/.claude/settings.json.touchstone-pre-update.bak"
 
 if git -C "$IN_PLACE_PROJECT" branch --list 'chore/touchstone-*' | grep -q .; then
@@ -294,6 +297,80 @@ fi
 if [ -n "$(git -C "$IGNORED_MANAGED_PROJECT" status --porcelain)" ]; then
   echo "FAIL: ignored managed update should leave a clean worktree after committing" >&2
   git -C "$IGNORED_MANAGED_PROJECT" status --short >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# --------------------------------------------------------------------------
+# Test 2d: direct project-local PR scripts self-update before running.
+# This covers the raw `bash scripts/merge-pr.sh` path, which bypasses the
+# touchstone CLI's normal auto-project-sync hook.
+# --------------------------------------------------------------------------
+echo ""
+echo "--- Step 3d: Direct workflow scripts update stale Touchstone files ---"
+
+SCRIPT_SYNC_PROJECT="$TEST_DIR/script-sync-project"
+SCRIPT_SYNC_BIN="$TEST_DIR/script-sync-bin"
+mkdir -p "$SCRIPT_SYNC_BIN"
+cat >"$SCRIPT_SYNC_BIN/touchstone" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$TOUCHSTONE_SCRIPT_SYNC_FAKE_LOG"
+TOUCHSTONE_NO_AUTO_UPDATE=1 exec "$TOUCHSTONE_BIN" "$@"
+EOF
+chmod +x "$SCRIPT_SYNC_BIN/touchstone"
+
+bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$SCRIPT_SYNC_PROJECT" --no-register >/dev/null
+configure_git "$SCRIPT_SYNC_PROJECT"
+commit_all "$SCRIPT_SYNC_PROJECT" "initial script sync test project"
+git -C "$SCRIPT_SYNC_PROJECT" checkout -q -b feature/script-sync-guard
+echo "0000000000000000000000000000000000000014" >"$SCRIPT_SYNC_PROJECT/.touchstone-version"
+commit_all "$SCRIPT_SYNC_PROJECT" "simulate stale script sync touchstone state"
+
+SCRIPT_SYNC_OUT="$TEST_DIR/script-sync-output.txt"
+SCRIPT_SYNC_LOG="$TEST_DIR/script-sync-touchstone.log"
+SCRIPT_SYNC_RC=0
+(
+  cd "$SCRIPT_SYNC_PROJECT"
+  PATH="$SCRIPT_SYNC_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    TOUCHSTONE_BIN="$TOUCHSTONE_ROOT/bin/touchstone" \
+    TOUCHSTONE_SCRIPT_SYNC_FAKE_LOG="$SCRIPT_SYNC_LOG" \
+    bash scripts/merge-pr.sh not-a-pr
+) >"$SCRIPT_SYNC_OUT" 2>&1 || SCRIPT_SYNC_RC=$?
+
+if [ "$SCRIPT_SYNC_RC" != "2" ]; then
+  echo "FAIL: guarded merge-pr invalid-argument run should exit 2 after sync" >&2
+  echo "    rc=$SCRIPT_SYNC_RC" >&2
+  cat "$SCRIPT_SYNC_OUT" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+assert_contains "$SCRIPT_SYNC_OUT" 'Touchstone script sync: project-local workflow files are stale'
+assert_contains "$SCRIPT_SYNC_OUT" 'Touchstone script sync: restarting'
+assert_contains "$SCRIPT_SYNC_OUT" 'Usage: bash scripts/merge-pr.sh <pr-number>'
+assert_contains "$SCRIPT_SYNC_LOG" '^update --check$'
+assert_contains "$SCRIPT_SYNC_LOG" '^update --in-place$'
+
+if [ "$(cat "$SCRIPT_SYNC_PROJECT/.touchstone-version" | tr -d '[:space:]')" = "$INITIAL_SHA" ]; then
+  echo "    PASS: direct script sync refreshed .touchstone-version"
+else
+  echo "FAIL: direct script sync did not refresh .touchstone-version" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+if git -C "$SCRIPT_SYNC_PROJECT" log -1 --format=%s | grep -q '^chore: update touchstone to '; then
+  echo "    PASS: direct script sync committed the update on the feature branch"
+else
+  echo "FAIL: direct script sync did not create a Touchstone update commit" >&2
+  git -C "$SCRIPT_SYNC_PROJECT" log -1 --format=%s >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+if [ "$(git -C "$SCRIPT_SYNC_PROJECT" branch --show-current)" != "feature/script-sync-guard" ]; then
+  echo "FAIL: direct script sync should stay on the current feature branch" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+if [ -n "$(git -C "$SCRIPT_SYNC_PROJECT" status --porcelain)" ]; then
+  echo "FAIL: direct script sync should leave a clean worktree after committing" >&2
+  git -C "$SCRIPT_SYNC_PROJECT" status --short >&2
   ERRORS=$((ERRORS + 1))
 fi
 


### PR DESCRIPTION
## Linked Issues

Closes #341

Closes #341

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
