### PR TITLE
fix(preflight): reuse clean deterministic markers

### DIFF
--- a/lib/preflight.sh
+++ b/lib/preflight.sh
@@ -20,11 +20,21 @@ fi
 
 TOUCHSTONE_PREFLIGHT_SCOPE_MODE="${TOUCHSTONE_PREFLIGHT_SCOPE_MODE:-all}"
 TOUCHSTONE_PREFLIGHT_DIFF_BASE="${TOUCHSTONE_PREFLIGHT_DIFF_BASE:-}"
+TOUCHSTONE_PREFLIGHT_CACHE_KEY=""
+TOUCHSTONE_PREFLIGHT_CACHE_FILE=""
+TOUCHSTONE_PREFLIGHT_CACHE_INPUTS=""
 
 touchstone_preflight_info() { printf '==> %s\n' "$*"; }
 touchstone_preflight_ok() { printf '  OK %s\n' "$*"; }
 touchstone_preflight_skip() { printf '  SKIP %s\n' "$*"; }
 touchstone_preflight_fail() { printf '  FAIL %s\n' "$*" >&2; }
+
+touchstone_preflight_truthy() {
+  case "$(printf '%s' "${1:-false}" | tr '[:upper:]' '[:lower:]')" in
+    true | 1 | yes | on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
 
 touchstone_preflight_unset_review_env() {
   unset TOUCHSTONE_CONDUCTOR_WITH
@@ -70,6 +80,195 @@ touchstone_preflight_repo_root() {
     return
   fi
   git rev-parse --show-toplevel 2>/dev/null || pwd
+}
+
+touchstone_preflight_hash_stream() {
+  shasum -a 256 | awk '{ print $1 }'
+}
+
+touchstone_preflight_hash_file() {
+  local path="$1"
+
+  if [ -f "$path" ]; then
+    shasum -a 256 "$path" | awk '{ print $1 }'
+  else
+    printf 'missing'
+  fi
+}
+
+touchstone_preflight_hash_paths() {
+  local repo_root="$1"
+  shift
+  local rel path
+
+  for rel in "$@"; do
+    path="$repo_root/$rel"
+    printf '%s\t%s\n' "$rel" "$(touchstone_preflight_hash_file "$path")"
+  done | touchstone_preflight_hash_stream
+}
+
+touchstone_preflight_hash_file_list() {
+  local label path
+
+  while [ "$#" -gt 0 ]; do
+    label="$1"
+    path="$2"
+    shift 2
+    printf '%s\t%s\n' "$label" "$(touchstone_preflight_hash_file "$path")"
+  done | touchstone_preflight_hash_stream
+}
+
+touchstone_preflight_worktree_hash() {
+  local repo_root="$1"
+
+  (
+    cd "$repo_root" || exit 1
+    git status --porcelain --untracked-files=all
+    printf '\n-- worktree diff --\n'
+    git diff --binary
+    printf '\n-- index diff --\n'
+    git diff --cached --binary
+    printf '\n-- untracked files --\n'
+    while IFS= read -r -d '' rel; do
+      printf 'path\t%s\n' "$rel"
+      if [ -f "$rel" ]; then
+        printf 'sha256\t%s\n' "$(touchstone_preflight_hash_file "$rel")"
+      else
+        printf 'sha256\tmissing\n'
+      fi
+    done < <(git ls-files --others --exclude-standard -z)
+  ) 2>/dev/null | touchstone_preflight_hash_stream
+}
+
+touchstone_preflight_changed_paths_hash() {
+  local repo_root="$1"
+  local base_ref="$2"
+
+  (cd "$repo_root" && git diff --name-only "$base_ref"...HEAD) 2>/dev/null \
+    | sort -u \
+    | touchstone_preflight_hash_stream
+}
+
+touchstone_preflight_tool_fingerprint() {
+  local tool path version_hash
+
+  for tool in shellcheck shfmt markdownlint-cli2 markdownlint actionlint; do
+    path="$(command -v "$tool" 2>/dev/null || true)"
+    if [ -n "$path" ]; then
+      version_hash="$({ "$tool" --version 2>&1 || true; } | touchstone_preflight_hash_stream)"
+      printf '%s\t%s\t%s\n' "$tool" "$path" "$version_hash"
+    else
+      printf '%s\tmissing\tmissing\n' "$tool"
+    fi
+  done | touchstone_preflight_hash_stream
+}
+
+touchstone_preflight_env_fingerprint() {
+  {
+    printf 'TOUCHSTONE_PREFLIGHT_VALIDATE_SCRIPT=%s\n' "${TOUCHSTONE_PREFLIGHT_VALIDATE_SCRIPT:-}"
+    printf 'TOUCHSTONE_PREFLIGHT_VALIDATE_COMMAND=%s\n' "${TOUCHSTONE_PREFLIGHT_VALIDATE_COMMAND:-}"
+  } | touchstone_preflight_hash_stream
+}
+
+touchstone_preflight_cache_inputs() {
+  local base_ref="$1"
+  local repo_root head_sha base_sha merge_base changed_paths_hash
+  local checker_hash config_hash worktree_hash tool_hash env_hash
+
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  repo_root="$(cd "$repo_root" && pwd)" || return 1
+  head_sha="$(git -C "$repo_root" rev-parse HEAD 2>/dev/null)" || return 1
+  base_sha="$(git -C "$repo_root" rev-parse --verify "$base_ref^{commit}" 2>/dev/null)" || return 1
+  merge_base="$(git -C "$repo_root" merge-base "$base_ref" "$head_sha" 2>/dev/null)" || return 1
+  changed_paths_hash="$(touchstone_preflight_changed_paths_hash "$repo_root" "$base_ref")" || return 1
+  checker_hash="$(touchstone_preflight_hash_file_list \
+    "lib/preflight.sh" "$PREFLIGHT_LIB_DIR/preflight.sh" \
+    "lib/preflight-scope.sh" "$PREFLIGHT_LIB_DIR/preflight-scope.sh" \
+    "scripts/touchstone-run.sh" "$PREFLIGHT_LIB_DIR/../scripts/touchstone-run.sh")"
+  config_hash="$(touchstone_preflight_hash_paths "$repo_root" \
+    ".touchstone-review.toml" \
+    ".codex-review.toml" \
+    ".touchstone-config" \
+    ".touchstone-version" \
+    ".pre-commit-config.yaml" \
+    ".markdownlint.json")"
+  worktree_hash="$(touchstone_preflight_worktree_hash "$repo_root")" || return 1
+  tool_hash="$(touchstone_preflight_tool_fingerprint)"
+  env_hash="$(touchstone_preflight_env_fingerprint)"
+
+  printf 'version=2\n'
+  printf 'repo_root=%s\n' "$repo_root"
+  printf 'scope=diff\n'
+  printf 'base_ref=%s\n' "$base_ref"
+  printf 'base_sha=%s\n' "$base_sha"
+  printf 'head_sha=%s\n' "$head_sha"
+  printf 'merge_base=%s\n' "$merge_base"
+  printf 'changed_paths_hash=%s\n' "$changed_paths_hash"
+  printf 'checker_hash=%s\n' "$checker_hash"
+  printf 'config_hash=%s\n' "$config_hash"
+  printf 'worktree_hash=%s\n' "$worktree_hash"
+  printf 'tool_hash=%s\n' "$tool_hash"
+  printf 'env_hash=%s\n' "$env_hash"
+}
+
+touchstone_preflight_cache_prepare() {
+  local base_ref="$1"
+  local cache_dir
+
+  TOUCHSTONE_PREFLIGHT_CACHE_KEY=""
+  TOUCHSTONE_PREFLIGHT_CACHE_FILE=""
+  TOUCHSTONE_PREFLIGHT_CACHE_INPUTS=""
+
+  if [ -z "$base_ref" ]; then
+    return 1
+  fi
+  if touchstone_preflight_truthy "${TOUCHSTONE_PREFLIGHT_DISABLE_CACHE:-false}"; then
+    return 1
+  fi
+
+  TOUCHSTONE_PREFLIGHT_CACHE_INPUTS="$(touchstone_preflight_cache_inputs "$base_ref")" || return 1
+  TOUCHSTONE_PREFLIGHT_CACHE_KEY="$(printf '%s\n' "$TOUCHSTONE_PREFLIGHT_CACHE_INPUTS" | touchstone_preflight_hash_stream)"
+  cache_dir="$(git rev-parse --git-path touchstone/preflight-clean 2>/dev/null)" || return 1
+  TOUCHSTONE_PREFLIGHT_CACHE_FILE="$cache_dir/$TOUCHSTONE_PREFLIGHT_CACHE_KEY.clean"
+}
+
+touchstone_preflight_cache_short_key() {
+  printf '%s' "${TOUCHSTONE_PREFLIGHT_CACHE_KEY:0:12}"
+}
+
+touchstone_preflight_cache_hit() {
+  local marker_inputs
+
+  [ -n "$TOUCHSTONE_PREFLIGHT_CACHE_FILE" ] || return 1
+  [ -f "$TOUCHSTONE_PREFLIGHT_CACHE_FILE" ] || return 1
+  grep -q '^result=preflight_clean$' "$TOUCHSTONE_PREFLIGHT_CACHE_FILE" || return 1
+  marker_inputs="$(sed '1,2d' "$TOUCHSTONE_PREFLIGHT_CACHE_FILE")"
+  [ "$marker_inputs" = "$TOUCHSTONE_PREFLIGHT_CACHE_INPUTS" ]
+}
+
+touchstone_preflight_write_clean_cache() {
+  local cache_dir tmp
+
+  [ -n "$TOUCHSTONE_PREFLIGHT_CACHE_FILE" ] || return 0
+  [ -n "$TOUCHSTONE_PREFLIGHT_CACHE_INPUTS" ] || return 0
+  cache_dir="$(dirname "$TOUCHSTONE_PREFLIGHT_CACHE_FILE")"
+  if ! mkdir -p "$cache_dir" 2>/dev/null; then
+    echo "WARNING: could not create preflight cache directory $cache_dir; continuing without cache." >&2
+    return 0
+  fi
+
+  tmp="$TOUCHSTONE_PREFLIGHT_CACHE_FILE.$$"
+  if {
+    printf 'result=preflight_clean\n'
+    printf 'created_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")"
+    printf '%s\n' "$TOUCHSTONE_PREFLIGHT_CACHE_INPUTS"
+  } >"$tmp" 2>/dev/null && mv "$tmp" "$TOUCHSTONE_PREFLIGHT_CACHE_FILE" 2>/dev/null; then
+    return 0
+  fi
+
+  rm -f "$tmp" 2>/dev/null || true
+  echo "WARNING: could not write preflight cache marker $TOUCHSTONE_PREFLIGHT_CACHE_FILE; continuing without cache." >&2
+  return 0
 }
 
 touchstone_preflight_all_files() {

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -383,34 +383,68 @@ preflight_hash_file_list() {
 }
 
 preflight_worktree_hash() {
-  {
-    git status --porcelain
+  local repo_root="$1"
+
+  (
+    cd "$repo_root" || exit 1
+    git status --porcelain --untracked-files=all
     printf '\n-- worktree diff --\n'
     git diff --binary
     printf '\n-- index diff --\n'
     git diff --cached --binary
-  } 2>/dev/null | preflight_hash_stream
+    printf '\n-- untracked files --\n'
+    while IFS= read -r -d '' rel; do
+      printf 'path\t%s\n' "$rel"
+      if [ -f "$rel" ]; then
+        printf 'sha256\t%s\n' "$(preflight_hash_file "$rel")"
+      else
+        printf 'sha256\tmissing\n'
+      fi
+    done < <(git ls-files --others --exclude-standard -z)
+  ) 2>/dev/null | preflight_hash_stream
 }
 
 preflight_changed_paths_hash() {
-  local base_ref="$1"
+  local repo_root="$1"
+  local base_ref="$2"
 
-  git diff --name-only "$base_ref"...HEAD 2>/dev/null \
+  (cd "$repo_root" && git diff --name-only "$base_ref"...HEAD) 2>/dev/null \
     | sort -u \
     | preflight_hash_stream
 }
 
+preflight_tool_fingerprint() {
+  local tool path version_hash
+
+  for tool in shellcheck shfmt markdownlint-cli2 markdownlint actionlint; do
+    path="$(command -v "$tool" 2>/dev/null || true)"
+    if [ -n "$path" ]; then
+      version_hash="$({ "$tool" --version 2>&1 || true; } | preflight_hash_stream)"
+      printf '%s\t%s\t%s\n' "$tool" "$path" "$version_hash"
+    else
+      printf '%s\tmissing\tmissing\n' "$tool"
+    fi
+  done | preflight_hash_stream
+}
+
+preflight_env_fingerprint() {
+  {
+    printf 'TOUCHSTONE_PREFLIGHT_VALIDATE_SCRIPT=%s\n' "${TOUCHSTONE_PREFLIGHT_VALIDATE_SCRIPT:-}"
+    printf 'TOUCHSTONE_PREFLIGHT_VALIDATE_COMMAND=%s\n' "${TOUCHSTONE_PREFLIGHT_VALIDATE_COMMAND:-}"
+  } | preflight_hash_stream
+}
+
 preflight_cache_inputs() {
   local base_ref="$1"
-  local event_mode="$2"
   local repo_root head_sha base_sha merge_base changed_paths_hash
-  local checker_hash config_hash worktree_hash
+  local checker_hash config_hash worktree_hash tool_hash env_hash
 
   repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-  head_sha="$(git rev-parse HEAD 2>/dev/null)" || return 1
-  base_sha="$(git rev-parse --verify "$base_ref^{commit}" 2>/dev/null)" || return 1
-  merge_base="$(git merge-base "$base_ref" "$head_sha" 2>/dev/null)" || return 1
-  changed_paths_hash="$(preflight_changed_paths_hash "$base_ref")" || return 1
+  repo_root="$(cd "$repo_root" && pwd)" || return 1
+  head_sha="$(git -C "$repo_root" rev-parse HEAD 2>/dev/null)" || return 1
+  base_sha="$(git -C "$repo_root" rev-parse --verify "$base_ref^{commit}" 2>/dev/null)" || return 1
+  merge_base="$(git -C "$repo_root" merge-base "$base_ref" "$head_sha" 2>/dev/null)" || return 1
+  changed_paths_hash="$(preflight_changed_paths_hash "$repo_root" "$base_ref")" || return 1
   checker_hash="$(preflight_hash_file_list \
     "lib/preflight.sh" "$PREFLIGHT_SCRIPT" \
     "lib/preflight-scope.sh" "$(dirname "$PREFLIGHT_SCRIPT")/preflight-scope.sh" \
@@ -422,12 +456,13 @@ preflight_cache_inputs() {
     ".touchstone-version" \
     ".pre-commit-config.yaml" \
     ".markdownlint.json")"
-  worktree_hash="$(preflight_worktree_hash)" || return 1
+  worktree_hash="$(preflight_worktree_hash "$repo_root")" || return 1
+  tool_hash="$(preflight_tool_fingerprint)"
+  env_hash="$(preflight_env_fingerprint)"
 
-  printf 'version=1\n'
+  printf 'version=2\n'
   printf 'repo_root=%s\n' "$repo_root"
   printf 'scope=diff\n'
-  printf 'event_mode=%s\n' "$event_mode"
   printf 'base_ref=%s\n' "$base_ref"
   printf 'base_sha=%s\n' "$base_sha"
   printf 'head_sha=%s\n' "$head_sha"
@@ -436,11 +471,12 @@ preflight_cache_inputs() {
   printf 'checker_hash=%s\n' "$checker_hash"
   printf 'config_hash=%s\n' "$config_hash"
   printf 'worktree_hash=%s\n' "$worktree_hash"
+  printf 'tool_hash=%s\n' "$tool_hash"
+  printf 'env_hash=%s\n' "$env_hash"
 }
 
 preflight_cache_prepare() {
   local base_ref="$1"
-  local event_mode="$2"
   local cache_dir
 
   PREFLIGHT_CACHE_KEY=""
@@ -451,7 +487,7 @@ preflight_cache_prepare() {
     return 1
   fi
 
-  PREFLIGHT_CACHE_INPUTS="$(preflight_cache_inputs "$base_ref" "$event_mode")" || return 1
+  PREFLIGHT_CACHE_INPUTS="$(preflight_cache_inputs "$base_ref")" || return 1
   PREFLIGHT_CACHE_KEY="$(printf '%s\n' "$PREFLIGHT_CACHE_INPUTS" | preflight_hash_stream)"
   cache_dir="$(git rev-parse --git-path touchstone/preflight-clean 2>/dev/null)" || return 1
   PREFLIGHT_CACHE_FILE="$cache_dir/$PREFLIGHT_CACHE_KEY.clean"

--- a/scripts/open-pr.sh
+++ b/scripts/open-pr.sh
@@ -188,6 +188,38 @@ run_pr_body_protocol_preflight() {
   fi
 }
 
+run_deterministic_preflight_for_advisory() {
+  local base_ref="$1"
+  local repo_root cache_key_short
+
+  repo_root="$(git rev-parse --show-toplevel)"
+
+  if declare -F touchstone_preflight_cache_prepare >/dev/null 2>&1 \
+    && touchstone_preflight_cache_prepare "$base_ref" \
+    && touchstone_preflight_cache_hit; then
+    cache_key_short="$(touchstone_preflight_cache_short_key)"
+    echo "==> Deterministic preflight clean (cached=true, key=$cache_key_short; before advisory review, diff vs $base_ref)."
+    return 0
+  fi
+
+  echo "==> Running deterministic preflight before advisory review ..."
+  if touchstone_preflight_main_sanitized --diff "$base_ref" "$repo_root"; then
+    if declare -F touchstone_preflight_write_clean_cache >/dev/null 2>&1; then
+      touchstone_preflight_write_clean_cache
+    fi
+    if [ -n "${TOUCHSTONE_PREFLIGHT_CACHE_KEY:-}" ] \
+      && declare -F touchstone_preflight_cache_short_key >/dev/null 2>&1; then
+      cache_key_short="$(touchstone_preflight_cache_short_key)"
+      echo "==> Deterministic preflight clean (cached=false, key=$cache_key_short)."
+    else
+      echo "==> Deterministic preflight clean (cached=false)."
+    fi
+    return 0
+  fi
+
+  return 1
+}
+
 truthy() {
   case "$(printf '%s' "${1:-false}" | tr '[:upper:]' '[:lower:]')" in
     true | 1 | yes | on) return 0 ;;
@@ -254,8 +286,7 @@ run_advisory_review_at_pr_open() {
 
   if truthy "$PREFLIGHT_REQUIRED" && ! truthy "${TOUCHSTONE_NO_PREFLIGHT:-false}"; then
     if declare -F touchstone_preflight_main >/dev/null 2>&1; then
-      echo "==> Running deterministic preflight before advisory review ..."
-      if ! touchstone_preflight_main_sanitized --diff "origin/$base_branch" "$(git rev-parse --show-toplevel)"; then
+      if ! run_deterministic_preflight_for_advisory "origin/$base_branch"; then
         echo "WARNING: preflight failed; skipping non-blocking advisory review to avoid spending provider tokens." >&2
         return 0
       fi

--- a/tests/test-advisory-at-pr-open.sh
+++ b/tests/test-advisory-at-pr-open.sh
@@ -94,7 +94,7 @@ git -C "$REPO_DIR" commit -m "test advisory" >/dev/null 2>&1
 run_open_pr() {
   local output_file="$1"
   (
-    cd "$REPO_DIR"
+    cd "${OPEN_PR_WORKDIR:-$REPO_DIR}"
     PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
       GH_COMMENT_FILE="$TEST_DIR/comments" \
       CODEX_REVIEW_STUB_EXIT="${CODEX_REVIEW_STUB_EXIT:-0}" \
@@ -189,12 +189,57 @@ OUT="$TEST_DIR/preflight.out"
   CODEX_REVIEW_STUB_EXIT=0 CODEX_REVIEW_STUB_FINDINGS=0 CODEX_REVIEW_STUB_REASON=clean run_open_pr "$OUT"
 )
 if grep -q '^TOUCHSTONE_PREFLIGHT_ALREADY_RAN=true$' "$TEST_DIR/review-env" \
-  && grep -q '^TOUCHSTONE_CONDUCTOR_WITH=deepseek-reasoner$' "$TEST_DIR/review-env"; then
+  && grep -q '^TOUCHSTONE_CONDUCTOR_WITH=deepseek-reasoner$' "$TEST_DIR/review-env" \
+  && grep -q 'Deterministic preflight clean (cached=false' "$OUT"; then
   echo "    PASS"
 else
   echo "    FAIL: advisory review should know clean preflight already ran" >&2
   cat "$OUT" >&2
   [ -f "$TEST_DIR/review-env" ] && cat "$TEST_DIR/review-env" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo "==> Case 5: repeated advisory preflight reuses the exact clean marker"
+reset_case
+OUT="$TEST_DIR/preflight-cached.out"
+(
+  export TOUCHSTONE_CONDUCTOR_WITH="deepseek-reasoner"
+  CODEX_REVIEW_STUB_EXIT=0 CODEX_REVIEW_STUB_FINDINGS=0 CODEX_REVIEW_STUB_REASON=clean run_open_pr "$OUT"
+)
+if grep -q 'Deterministic preflight clean (cached=true' "$OUT" \
+  && grep -q '^TOUCHSTONE_PREFLIGHT_ALREADY_RAN=true$' "$TEST_DIR/review-env"; then
+  echo "    PASS"
+else
+  echo "    FAIL: repeated advisory preflight should reuse the clean marker" >&2
+  cat "$OUT" >&2
+  [ -f "$TEST_DIR/review-env" ] && cat "$TEST_DIR/review-env" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo "==> Case 6: advisory preflight cache hashes root worktree state from subdirs"
+reset_case
+mkdir -p "$REPO_DIR/nested"
+printf 'root one\n' >"$REPO_DIR/root-untracked.txt"
+OUT="$TEST_DIR/preflight-subdir-first.out"
+(
+  export OPEN_PR_WORKDIR="$REPO_DIR/nested"
+  CODEX_REVIEW_STUB_EXIT=0 CODEX_REVIEW_STUB_FINDINGS=0 CODEX_REVIEW_STUB_REASON=clean run_open_pr "$OUT"
+)
+printf 'root two\n' >"$REPO_DIR/root-untracked.txt"
+OUT2="$TEST_DIR/preflight-subdir-second.out"
+(
+  export OPEN_PR_WORKDIR="$REPO_DIR/nested"
+  CODEX_REVIEW_STUB_EXIT=0 CODEX_REVIEW_STUB_FINDINGS=0 CODEX_REVIEW_STUB_REASON=clean run_open_pr "$OUT2"
+)
+rm -f "$REPO_DIR/root-untracked.txt"
+if grep -q 'Deterministic preflight clean (cached=false' "$OUT" \
+  && grep -q 'Deterministic preflight clean (cached=false' "$OUT2" \
+  && ! grep -q 'Deterministic preflight clean (cached=true' "$OUT2"; then
+  echo "    PASS"
+else
+  echo "    FAIL: subdir-launched advisory preflight missed root worktree state" >&2
+  cat "$OUT" >&2
+  cat "$OUT2" >&2
   ERRORS=$((ERRORS + 1))
 fi
 

--- a/tests/test-merge-pr.sh
+++ b/tests/test-merge-pr.sh
@@ -11,7 +11,8 @@ trap 'rm -rf "$TEST_DIR"' EXIT
 FAKE_BIN="$TEST_DIR/bin"
 MERGE_SCRIPT_DIR="$TEST_DIR/scripts"
 GIT_PATH_ROOT="$TEST_DIR/git-path"
-mkdir -p "$FAKE_BIN" "$MERGE_SCRIPT_DIR" "$GIT_PATH_ROOT"
+DEFAULT_FAKE_WORKTREE="$TEST_DIR/default-feature-worktree"
+mkdir -p "$FAKE_BIN" "$MERGE_SCRIPT_DIR" "$GIT_PATH_ROOT" "$DEFAULT_FAKE_WORKTREE"
 cp "$TOUCHSTONE_ROOT/scripts/merge-pr.sh" "$MERGE_SCRIPT_DIR/merge-pr.sh"
 cat >"$MERGE_SCRIPT_DIR/codex-review.sh" <<'EOF'
 #!/usr/bin/env bash
@@ -125,9 +126,12 @@ cat >"$FAKE_BIN/git" <<'EOF'
 set -euo pipefail
 
 if [ "${1:-}" = "-C" ]; then
-  case "${3:-} ${4:-}" in
+  git_c_target="$2"
+  cd "$git_c_target"
+  shift 2
+  case "${1:-} ${2:-}" in
     "pull --ff-only")
-      printf '%s\n' "$2" > "$GIT_SIBLING_PULL_FILE"
+      printf '%s\n' "$git_c_target" > "$GIT_SIBLING_PULL_FILE"
       if [ "${GIT_SIBLING_PULL_FAIL:-false}" = "true" ]; then
         echo "sibling pull failed" >&2
         exit 1
@@ -140,17 +144,14 @@ if [ "${1:-}" = "-C" ]; then
       exit 0
       ;;
     "worktree remove")
-      printf '%s\n' "${5:-}" > "$GIT_WORKTREE_REMOVE_FILE"
+      remove_target="${4:-${3:-}}"
+      printf '%s\n' "$remove_target" > "$GIT_WORKTREE_REMOVE_FILE"
       if [ "${GIT_WORKTREE_REMOVE_FAIL:-false}" = "true" ]; then
         echo "worktree remove failed" >&2
         exit 1
       fi
-      echo "removed ${5:-}"
+      echo "removed $remove_target"
       exit 0
-      ;;
-    *)
-      echo "unexpected git -C args: $*" >&2
-      exit 1
       ;;
   esac
 fi
@@ -217,7 +218,13 @@ case "$*" in
   "fetch origin +refs/heads/main:refs/remotes/origin/main")
     echo "fetched main"
     ;;
-  "status --porcelain")
+  "status --porcelain" | "status --porcelain --untracked-files=all")
+    ;;
+  "ls-files --others --exclude-standard -z")
+    if [ -n "${GIT_UNTRACKED_PATH:-}" ] \
+      && { [ "${GIT_REQUIRE_ROOT_FOR_UNTRACKED:-false}" != "true" ] || [ "$PWD" = "${TEST_CURRENT_WORKTREE:-}" ]; }; then
+      printf '%s\0' "$GIT_UNTRACKED_PATH"
+    fi
     ;;
   "diff --name-only origin/main...HEAD")
     printf '%s\n' "${GIT_CHANGED_PATHS:-example.txt}"
