### PR TITLE
fix(update): use brew formula freshness for auto-update

### DIFF
--- a/lib/auto-update.sh
+++ b/lib/auto-update.sh
@@ -2,8 +2,8 @@
 #
 # lib/auto-update.sh — auto-update check for the Touchstone CLI.
 #
-# Checks if a newer version is available on GitHub. If yes, upgrades
-# via brew (if installed that way) or git pull (if running from clone).
+# Checks if a newer version is available. Brew installs use Homebrew's formula
+# state; source checkouts use GitHub Releases before pulling.
 #
 # Called on every `touchstone` invocation. Throttled to check at most
 # once per hour to avoid slowing down every command.
@@ -63,6 +63,33 @@ touchstone_auto_update_version_gte() {
     }'
 }
 
+touchstone_auto_update_installed_via_brew() {
+  command -v brew >/dev/null 2>&1 && brew list touchstone &>/dev/null
+}
+
+touchstone_auto_update_brew_outdated() {
+  local outdated
+
+  outdated="$(brew outdated --quiet touchstone 2>/dev/null)" || return 2
+  if printf '%s\n' "$outdated" | grep -Eq '(^|/)touchstone$'; then
+    return 0
+  fi
+
+  return 1
+}
+
+touchstone_auto_update_brew_upgrade() {
+  if brew upgrade touchstone 2>&1 | sed 's/^/    /' >&2; then
+    echo "==> Updated touchstone via brew." >&2
+    TOUCHSTONE_AUTO_UPDATE_REEXEC_PATH="$(command -v touchstone 2>/dev/null || true)"
+    export TOUCHSTONE_AUTO_UPDATE_REEXEC_PATH
+    return "$TOUCHSTONE_AUTO_UPDATE_REEXEC_EXIT"
+  fi
+
+  echo "WARNING: touchstone auto-update via brew failed; continuing with current version." >&2
+  return 0
+}
+
 touchstone_auto_update() {
   # Skip if disabled.
   if [ "${TOUCHSTONE_NO_AUTO_UPDATE:-}" = "1" ] \
@@ -95,6 +122,26 @@ touchstone_auto_update() {
     return 0
   fi
 
+  local installed_via_brew=false
+  if touchstone_auto_update_installed_via_brew; then
+    installed_via_brew=true
+    local brew_outdated_status=0
+    touchstone_auto_update_brew_outdated || brew_outdated_status=$?
+    case "$brew_outdated_status" in
+      0)
+        echo "==> touchstone v${current_version} is outdated according to Homebrew. Updating..." >&2
+        touchstone_auto_update_brew_upgrade
+        return $?
+        ;;
+      1)
+        return 0
+        ;;
+      *)
+        echo "WARNING: touchstone auto-update could not check Homebrew formula freshness; falling back to GitHub release metadata." >&2
+        ;;
+    esac
+  fi
+
   # Fetch latest release version from GitHub (non-blocking, timeout 5s).
   local latest_version
   latest_version="$(curl -fsSL --max-time 5 \
@@ -113,15 +160,9 @@ touchstone_auto_update() {
   # Installed version is older — try to upgrade.
   echo "==> touchstone v${current_version} is outdated (latest: v${latest_version}). Updating..." >&2
 
-  if command -v brew >/dev/null 2>&1 && brew list touchstone &>/dev/null; then
-    # Installed via brew — upgrade that way.
-    if brew upgrade touchstone 2>&1 | sed 's/^/    /' >&2; then
-      echo "==> Updated to v${latest_version} via brew." >&2
-      TOUCHSTONE_AUTO_UPDATE_REEXEC_PATH="$(command -v touchstone 2>/dev/null || true)"
-      export TOUCHSTONE_AUTO_UPDATE_REEXEC_PATH
-      return "$TOUCHSTONE_AUTO_UPDATE_REEXEC_EXIT"
-    fi
-    echo "WARNING: touchstone auto-update via brew failed; continuing with current version." >&2
+  if [ "$installed_via_brew" = true ]; then
+    touchstone_auto_update_brew_upgrade
+    return $?
   elif [ -d "$TOUCHSTONE_ROOT/.git" ]; then
     # Running from a git clone — pull.
     if git -C "$TOUCHSTONE_ROOT" pull --rebase 2>&1 | sed 's/^/    /' >&2; then

--- a/tests/test-auto-update.sh
+++ b/tests/test-auto-update.sh
@@ -26,6 +26,17 @@ case "${1:-}" in
     [ "${2:-}" = "touchstone" ] || exit 1
     exit 0
     ;;
