### PR TITLE
fix(preflight): skip app validate for delivery-only syncs

### DIFF
--- a/lib/preflight.sh
+++ b/lib/preflight.sh
@@ -347,6 +347,73 @@ touchstone_preflight_test_files() {
     done
 }
 
+touchstone_preflight_delivery_only_path() {
+  local path="$1"
+
+  case "$path" in
+    .touchstone-version | .touchstone-manifest | TOUCHSTONE.md | AGENTS.md | GEMINI.md)
+      return 0
+      ;;
+    .touchstone-review.toml | .codex-review.toml)
+      return 0
+      ;;
+    .github/workflows/issue-claim-check.yml)
+      return 0
+      ;;
+    .claude/settings.json | .claude/skills/touchstone-*/*)
+      return 0
+      ;;
+    principles/*)
+      return 0
+      ;;
+    scripts/conductor-review.sh | scripts/codex-review.sh | scripts/branch-guard.sh)
+      return 0
+      ;;
+    scripts/emergency-disclosure.sh | scripts/cortex-pr-merged-hook.sh)
+      return 0
+      ;;
+    scripts/touchstone-run.sh | scripts/open-pr.sh | scripts/merge-pr.sh)
+      return 0
+      ;;
+    scripts/claim-issue.sh | scripts/issue-claim-check.sh)
+      return 0
+      ;;
+    scripts/cleanup-branches.sh | scripts/spawn-worktree.sh)
+      return 0
+      ;;
+    scripts/cleanup-worktrees.sh | scripts/worker.sh | scripts/run-pytest-in-venv.sh)
+      return 0
+      ;;
+    lib/toml.sh | lib/events.sh | lib/worker-state.sh | lib/script-sync-guard.sh)
+      return 0
+      ;;
+    lib/preflight.sh | lib/preflight-scope.sh | lib/review-comment.sh)
+      return 0
+      ;;
+    hooks/conductor-review.sh | hooks/codex-review.sh)
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
+touchstone_preflight_delivery_only_diff() {
+  local path saw_path=false
+
+  [ "$TOUCHSTONE_PREFLIGHT_SCOPE_MODE" = "diff" ] || return 1
+
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    saw_path=true
+    if ! touchstone_preflight_delivery_only_path "$path"; then
+      return 1
+    fi
+  done < <(touchstone_preflight_changed_files)
+
+  [ "$saw_path" = true ]
+}
+
 touchstone_preflight_is_touchstone_repo() {
   [ -f VERSION ] \
     && [ -f bootstrap/new-project.sh ] \
@@ -463,6 +530,11 @@ touchstone_preflight_validate() {
       fi
       touchstone_preflight_fail "tests"
       return 1
+    fi
+
+    if touchstone_preflight_delivery_only_diff; then
+      touchstone_preflight_skip "tests (delivery-only Touchstone-managed diff; project validate not required)"
+      return 0
     fi
 
     if [ -f "$validate_script" ]; then
@@ -582,7 +654,8 @@ the changed file set versus the base ref, not the whole project, unless
 --all-files is explicitly passed.
 
 Scoped checks: shellcheck, shfmt, markdownlint, actionlint.
-Full-project check: the project validate command remains full-project.
+Full-project check: the project validate command remains full-project, except
+delivery-only Touchstone-managed sync diffs skip app validation.
 EOF
         return 0
         ;;

--- a/tests/test-preflight-scope-aware.sh
+++ b/tests/test-preflight-scope-aware.sh
@@ -256,6 +256,75 @@ fi
 assert_log_contains "$LOG" '^validate:validate$'
 echo "==> PASS: diff mode blocks on full project validate failure"
 
+echo "==> Test: delivery-only Touchstone-managed diff skips project validate"
+REPO="$TEST_DIR/repo-delivery-only"
+LOG="$TEST_DIR/delivery-only.log"
+OUT="$TEST_DIR/delivery-only.out"
+new_fixture_repo "$REPO"
+(
+  cd "$REPO"
+  mkdir -p lib scripts principles .claude/skills/touchstone-git-workflow
+  printf '2.99.0\n' >.touchstone-version
+  printf '# touchstone managed\n' >lib/preflight.sh
+  printf '#!/usr/bin/env bash\nset -euo pipefail\necho managed\n' >scripts/merge-pr.sh
+  printf '# Principle\n' >principles/git-workflow.md
+  printf '# Skill\n' >.claude/skills/touchstone-git-workflow/SKILL.md
+  git add .touchstone-version lib/preflight.sh scripts/merge-pr.sh principles/git-workflow.md .claude/skills/touchstone-git-workflow/SKILL.md
+  git commit -q -m "touchstone delivery-only bump"
+)
+: >"$LOG"
+run_preflight "$REPO" "$OUT" "$LOG"
+assert_log_contains "$LOG" 'shellcheck:.*scripts/merge-pr.sh'
+assert_log_contains "$LOG" 'shfmt:.*scripts/merge-pr.sh'
+assert_log_not_contains "$LOG" '^validate:validate$'
+if ! grep -q 'SKIP tests (delivery-only Touchstone-managed diff; project validate not required)' "$OUT"; then
+  echo "FAIL: delivery-only diff did not report the project validate skip" >&2
+  cat "$OUT" >&2
+  exit 1
+fi
+echo "==> PASS: delivery-only sync diff skips app validation while keeping file checks"
+
+echo "==> Test: mixed delivery and app diff keeps project validate"
+REPO="$TEST_DIR/repo-delivery-mixed"
+LOG="$TEST_DIR/delivery-mixed.log"
+OUT="$TEST_DIR/delivery-mixed.out"
+new_fixture_repo "$REPO"
+(
+  cd "$REPO"
+  mkdir -p scripts
+  printf '#!/usr/bin/env bash\nset -euo pipefail\necho managed\n' >scripts/merge-pr.sh
+  printf 'changed = True\n' >app/feature.py
+  git add scripts/merge-pr.sh app/feature.py
+  git commit -q -m "touchstone bump plus app change"
+)
+: >"$LOG"
+run_preflight "$REPO" "$OUT" "$LOG"
+assert_log_contains "$LOG" 'shellcheck:.*scripts/merge-pr.sh'
+assert_log_contains "$LOG" '^validate:validate$'
+echo "==> PASS: app-impacting mixed diff still runs project validate"
+
+echo "==> Test: explicit validate command overrides delivery-only skip"
+REPO="$TEST_DIR/repo-delivery-explicit-validate"
+LOG="$TEST_DIR/delivery-explicit-validate.log"
+OUT="$TEST_DIR/delivery-explicit-validate.out"
+new_fixture_repo "$REPO"
+(
+  cd "$REPO"
+  mkdir -p scripts
+  printf '#!/usr/bin/env bash\nset -euo pipefail\necho managed\n' >scripts/merge-pr.sh
+  git add scripts/merge-pr.sh
+  git commit -q -m "touchstone managed script"
+)
+: >"$LOG"
+if ! TOUCHSTONE_PREFLIGHT_VALIDATE_COMMAND='printf "custom-validate\n" >>"$PREFLIGHT_TOOL_LOG"' run_preflight "$REPO" "$OUT" "$LOG"; then
+  echo "FAIL: explicit validate command failed unexpectedly" >&2
+  cat "$OUT" >&2
+  exit 1
+fi
+assert_log_contains "$LOG" '^custom-validate$'
+assert_log_not_contains "$LOG" '^validate:validate$'
+echo "==> PASS: explicit validate command remains authoritative"
+
 echo "==> Test: --all-files restores full-project behavior"
 REPO="$TEST_DIR/repo-all-files"
 LOG="$TEST_DIR/all-files.log"
@@ -283,17 +352,23 @@ OUT="$TEST_DIR/touchstone-bump.out"
 new_fixture_repo "$REPO"
 (
   cd "$REPO"
-  mkdir -p lib scripts hooks principles .claude/skills/example
+  mkdir -p lib scripts hooks principles .claude/skills/touchstone-example
   printf '# touchstone managed\n' >lib/preflight.sh
   printf '#!/usr/bin/env bash\nset -euo pipefail\necho managed\n' >scripts/merge-pr.sh
   printf '#!/usr/bin/env bash\nset -euo pipefail\necho managed\n' >hooks/codex-review.sh
   printf '# Principle\n' >principles/git-workflow.md
-  printf '# Skill\n' >.claude/skills/example/SKILL.md
-  git add lib/preflight.sh scripts/merge-pr.sh hooks/codex-review.sh principles/git-workflow.md .claude/skills/example/SKILL.md
+  printf '# Skill\n' >.claude/skills/touchstone-example/SKILL.md
+  git add lib/preflight.sh scripts/merge-pr.sh hooks/codex-review.sh principles/git-workflow.md .claude/skills/touchstone-example/SKILL.md
   git commit -q -m "touchstone bump"
 )
 : >"$LOG"
 run_preflight "$REPO" "$OUT" "$LOG"
 assert_log_not_contains "$LOG" 'app/preexisting_type_debt.py'
 assert_log_not_contains "$LOG" 'unchanged-bad.sh'
+assert_log_not_contains "$LOG" '^validate:validate$'
+if ! grep -q 'SKIP tests (delivery-only Touchstone-managed diff; project validate not required)' "$OUT"; then
+  echo "FAIL: touchstone-bump diff did not report the project validate skip" >&2
+  cat "$OUT" >&2
+  exit 1
+fi
 echo "==> PASS: pre-existing debt outside a touchstone-bump diff does not block"


### PR DESCRIPTION
## Linked Issues

Closes #373

Closes #373

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