@@ -290,8 +297,11 @@ reset_case_files() {
   unset GIT_CHANGED_PATHS
   unset GIT_WORKTREE_DIFF
   unset GIT_INDEX_DIFF
+  unset GIT_UNTRACKED_PATH
+  unset GIT_REQUIRE_ROOT_FOR_UNTRACKED
   unset GIT_WORKTREE_STATUS
   unset GIT_WORKTREE_REMOVE_FAIL
+  unset SHELLCHECK_VERSION_LINE
 }
 
 run_merge_pr() {
@@ -326,15 +336,18 @@ run_merge_pr() {
     GIT_CHANGED_PATHS="${GIT_CHANGED_PATHS:-example.txt}" \
     GIT_WORKTREE_DIFF="${GIT_WORKTREE_DIFF:-}" \
     GIT_INDEX_DIFF="${GIT_INDEX_DIFF:-}" \
+    GIT_UNTRACKED_PATH="${GIT_UNTRACKED_PATH:-}" \
+    GIT_REQUIRE_ROOT_FOR_UNTRACKED="${GIT_REQUIRE_ROOT_FOR_UNTRACKED:-false}" \
     GIT_WORKTREE_STATUS="${GIT_WORKTREE_STATUS:-}" \
     GIT_WORKTREE_REMOVE_FAIL="${GIT_WORKTREE_REMOVE_FAIL:-false}" \
+    SHELLCHECK_VERSION_LINE="${SHELLCHECK_VERSION_LINE:-}" \
     CODEX_REVIEW_EXIT="${CODEX_REVIEW_EXIT:-0}" \
     CODEX_REVIEW_STUB_OUTPUT="${CODEX_REVIEW_STUB_OUTPUT:-}" \
     CODEX_REVIEW_STUB_SUMMARY="${CODEX_REVIEW_STUB_SUMMARY:-}" \
     CODEX_REVIEW_MUTATE_HEAD="${CODEX_REVIEW_MUTATE_HEAD:-}" \
     GIT_LOCAL_BRANCH_HEAD="${GIT_LOCAL_BRANCH_HEAD:-pr-head-oid}" \
     PREFLIGHT_CALLS_FILE="${PREFLIGHT_CALLS_FILE:-}" \
-    TEST_CURRENT_WORKTREE="${TEST_CURRENT_WORKTREE:-/tmp/touchstone-feature-worktree}" \
+    TEST_CURRENT_WORKTREE="${TEST_CURRENT_WORKTREE:-$DEFAULT_FAKE_WORKTREE}" \
     bash "$MERGE_SCRIPT_DIR/merge-pr.sh" "$@" >"$output_file" 2>&1
 }
 
@@ -541,6 +554,119 @@ else
   cat "$TEST_DIR/preflight-calls" >&2
   cat "$TEST_DIR/output-preflight-cache-checker-second.txt" >&2
   cat "$TEST_DIR/output-preflight-cache-config-third.txt" >&2
+  exit 1
+fi
+
+echo "==> Test: preflight cache reruns when untracked file contents change"
+install_preflight_counter_fixture
+reset_case_files
+UNTRACKED_FILE="$TEST_DIR/untracked-local-test.sh"
+printf 'echo pass\n' >"$UNTRACKED_FILE"
+: >"$TEST_DIR/preflight-calls"
+if CODEX_REVIEW_EXIT=1 \
+  GIT_UNTRACKED_PATH="$UNTRACKED_FILE" \
+  PREFLIGHT_CALLS_FILE="$TEST_DIR/preflight-calls" \
+  run_merge_pr "$TEST_DIR/output-preflight-cache-untracked-first.txt" 123; then
+  echo "FAIL: first untracked-content fixture run should stop at review failure" >&2
+  exit 1
+fi
+printf 'echo fail\n' >"$UNTRACKED_FILE"
+if CODEX_REVIEW_EXIT=1 \
+  GIT_UNTRACKED_PATH="$UNTRACKED_FILE" \
+  PREFLIGHT_CALLS_FILE="$TEST_DIR/preflight-calls" \
+  run_merge_pr "$TEST_DIR/output-preflight-cache-untracked-second.txt" 123; then
+  echo "FAIL: second untracked-content fixture run should stop at review failure" >&2
+  exit 1
+fi
+rm -rf "${TEST_DIR:?}/lib"
+if [ "$(wc -l <"$TEST_DIR/preflight-calls" | tr -d ' ')" = "2" ] \
+  && ! grep -q 'Deterministic preflight clean (cached=true' "$TEST_DIR/output-preflight-cache-untracked-second.txt"; then
+  echo "==> PASS: changed untracked file contents forced preflight rerun"
+else
+  echo "FAIL: changed untracked file contents should force preflight rerun" >&2
+  cat "$TEST_DIR/preflight-calls" >&2
+  cat "$TEST_DIR/output-preflight-cache-untracked-second.txt" >&2
+  exit 1
+fi
+
+echo "==> Test: preflight cache hashes root worktree state from subdirs"
+install_preflight_counter_fixture
+reset_case_files
+ROOT_HASH_WORKTREE="$TEST_DIR/root-hash-worktree"
+mkdir -p "$ROOT_HASH_WORKTREE/nested"
+printf 'root one\n' >"$ROOT_HASH_WORKTREE/root-only.log"
+: >"$TEST_DIR/preflight-calls"
+if CODEX_REVIEW_EXIT=1 \
+  TEST_CURRENT_WORKTREE="$ROOT_HASH_WORKTREE" \
+  GIT_UNTRACKED_PATH="root-only.log" \
+  GIT_REQUIRE_ROOT_FOR_UNTRACKED=true \
+  PREFLIGHT_CALLS_FILE="$TEST_DIR/preflight-calls" \
+  run_merge_pr "$TEST_DIR/output-preflight-cache-root-first.txt" 123; then
+  echo "FAIL: first root-state fixture run should stop at review failure" >&2
+  exit 1
+fi
+printf 'root two\n' >"$ROOT_HASH_WORKTREE/root-only.log"
+(
+  cd "$ROOT_HASH_WORKTREE/nested"
+  if CODEX_REVIEW_EXIT=1 \
+    TEST_CURRENT_WORKTREE="$ROOT_HASH_WORKTREE" \
+    GIT_UNTRACKED_PATH="root-only.log" \
+    GIT_REQUIRE_ROOT_FOR_UNTRACKED=true \
+    PREFLIGHT_CALLS_FILE="$TEST_DIR/preflight-calls" \
+    run_merge_pr "$TEST_DIR/output-preflight-cache-root-second.txt" 123; then
+    echo "FAIL: second root-state fixture run should stop at review failure" >&2
+    exit 1
+  fi
+)
+rm -rf "${TEST_DIR:?}/lib"
+if [ "$(wc -l <"$TEST_DIR/preflight-calls" | tr -d ' ')" = "2" ] \
+  && ! grep -q 'Deterministic preflight clean (cached=true' "$TEST_DIR/output-preflight-cache-root-second.txt"; then
+  echo "==> PASS: subdir launch still hashes root worktree state"
+else
+  echo "FAIL: subdir launch should not reuse stale root worktree cache" >&2
+  cat "$TEST_DIR/preflight-calls" >&2
+  cat "$TEST_DIR/output-preflight-cache-root-second.txt" >&2
+  exit 1
+fi
+
+echo "==> Test: preflight cache reruns when full tool version output changes"
+install_preflight_counter_fixture
+reset_case_files
+cat >"$FAKE_BIN/shellcheck" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "--version" ]; then
+  printf 'ShellCheck - shell script analysis tool\n'
+  printf 'version: %s\n' "${SHELLCHECK_VERSION_LINE:-0.10.0}"
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "$FAKE_BIN/shellcheck"
+: >"$TEST_DIR/preflight-calls"
+if CODEX_REVIEW_EXIT=1 \
+  SHELLCHECK_VERSION_LINE="0.10.0" \
+  PREFLIGHT_CALLS_FILE="$TEST_DIR/preflight-calls" \
+  run_merge_pr "$TEST_DIR/output-preflight-cache-tool-first.txt" 123; then
+  echo "FAIL: first tool-version fixture run should stop at review failure" >&2
+  exit 1
+fi
+if CODEX_REVIEW_EXIT=1 \
+  SHELLCHECK_VERSION_LINE="0.11.0" \
+  PREFLIGHT_CALLS_FILE="$TEST_DIR/preflight-calls" \
+  run_merge_pr "$TEST_DIR/output-preflight-cache-tool-second.txt" 123; then
+  echo "FAIL: second tool-version fixture run should stop at review failure" >&2
+  exit 1
+fi
+rm -f "$FAKE_BIN/shellcheck"
+rm -rf "${TEST_DIR:?}/lib"
+if [ "$(wc -l <"$TEST_DIR/preflight-calls" | tr -d ' ')" = "2" ] \
+  && ! grep -q 'Deterministic preflight clean (cached=true' "$TEST_DIR/output-preflight-cache-tool-second.txt"; then
+  echo "==> PASS: full tool version output change forced preflight rerun"
+else
+  echo "FAIL: full tool version output change should force preflight rerun" >&2
+  cat "$TEST_DIR/preflight-calls" >&2
+  cat "$TEST_DIR/output-preflight-cache-tool-second.txt" >&2
   exit 1
 fi
 
