### PR TITLE
fix(claim): parse same-repo qualified refs

### DIFF
--- a/scripts/issue-claim-check.sh
+++ b/scripts/issue-claim-check.sh
@@ -50,7 +50,7 @@ extract_issue_refs() {
   # Pattern 2: closes/fixes/resolves with optional owner/repo prefix.
   while IFS= read -r match; do
     normalized="$(printf '%s' "$match" | tr '[:upper:]' '[:lower:]')"
-    target_repo="$(printf '%s' "$normalized" | sed -nE 's/.*(autumngarage\/[[:alnum:]_-]+)#.*/\1/p')"
+    target_repo="$(printf '%s' "$normalized" | sed -nE 's/^(closes|fixes|resolves):?[[:space:]]*([[:alnum:]_.-]+\/[[:alnum:]_.-]+)#[0-9]+$/\2/p')"
     if [ -n "$target_repo" ] && [ -n "$current_repo" ] && [ "$target_repo" != "$current_repo" ]; then
       echo "==> Skipping cross-repo reference: $match"
       continue
@@ -59,7 +59,7 @@ extract_issue_refs() {
     if [ -n "$issue_number" ]; then
       printf '%s\n' "$issue_number" >>"$refs_file"
     fi
-  done < <(grep -Eoi '\b(closes|fixes|resolves):?[[:space:]]*(autumngarage/[[:alnum:]_-]+)?#[0-9]+\b' "$body_file" || true)
+  done < <(grep -Eoi '\b(closes|fixes|resolves):?[[:space:]]*([[:alnum:]_.-]+/[[:alnum:]_.-]+)?#[0-9]+\b' "$body_file" || true)
 }
 
 format_assignee_label() {

--- a/tests/test-open-pr-linked-issues.sh
+++ b/tests/test-open-pr-linked-issues.sh
@@ -277,12 +277,13 @@ fi
 
 echo "==> Case 6: fully-qualified same-repo issue is enforced"
 BODY="$TEST_DIR/same-repo-qualified.md"
-printf 'Closes autumngarage/touchstone#50\n' >"$BODY"
+printf 'Closes outriderintel/outrider#50\n' >"$BODY"
 OUT="$TEST_DIR/same-repo-qualified.out"
 RC=0
 (
   cd "$REPO_DIR"
   PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    GH_REPO="outriderintel/outrider" \
     bash "$SCRIPT_DIR/issue-claim-check.sh" --body-file "$BODY" --author alice
 ) >"$OUT" 2>&1 || RC=$?
 
@@ -299,12 +300,13 @@ fi
 
 echo "==> Case 7: fully-qualified cross-repo issue is skipped"
 BODY="$TEST_DIR/cross-repo-qualified.md"
-printf 'Closes autumngarage/other-project#50\n' >"$BODY"
+printf 'Closes another-org/other-project#50\n' >"$BODY"
 OUT="$TEST_DIR/cross-repo-qualified.out"
 RC=0
 (
   cd "$REPO_DIR"
   PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    GH_REPO="outriderintel/outrider" \
     bash "$SCRIPT_DIR/issue-claim-check.sh" --body-file "$BODY" --author alice
 ) >"$OUT" 2>&1 || RC=$?
 


### PR DESCRIPTION
## Summary

- Generalize `issue-claim-check.sh` fully-qualified closing refs from `autumngarage/<repo>#N` to the current `owner/repo#N`.
- Keep cross-repo closing refs ignored for local claim enforcement.
- Add regression coverage for a non-`autumngarage` same-repo qualified ref and a cross-repo qualified ref.

## Validation

- `bash -n scripts/issue-claim-check.sh tests/test-open-pr-linked-issues.sh`
- `bash tests/test-open-pr-linked-issues.sh`
- `shellcheck --severity=warning scripts/issue-claim-check.sh tests/test-open-pr-linked-issues.sh`
- `git diff --check`
- `pre-commit run --files scripts/issue-claim-check.sh tests/test-open-pr-linked-issues.sh`
- `for test in tests/test-*.sh; do echo "==> $test"; bash "$test" || exit 1; done`

Closes #358