### PR TITLE
fix(doctor): require conductor peer dependency

### DIFF
--- a/bin/touchstone
+++ b/bin/touchstone
@@ -715,7 +715,7 @@ cmd_doctor_project() {
     tk_dim "  Fix: echo \"$project_dir\" >> $projects_file"
   fi
 
-  # 6. Optional — Conductor review config present?
+  # 6. Conductor review config and required reviewer peer.
   local review_config=""
   if [ -f "$project_dir/.touchstone-review.toml" ]; then
     review_config=".touchstone-review.toml"
@@ -735,6 +735,13 @@ cmd_doctor_project() {
     fi
   else
     tk_dim ".touchstone-review.toml not found (optional — configures AI review)"
+  fi
+  if _touchstone_doctor_review_enabled "$project_dir/$review_config"; then
+    if ! _touchstone_doctor_check_conductor_peer; then
+      issues=$((issues + 1))
+    fi
+  else
+    tk_dim "conductor: not required ([review] enabled = false)"
   fi
 
   # 7. Profile-aware test-surface and tooling gap checks.
@@ -823,6 +830,62 @@ cmd_doctor_project() {
   fi
   tk_warn "$issues issue(s) found. See fixes above, or run: touchstone init"
   echo ""
+  return 1
+}
+
+_touchstone_doctor_review_enabled() {
+  local config_path="$1"
+  [ -f "$config_path" ] || return 0
+
+  awk '
+    function trim(s) {
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", s)
+      return s
+    }
+    /^[[:space:]]*#/ || /^[[:space:]]*$/ { next }
+    /^[[:space:]]*\[/ {
+      section = $0
+      sub(/^[[:space:]]*\[/, "", section)
+      sub(/\].*$/, "", section)
+      section = trim(section)
+      next
+    }
+    section == "review" {
+      line = $0
+      sub(/[[:space:]]+#.*$/, "", line)
+      if (line ~ /^[[:space:]]*enabled[[:space:]]*=/) {
+        sub(/^[^=]*=/, "", line)
+        value = trim(line)
+        gsub(/^"|"$/, "", value)
+        if (value == "false") {
+          disabled = 1
+        }
+      }
+    }
+    END {
+      exit disabled ? 0 : 1
+    }
+  ' "$config_path" && return 1
+
+  return 0
+}
+
+_touchstone_doctor_check_conductor_peer() {
+  if command -v conductor >/dev/null 2>&1; then
+    # Touchstone 2.0 delegates all review to conductor; richer status
+    # lives in `conductor doctor`.
+    if conductor doctor --json 2>/dev/null | grep -q '"configured"[[:space:]]*:[[:space:]]*true'; then
+      tk_ok "conductor: $(command -v conductor) (at least one provider configured)"
+      return 0
+    fi
+    tk_warn "conductor: $(command -v conductor) (no provider configured — run: conductor init)"
+    return 1
+  fi
+
+  tk_fail "conductor: MISSING — the pre-push review hook will not run without conductor"
+  tk_dim "  Install: brew install autumngarage/conductor/conductor"
+  tk_dim "  Configure: conductor init"
+  tk_dim "  Required by autumn-garage doctrine 0009"
   return 1
 }
 
@@ -1207,6 +1270,9 @@ cmd_doctor() {
       issues=$((issues + 1))
     fi
   done
+  if ! _touchstone_doctor_check_conductor_peer; then
+    issues=$((issues + 1))
+  fi
 
   # Recommended tools.
   for tool in pre-commit gitleaks shellcheck shfmt; do
@@ -1219,18 +1285,6 @@ cmd_doctor() {
   done
 
   # Optional tools.
-  if command -v conductor >/dev/null 2>&1; then
-    # Touchstone 2.0 delegates all review to conductor; richer status
-    # lives in `conductor doctor`.
-    if conductor doctor --json 2>/dev/null | grep -q '"configured"[[:space:]]*:[[:space:]]*true'; then
-      tk_ok "conductor: $(command -v conductor) (at least one provider configured)"
-    else
-      tk_warn "conductor: $(command -v conductor) (no provider configured — run: conductor init)"
-      issues=$((issues + 1))
-    fi
-  else
-    tk_dim "conductor: not installed (optional — brew install autumngarage/conductor/conductor)"
-  fi
   if command -v but >/dev/null 2>&1; then
     tk_ok "but: $(command -v but)"
   else

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -1278,6 +1278,18 @@ fi
 
 phase "touchstone doctor + sibling detection"
 
+DOCTOR_CONDUCTOR_BIN="$TEST_DIR/doctor-conductor-bin"
+mkdir -p "$DOCTOR_CONDUCTOR_BIN"
+cat >"$DOCTOR_CONDUCTOR_BIN/conductor" <<'CONDUCTORSTUB'
+#!/usr/bin/env bash
+if [ "${1:-}" = "doctor" ] && [ "${2:-}" = "--json" ]; then
+  printf '{"providers":[{"configured":true}]}\n'
+  exit 0
+fi
+exit 0
+CONDUCTORSTUB
+chmod +x "$DOCTOR_CONDUCTOR_BIN/conductor"
+
 # touchstone doctor --project must exit clean on a fully-armed repo.
 # Use the fake pre-commit so hooks install regardless of what's on the tester's real PATH.
 PATH="$HOOKS_FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_DOCTOR" --no-register >/dev/null
@@ -1302,7 +1314,7 @@ assert_contains "$TEST_DIR/doctor-clean.txt" 'Autumn Garage siblings'
 PROJECT_DOCTOR_NO_SIBLINGS="$TEST_DIR/test-project-doctor-no-siblings"
 PATH="$HOOKS_FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_DOCTOR_NO_SIBLINGS" --no-register \
   --no-with-cortex --no-with-sentinel >/dev/null
-if (cd "$PROJECT_DOCTOR_NO_SIBLINGS" && PATH="/usr/bin:/bin" TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" doctor --project) >"$TEST_DIR/doctor-no-siblings.txt" 2>&1; then
+if (cd "$PROJECT_DOCTOR_NO_SIBLINGS" && PATH="$DOCTOR_CONDUCTOR_BIN:/usr/bin:/bin" TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" doctor --project) >"$TEST_DIR/doctor-no-siblings.txt" 2>&1; then
   assert_contains "$TEST_DIR/doctor-no-siblings.txt" 'Autumn Garage siblings'
   assert_contains "$TEST_DIR/doctor-no-siblings.txt" 'cortex not installed'
   assert_contains "$TEST_DIR/doctor-no-siblings.txt" 'sentinel not installed'
@@ -1318,7 +1330,7 @@ fi
 PROJECT_DOCTOR_MARKER_ONLY="$TEST_DIR/test-project-doctor-marker-only"
 PATH="$HOOKS_FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_DOCTOR_MARKER_ONLY" --no-register >/dev/null
 mkdir -p "$PROJECT_DOCTOR_MARKER_ONLY/.cortex"
-if (cd "$PROJECT_DOCTOR_MARKER_ONLY" && PATH="/usr/bin:/bin" TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" doctor --project) >"$TEST_DIR/doctor-marker-only.txt" 2>&1; then
+if (cd "$PROJECT_DOCTOR_MARKER_ONLY" && PATH="$DOCTOR_CONDUCTOR_BIN:/usr/bin:/bin" TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" doctor --project) >"$TEST_DIR/doctor-marker-only.txt" 2>&1; then
   assert_contains "$TEST_DIR/doctor-marker-only.txt" 'cortex CLI missing but .cortex/ present'
 else
   echo "FAIL: doctor --project should exit 0 when a sibling CLI is missing but its marker dir is present — still non-blocking" >&2
@@ -1351,7 +1363,7 @@ chmod +x "$SIBLING_STUB_BIN/sentinel"
 
 PROJECT_DOCTOR_SIBLINGS="$TEST_DIR/test-project-doctor-with-siblings"
 PATH="$HOOKS_FAKE_BIN:$PATH" bash "$TOUCHSTONE_ROOT/bootstrap/new-project.sh" "$PROJECT_DOCTOR_SIBLINGS" --no-register >/dev/null
-if (cd "$PROJECT_DOCTOR_SIBLINGS" && PATH="$SIBLING_STUB_BIN:/usr/bin:/bin" TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" doctor --project) >"$TEST_DIR/doctor-with-siblings.txt" 2>&1; then
+if (cd "$PROJECT_DOCTOR_SIBLINGS" && PATH="$SIBLING_STUB_BIN:$DOCTOR_CONDUCTOR_BIN:/usr/bin:/bin" TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" doctor --project) >"$TEST_DIR/doctor-with-siblings.txt" 2>&1; then
   assert_contains "$TEST_DIR/doctor-with-siblings.txt" 'cortex 9.9.9 (installed)'
   # Sentinel only responds to --version — asserts the probe-fallback works.
   assert_contains "$TEST_DIR/doctor-with-siblings.txt" 'sentinel 8.8.8 (installed)'
@@ -1502,7 +1514,7 @@ printf 'profile=python\n' >>"$PROJECT_DOCTOR_ALIAS_KEY/.touchstone-config"
 if PATH="/usr/bin:/bin" command -v ruff >/dev/null 2>&1; then
   echo "SKIP: ruff on minimal PATH; cannot test project_type/profile last-wins doctor case on this machine" >&2
 else
-  if (cd "$PROJECT_DOCTOR_ALIAS_KEY" && PATH="/usr/bin:/bin" TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" doctor --project) >"$TEST_DIR/doctor-alias-key.txt" 2>&1; then
+  if (cd "$PROJECT_DOCTOR_ALIAS_KEY" && PATH="$DOCTOR_CONDUCTOR_BIN:/usr/bin:/bin" TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" doctor --project) >"$TEST_DIR/doctor-alias-key.txt" 2>&1; then
     echo "FAIL: doctor --project on a Python-via-profile= project with no ruff should exit nonzero" >&2
     ERRORS=$((ERRORS + 1))
   else
@@ -1594,7 +1606,7 @@ sed -i '' 's|^test_command=.*|test_command=echo "custom test"|' "$PROJECT_DOCTOR
 if PATH="/usr/bin:/bin" command -v ruff >/dev/null 2>&1; then
   echo "SKIP: ruff on minimal PATH; cannot test override-suppresses-ruff-check on this machine" >&2
 else
-  if (cd "$PROJECT_DOCTOR_PY_OVERRIDE" && PATH="/usr/bin:/bin" TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" doctor --project) >"$TEST_DIR/doctor-py-override.txt" 2>&1; then
+  if (cd "$PROJECT_DOCTOR_PY_OVERRIDE" && PATH="$DOCTOR_CONDUCTOR_BIN:/usr/bin:/bin" TOUCHSTONE_NO_AUTO_UPDATE=1 "$TOUCHSTONE_ROOT/bin/touchstone" doctor --project) >"$TEST_DIR/doctor-py-override.txt" 2>&1; then
     assert_contains "$TEST_DIR/doctor-py-override.txt" 'Project is fully armed'
     assert_contains "$TEST_DIR/doctor-py-override.txt" 'lint: overridden via .touchstone-config'
     assert_contains "$TEST_DIR/doctor-py-override.txt" 'tests: overridden via .touchstone-config'

--- a/tests/test-doctor.sh
+++ b/tests/test-doctor.sh
@@ -51,6 +51,35 @@ run_doctor() {
   run_touchstone "$fake_home" doctor "$@"
 }
 
+write_fake_install_tools() {
+  local dir="$1" conductor_mode="$2" version
+  version="$(tr -d '[:space:]' <"$TOUCHSTONE_ROOT/VERSION")"
+  mkdir -p "$dir"
+  for tool in gh pre-commit gitleaks shellcheck shfmt; do
+    cat >"$dir/$tool" <<'EOF_FAKE_TOOL'
+#!/usr/bin/env bash
+exit 0
+EOF_FAKE_TOOL
+    chmod +x "$dir/$tool"
+  done
+  cat >"$dir/curl" <<EOF_FAKE_CURL
+#!/usr/bin/env bash
+printf '{"tag_name":"v%s"}\n' "$version"
+EOF_FAKE_CURL
+  chmod +x "$dir/curl"
+  if [ "$conductor_mode" = "present" ]; then
+    cat >"$dir/conductor" <<'EOF_FAKE_CONDUCTOR'
+#!/usr/bin/env bash
+if [ "${1:-}" = "doctor" ] && [ "${2:-}" = "--json" ]; then
+  printf '{"providers":[{"configured":true}]}\n'
+  exit 0
+fi
+exit 0
+EOF_FAKE_CONDUCTOR
+    chmod +x "$dir/conductor"
+  fi
+}
+
 timestamp_now() {
   date '+%Y-%m-%dT%H:%M:%S%z'
 }
@@ -100,6 +129,42 @@ set -e
 
 assert_exit "$DOCTOR_METRICS_EXIT" 2 "doctor metrics flags"
 assert_contains "$DOCTOR_METRICS_OUT" "review metrics moved to: touchstone review-stats"
+
+# --------------------------------------------------------------------------
+# Test 2b: installation doctor fails hard when Conductor is missing
+# --------------------------------------------------------------------------
+echo ""
+echo "--- Test 2b: installation doctor requires conductor peer ---"
+
+MISSING_CONDUCTOR_BIN="$TEST_DIR/missing-conductor-bin"
+write_fake_install_tools "$MISSING_CONDUCTOR_BIN" "missing"
+MISSING_CONDUCTOR_OUT="$TEST_DIR/missing-conductor.out"
+set +e
+PATH="$MISSING_CONDUCTOR_BIN:/usr/bin:/bin" run_doctor "$FAKE_HOME" --installation >"$MISSING_CONDUCTOR_OUT" 2>&1
+MISSING_CONDUCTOR_EXIT=$?
+set -e
+
+assert_exit "$MISSING_CONDUCTOR_EXIT" 1 "missing conductor peer"
+assert_contains "$MISSING_CONDUCTOR_OUT" "the pre-push review hook will not run without conductor"
+assert_contains "$MISSING_CONDUCTOR_OUT" "brew install autumngarage/conductor/conductor"
+assert_contains "$MISSING_CONDUCTOR_OUT" "autumn-garage doctrine 0009"
+
+# --------------------------------------------------------------------------
+# Test 2c: installation doctor exits zero when Conductor is present
+# --------------------------------------------------------------------------
+echo ""
+echo "--- Test 2c: installation doctor accepts conductor peer ---"
+
+PRESENT_CONDUCTOR_BIN="$TEST_DIR/present-conductor-bin"
+write_fake_install_tools "$PRESENT_CONDUCTOR_BIN" "present"
+PRESENT_CONDUCTOR_OUT="$TEST_DIR/present-conductor.out"
+set +e
+PATH="$PRESENT_CONDUCTOR_BIN:/usr/bin:/bin" run_doctor "$FAKE_HOME" --installation >"$PRESENT_CONDUCTOR_OUT" 2>&1
+PRESENT_CONDUCTOR_EXIT=$?
+set -e
+
+assert_exit "$PRESENT_CONDUCTOR_EXIT" 0 "present conductor peer"
+assert_contains "$PRESENT_CONDUCTOR_OUT" "conductor: $PRESENT_CONDUCTOR_BIN/conductor (at least one provider configured)"
 
 # --------------------------------------------------------------------------
 # Test 3: review-stats missing log exits 0 with friendly message
@@ -332,6 +397,38 @@ if [ "$REVIEW_SCHEMA_EXIT" -eq 0 ]; then
 fi
 assert_contains "$REVIEW_SCHEMA_OUT" ".codex-review.toml uses legacy 1.x review schema"
 assert_contains "$REVIEW_SCHEMA_OUT" "touchstone migrate-review-config"
+
+# --------------------------------------------------------------------------
+# Test 13: project doctor fails hard when review is enabled but Conductor is missing
+# --------------------------------------------------------------------------
+echo ""
+echo "--- Test 13: project doctor requires conductor peer for review ---"
+
+PROJECT_PEER="$TEST_DIR/project-peer"
+mkdir -p "$PROJECT_PEER"
+git -C "$PROJECT_PEER" init -q
+git -C "$PROJECT_PEER" config user.email test@example.com
+git -C "$PROJECT_PEER" config user.name "Touchstone Test"
+git -C "$PROJECT_PEER" commit --allow-empty -q -m "initial"
+git -C "$TOUCHSTONE_ROOT" rev-parse HEAD >"$PROJECT_PEER/.touchstone-version"
+cat >"$PROJECT_PEER/.touchstone-review.toml" <<'EOF_PROJECT_PEER'
+[review]
+enabled = true
+reviewer = "conductor"
+EOF_PROJECT_PEER
+
+PROJECT_PEER_OUT="$TEST_DIR/project-peer.out"
+set +e
+(cd "$PROJECT_PEER" && PATH="$MISSING_CONDUCTOR_BIN:/usr/bin:/bin" run_doctor "$FAKE_HOME") >"$PROJECT_PEER_OUT" 2>&1
+PROJECT_PEER_EXIT=$?
+set -e
+
+if [ "$PROJECT_PEER_EXIT" -eq 0 ]; then
+  echo "FAIL: project doctor should fail when review is enabled and conductor is missing" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+assert_contains "$PROJECT_PEER_OUT" "the pre-push review hook will not run without conductor"
+assert_contains "$PROJECT_PEER_OUT" "brew install autumngarage/conductor/conductor"
 
 if [ "$ERRORS" -ne 0 ]; then
   echo ""


### PR DESCRIPTION
## Summary

Require Conductor as a Touchstone peer dependency in `touchstone doctor`, so projects surface a hard readiness failure before the pre-push review hook silently cannot run.

## Root Cause

Touchstone 2.x delegates review to Conductor, but installation/project doctor still treated Conductor as optional. A customer could have a green-ish Touchstone installation while the actual review gate was unable to run.

## Changes

- Make installation doctor fail when `conductor` is missing.
- Make project doctor fail when review is enabled and `conductor` is missing.
- Keep `[review] enabled = false` as an explicit opt-out path.
- Add regression coverage for missing/present Conductor peer checks.

## Validation

- `for test in tests/test-*.sh; do printf '==> %s\n' "$test"; bash "$test" || exit 1; done`
- `git diff --check`
- `pre-commit run --files bin/touchstone tests/test-bootstrap.sh tests/test-doctor.sh`

Closes #340