@@ -836,14 +962,17 @@ fi
 
 echo "==> Test: gh local-branch-delete failure on a MERGED PR is a warning, not an error"
 reset_case_files
-TEST_CURRENT_WORKTREE="/tmp/touchstone-feature-worktree"
+LOCAL_DELETE_MAIN_WORKTREE="$TEST_DIR/touchstone-main-worktree"
+LOCAL_DELETE_FEATURE_WORKTREE="$TEST_DIR/touchstone-feature-worktree"
+mkdir -p "$LOCAL_DELETE_MAIN_WORKTREE" "$LOCAL_DELETE_FEATURE_WORKTREE"
+TEST_CURRENT_WORKTREE="$LOCAL_DELETE_FEATURE_WORKTREE"
 GIT_WORKTREE_LIST="$(
-  cat <<'EOF'
-worktree /tmp/touchstone-main-worktree
+  cat <<EOF
+worktree $LOCAL_DELETE_MAIN_WORKTREE
 HEAD main-oid
 branch refs/heads/main
 
-worktree /tmp/touchstone-feature-worktree
+worktree $LOCAL_DELETE_FEATURE_WORKTREE
 HEAD feature-oid
 branch refs/heads/feature/test
 

--- a/tests/test-preflight.sh
+++ b/tests/test-preflight.sh
@@ -118,6 +118,12 @@ EOF
 cat >"$MERGE_DIR/bin/git" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+
