### PR TITLE
fix(update): ignore stale older release metadata

### DIFF
--- a/bin/touchstone
+++ b/bin/touchstone
@@ -1329,6 +1329,8 @@ cmd_doctor() {
   if [ -n "$latest" ]; then
     if [ "$version" = "$latest" ]; then
       tk_ok "v${latest} — you're current"
+    elif run_script_version_satisfies "$latest" "$version"; then
+      tk_ok "v${version} — newer than latest GitHub release v${latest}"
     else
       tk_warn "v${latest} available (you have v${version}). Run: brew upgrade touchstone"
       issues=$((issues + 1))

--- a/lib/auto-update.sh
+++ b/lib/auto-update.sh
@@ -27,6 +27,42 @@ TOUCHSTONE_STATE_DIR="${TOUCHSTONE_STATE_DIR:-$HOME/.touchstone}"
 LAST_CHECK_FILE="$TOUCHSTONE_STATE_DIR/last-update-check"
 TOUCHSTONE_AUTO_UPDATE_REEXEC_EXIT=75
 
+touchstone_auto_update_version_gte() {
+  local current="${1#v}" latest="${2#v}"
+  awk -v current="$current" -v latest="$latest" '
+    function parse_version(version, parts, count, i) {
+      count = split(version, parts, ".")
+      if (count < 2 || count > 3) {
+        return 0
+      }
+      for (i = 1; i <= count; i++) {
+        if (parts[i] !~ /^[0-9]+$/) {
+          return 0
+        }
+        parts[i] += 0
+      }
+      for (i = count + 1; i <= 3; i++) {
+        parts[i] = 0
+      }
+      return 1
+    }
+
+    BEGIN {
+      if (!parse_version(current, cur) || !parse_version(latest, lat)) {
+        exit 1
+      }
+      for (i = 1; i <= 3; i++) {
+        if (cur[i] > lat[i]) {
+          exit 0
+        }
+        if (cur[i] < lat[i]) {
+          exit 1
+        }
+      }
+      exit 0
+    }'
+}
+
 touchstone_auto_update() {
   # Skip if disabled.
   if [ "${TOUCHSTONE_NO_AUTO_UPDATE:-}" = "1" ] \
@@ -69,12 +105,12 @@ touchstone_auto_update() {
     return 0
   fi
 
-  # Compare versions (simple string compare — works for semver if we don't skip versions).
-  if [ "$current_version" = "$latest_version" ]; then
+  # Only upgrade when the published latest release is newer than this install.
+  if touchstone_auto_update_version_gte "$current_version" "$latest_version"; then
     return 0
   fi
 
-  # Version differs — try to upgrade.
+  # Installed version is older — try to upgrade.
   echo "==> touchstone v${current_version} is outdated (latest: v${latest_version}). Updating..." >&2
 
   if command -v brew >/dev/null 2>&1 && brew list touchstone &>/dev/null; then

--- a/tests/test-auto-update.sh
+++ b/tests/test-auto-update.sh
@@ -59,3 +59,24 @@ else
   cat "$OUT" >&2
   exit 1
 fi
+
+cat >"$FAKE_BIN/curl" <<'EOF'
+#!/usr/bin/env bash
+printf '{"tag_name":"v0.0.1"}\n'
+EOF
+chmod +x "$FAKE_BIN/curl"
+
+OUT_CURRENT="$TEST_DIR/current-newer.out"
+PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+  TOUCHSTONE_UPDATE_INTERVAL=0 \
+  TOUCHSTONE_STATE_DIR="$STATE_DIR" \
+  "$TOUCHSTONE_ROOT/bin/touchstone" version >"$OUT_CURRENT" 2>&1
+
+if grep -q 'fake brew upgraded touchstone' "$OUT_CURRENT" \
+  || grep -q '^REEXECED:1:version$' "$OUT_CURRENT"; then
+  echo "FAIL: installed version newer than latest release must not trigger auto-update" >&2
+  cat "$OUT_CURRENT" >&2
+  exit 1
+fi
+
+echo "PASS: touchstone auto-update ignores stale older latest release"

--- a/tests/test-doctor.sh
+++ b/tests/test-doctor.sh
@@ -52,8 +52,9 @@ run_doctor() {
 }
 
 write_fake_install_tools() {
-  local dir="$1" conductor_mode="$2" version
+  local dir="$1" conductor_mode="$2" latest_version="${3:-}" version
   version="$(tr -d '[:space:]' <"$TOUCHSTONE_ROOT/VERSION")"
+  [ -n "$latest_version" ] || latest_version="$version"
   mkdir -p "$dir"
   for tool in gh pre-commit gitleaks shellcheck shfmt; do
     cat >"$dir/$tool" <<'EOF_FAKE_TOOL'
@@ -64,7 +65,7 @@ EOF_FAKE_TOOL
   done
   cat >"$dir/curl" <<EOF_FAKE_CURL
 #!/usr/bin/env bash
-printf '{"tag_name":"v%s"}\n' "$version"
+printf '{"tag_name":"v%s"}\n' "$latest_version"
 EOF_FAKE_CURL
   chmod +x "$dir/curl"
   if [ "$conductor_mode" = "present" ]; then
@@ -165,6 +166,27 @@ set -e
 
 assert_exit "$PRESENT_CONDUCTOR_EXIT" 0 "present conductor peer"
 assert_contains "$PRESENT_CONDUCTOR_OUT" "conductor: $PRESENT_CONDUCTOR_BIN/conductor (at least one provider configured)"
+
+# --------------------------------------------------------------------------
+# Test 2d: installation doctor ignores stale older latest-release metadata
+# --------------------------------------------------------------------------
+echo ""
+echo "--- Test 2d: installation doctor accepts installed version newer than latest release ---"
+
+STALE_LATEST_BIN="$TEST_DIR/stale-latest-bin"
+write_fake_install_tools "$STALE_LATEST_BIN" "present" "0.0.1"
+STALE_LATEST_OUT="$TEST_DIR/stale-latest.out"
+set +e
+PATH="$STALE_LATEST_BIN:/usr/bin:/bin" run_doctor "$FAKE_HOME" --installation >"$STALE_LATEST_OUT" 2>&1
+STALE_LATEST_EXIT=$?
+set -e
+
+assert_exit "$STALE_LATEST_EXIT" 0 "stale latest release"
+assert_contains "$STALE_LATEST_OUT" "newer than latest GitHub release v0.0.1"
+if grep -q "available (you have" "$STALE_LATEST_OUT"; then
+  echo "FAIL: stale older latest release should not be reported as an available upgrade" >&2
+  ERRORS=$((ERRORS + 1))
+fi
 
 # --------------------------------------------------------------------------
 # Test 3: review-stats missing log exits 0 with friendly message


### PR DESCRIPTION
## Summary

Fix the customer-facing case where GitHub Release metadata lags behind the tag/Homebrew tap and Touchstone treats an already-newer install as outdated.

## Root Cause

`touchstone doctor --installation` and `touchstone_auto_update` compared release versions with simple inequality. If the latest GitHub Release object is stale, any mismatch looked like an available upgrade, even when the installed version is newer.

## Changes

- Treat installed versions equal to or newer than the GitHub latest release tag as current.
- Keep warning/updating only when the release tag is actually newer than the installed version.
- Add regression coverage for stale older latest-release metadata in both doctor and auto-update.

## Validation

- `bash tests/test-auto-update.sh`
- `bash tests/test-doctor.sh`
- `shellcheck --severity=warning bin/touchstone lib/auto-update.sh tests/test-auto-update.sh tests/test-doctor.sh`
- `pre-commit run --files bin/touchstone lib/auto-update.sh tests/test-auto-update.sh tests/test-doctor.sh`
- `for test in tests/test-*.sh; do printf '==> %s\n' "$test"; bash "$test" || exit 1; done`

Closes #356