+  outdated)
+    [ "${2:-}" = "--quiet" ] || exit 1
+    [ "${3:-}" = "touchstone" ] || exit 1
+    if [ "${BREW_OUTDATED_FAIL:-0}" = "1" ]; then
+      exit 42
+    fi
+    if [ "${BREW_TOUCHSTONE_OUTDATED:-0}" = "1" ]; then
+      echo "touchstone"
+    fi
+    exit 0
+    ;;
   upgrade)
     [ "${2:-}" = "touchstone" ] || exit 1
     echo "fake brew upgraded touchstone"
@@ -47,6 +58,7 @@ chmod +x "$FAKE_BIN/touchstone"
 
 OUT="$TEST_DIR/reexec.out"
 PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+  BREW_TOUCHSTONE_OUTDATED=1 \
   TOUCHSTONE_UPDATE_INTERVAL=0 \
   TOUCHSTONE_STATE_DIR="$STATE_DIR" \
   "$TOUCHSTONE_ROOT/bin/touchstone" version >"$OUT" 2>&1
@@ -68,6 +80,7 @@ chmod +x "$FAKE_BIN/curl"
 
 OUT_CURRENT="$TEST_DIR/current-newer.out"
 PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+  BREW_TOUCHSTONE_OUTDATED=0 \
   TOUCHSTONE_UPDATE_INTERVAL=0 \
   TOUCHSTONE_STATE_DIR="$STATE_DIR" \
   "$TOUCHSTONE_ROOT/bin/touchstone" version >"$OUT_CURRENT" 2>&1
@@ -80,3 +93,43 @@ if grep -q 'fake brew upgraded touchstone' "$OUT_CURRENT" \
 fi
 
 echo "PASS: touchstone auto-update ignores stale older latest release"
+
+OUT_BREW_CURRENT="$TEST_DIR/brew-newer-than-release.out"
+PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+  BREW_TOUCHSTONE_OUTDATED=1 \
+  TOUCHSTONE_UPDATE_INTERVAL=0 \
+  TOUCHSTONE_STATE_DIR="$STATE_DIR" \
+  "$TOUCHSTONE_ROOT/bin/touchstone" version >"$OUT_BREW_CURRENT" 2>&1
+
+if grep -q 'fake brew upgraded touchstone' "$OUT_BREW_CURRENT" \
+  && grep -q '^REEXECED:1:version$' "$OUT_BREW_CURRENT"; then
+  echo "PASS: brew auto-update follows formula state when GitHub release is stale"
+else
+  echo "FAIL: brew formula freshness should trigger auto-update despite stale GitHub release" >&2
+  cat "$OUT_BREW_CURRENT" >&2
+  exit 1
+fi
+
+cat >"$FAKE_BIN/curl" <<'EOF'
+#!/usr/bin/env bash
+printf '{"tag_name":"v999.0.0"}\n'
+EOF
+chmod +x "$FAKE_BIN/curl"
+
+OUT_BREW_FAIL="$TEST_DIR/brew-outdated-fails.out"
+PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+  BREW_OUTDATED_FAIL=1 \
+  BREW_TOUCHSTONE_OUTDATED=0 \
+  TOUCHSTONE_UPDATE_INTERVAL=0 \
+  TOUCHSTONE_STATE_DIR="$STATE_DIR" \
+  "$TOUCHSTONE_ROOT/bin/touchstone" version >"$OUT_BREW_FAIL" 2>&1
+
+if grep -q 'could not check Homebrew formula freshness' "$OUT_BREW_FAIL" \
+  && grep -q 'fake brew upgraded touchstone' "$OUT_BREW_FAIL" \
+  && grep -q '^REEXECED:1:version$' "$OUT_BREW_FAIL"; then
+  echo "PASS: brew auto-update falls back visibly when brew freshness check fails"
+else
+  echo "FAIL: brew freshness check failure should warn and fall back to GitHub metadata" >&2
+  cat "$OUT_BREW_FAIL" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Make Homebrew-installed Touchstone auto-update check Homebrew formula freshness via `brew outdated --quiet touchstone`.
- Keep GitHub Release metadata as the source only for non-Brew/source-checkout update decisions.
- Add regression coverage for stale GitHub latest Release metadata while Homebrew reports Touchstone as outdated.

## Validation

- `bash -n lib/auto-update.sh tests/test-auto-update.sh`
- `bash tests/test-auto-update.sh`
- `shellcheck --severity=warning lib/auto-update.sh tests/test-auto-update.sh`
- `git diff --check`
- `pre-commit run --files lib/auto-update.sh tests/test-auto-update.sh`
- `for test in tests/test-*.sh; do echo "==> $test"; bash "$test" || exit 1; done`

Closes #360