+if [ "${1:-}" = "-C" ]; then
+  cd "$2"
+  shift 2
+fi
+
 case "$*" in
   "rev-parse --show-toplevel") printf '%s\n' "$TEST_REPO_ROOT" ;;
   "rev-parse --abbrev-ref HEAD")
@@ -133,11 +139,12 @@ case "$*" in
   "fetch origin +refs/heads/main:refs/remotes/origin/main") echo fetched ;;
   "cat-file -e pr-head-oid^{commit}") ;;
   "merge-base origin/main pr-head-oid") echo "base-oid" ;;
-  "status --porcelain") ;;
+  "status --porcelain" | "status --porcelain --untracked-files=all") ;;
   "diff --name-only origin/main...HEAD") echo "broken.sh" ;;
   "diff --name-only --cached") ;;
   "diff --name-only") ;;
   "ls-files") echo "broken.sh" ;;
+  "ls-files --others --exclude-standard -z") ;;
   "worktree list --porcelain") ;;
   *) echo "unexpected git args: $*" >&2; exit 1 ;;
 esac


### PR DESCRIPTION
## Linked Issues

Closes #367

Reuse deterministic preflight clean markers across PR-open and merge-gate phases only when the exact input identity matches. Include dirty worktree/index state, untracked file contents, full tool version output, checker/config hashes, and branch/base/head identity so stale markers rerun preflight instead of skipping required checks.

Closes #367

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
