### PR TITLE
fix(release): preflight gh auth before tagging

### DIFF
--- a/lib/release.sh
+++ b/lib/release.sh
@@ -13,6 +13,18 @@ source "${TOUCHSTONE_ROOT}/lib/colors.sh"
 
 TOUCHSTONE_ROOT="${TOUCHSTONE_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 
+touchstone_release_preflight_github_release_auth() {
+  if ! command -v gh >/dev/null 2>&1; then
+    tk_fail "GitHub CLI is required to create the release. Install gh and try again."
+    return 1
+  fi
+
+  if ! gh auth status --hostname github.com >/dev/null 2>&1; then
+    tk_fail "GitHub CLI is not authenticated. Run: gh auth login"
+    return 1
+  fi
+}
+
 touchstone_release() {
   local bump_type="${1:-minor}"
 
@@ -54,6 +66,10 @@ touchstone_release() {
   esac
   local new_version="${major}.${minor}.${patch}"
   tk_info "New version: v${new_version}"
+
+  # Fail before mutating the repo; otherwise a local auth problem can leave a
+  # pushed tag without the GitHub Release object that drives release workflows.
+  touchstone_release_preflight_github_release_auth || return 1
 
   # Bump VERSION file and touchstone's own dogfood stamp.
   echo "$new_version" >"$TOUCHSTONE_ROOT/VERSION"

--- a/tests/test-release.sh
+++ b/tests/test-release.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# tests/test-release.sh — release workflow guardrails.
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_DIR="$(mktemp -d -t touchstone-test-release.XXXXXX)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+PROJECT="$TEST_DIR/project"
+FAKE_BIN="$TEST_DIR/bin"
+mkdir -p "$PROJECT/lib" "$FAKE_BIN"
+
+cp "$REPO_ROOT/lib/colors.sh" "$PROJECT/lib/colors.sh"
+printf '1.2.3\n' >"$PROJECT/VERSION"
+printf '1.2.3\n' >"$PROJECT/.touchstone-version"
+
+git -C "$PROJECT" init -q
+git -C "$PROJECT" checkout -q -b main
+git -C "$PROJECT" config user.email test@example.test
+git -C "$PROJECT" config user.name "Touchstone Test"
+git -C "$PROJECT" add VERSION .touchstone-version lib/colors.sh
+git -C "$PROJECT" commit -q -m "initial"
+INITIAL_HEAD="$(git -C "$PROJECT" rev-parse HEAD)"
+
+cat >"$FAKE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${FAKE_GH_LOG:?}"
+case "${1:-} ${2:-}" in
+  "auth status") exit 1 ;;
+  "release create") exit 99 ;;
+esac
+exit 1
+EOF
+chmod +x "$FAKE_BIN/gh"
+
+OUT="$TEST_DIR/release.out"
+FAKE_GH_LOG="$TEST_DIR/gh.log"
+export FAKE_GH_LOG
+
+set +e
+(
+  export TOUCHSTONE_ROOT="$PROJECT"
+  export PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin"
+  # shellcheck source=../lib/release.sh
+  source "$REPO_ROOT/lib/release.sh"
+  touchstone_release patch
+) >"$OUT" 2>&1
+release_status=$?
+set -e
+
+if [ "$release_status" -eq 0 ]; then
+  echo "FAIL: release should fail when gh is unauthenticated" >&2
+  cat "$OUT" >&2
+  exit 1
+fi
+
+if [ "$(tr -d '[:space:]' <"$PROJECT/VERSION")" != "1.2.3" ] \
+  || [ "$(tr -d '[:space:]' <"$PROJECT/.touchstone-version")" != "1.2.3" ]; then
+  echo "FAIL: release auth preflight mutated version files" >&2
+  cat "$OUT" >&2
+  exit 1
+fi
+
+if [ "$(git -C "$PROJECT" rev-parse HEAD)" != "$INITIAL_HEAD" ]; then
+  echo "FAIL: release auth preflight created a commit" >&2
+  cat "$OUT" >&2
+  exit 1
+fi
+
+if git -C "$PROJECT" rev-parse -q --verify refs/tags/v1.2.4 >/dev/null; then
+  echo "FAIL: release auth preflight created a tag" >&2
+  cat "$OUT" >&2
+  exit 1
+fi
+
+if ! grep -q '^auth status --hostname github.com$' "$FAKE_GH_LOG"; then
+  echo "FAIL: release did not check gh auth status" >&2
+  cat "$OUT" >&2
+  exit 1
+fi
+
+if grep -q '^release create ' "$FAKE_GH_LOG"; then
+  echo "FAIL: release tried to create GitHub release after failed auth preflight" >&2
+  cat "$OUT" >&2
+  exit 1
+fi
+
+if ! grep -q 'gh auth login' "$OUT"; then
+  echo "FAIL: release auth failure should print actionable login guidance" >&2
+  cat "$OUT" >&2
+  exit 1
+fi
+
+echo "PASS: release auth preflight fails before VERSION, commit, or tag mutation"


### PR DESCRIPTION
## Summary

- Add a release preflight that verifies `gh` is installed and authenticated before mutating VERSION, committing, tagging, or pushing.
- Add a regression test proving an unauthenticated `gh` failure leaves VERSION, HEAD, and tags unchanged.

## Validation

- `bash -n lib/release.sh tests/test-release.sh`
- `bash tests/test-release.sh`
- `shellcheck --severity=warning lib/release.sh tests/test-release.sh`
- `pre-commit run --files lib/release.sh tests/test-release.sh`
- `for test in tests/test-*.sh; do echo "==> $test"; bash "$test" || exit 1; done`

Closes #362