### PR TITLE
fix(review): parse alternate finding formats

### DIFF
--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -261,6 +261,11 @@ if [ -f "$PREFLIGHT_SCRIPT" ]; then
   # shellcheck source=../lib/preflight.sh
   source "$PREFLIGHT_SCRIPT"
 fi
+REVIEW_COMMENT_SCRIPT="$TOUCHSTONE_ROOT/lib/review-comment.sh"
+if [ -f "$REVIEW_COMMENT_SCRIPT" ]; then
+  # shellcheck source=../lib/review-comment.sh
+  source "$REVIEW_COMMENT_SCRIPT"
+fi
 
 # --------------------------------------------------------------------------
 # Skip-event audit log
@@ -2882,12 +2887,17 @@ review_findings_history_file() {
   printf '%s/%s.jsonl' "$(review_findings_history_dir)" "$(review_clean_marker_key "$branch")"
 }
 
-# Strip trailing whitespace from each line and drop empty trailing lines.
-# Findings text comes from the reviewer's stdout, which can include shell
-# color codes or stray indentation; the gate only persists lines that start
-# with `- ` (the BLOCKED contract).
+# Extract and normalize actionable findings from reviewer stdout. The prompt
+# asks for `- path:line` bullets, but hosted reviewers sometimes return
+# numbered lists, Markdown finding headings, or `Issue:` prefixes. Normalize
+# those shapes back to `- ...` so operators see the findings instead of a
+# parser failure.
 extract_findings_block() {
-  printf '%s\n' "$1" | awk '/^- / { print } /^$/ { if (have_finding) exit }'
+  if declare -F review_comment_findings_from_output >/dev/null 2>&1; then
+    review_comment_findings_from_output "$1"
+    return 0
+  fi
+  printf '%s\n' "$1" | awk '/^- / { print; found = 1 } /^$/ { if (found) exit }'
 }
 
 write_review_findings() {
@@ -4487,7 +4497,7 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
 
     CODEX_REVIEW_BLOCKED)
       phase "done — blocked"
-      REVIEW_FINDINGS_COUNT="$(printf '%s\n' "$OUTPUT" | grep -c '^- ' || true)"
+      REVIEW_FINDINGS_COUNT="$(extract_findings_block "$OUTPUT" | grep -c '^- ' || true)"
       blocked_subtitle="${REVIEWER_LABEL} flagged issues to address · push refused"
       tk_verdict fail "PUSH BLOCKED" "$blocked_subtitle"
       printf '%s\n' "$OUTPUT" | sed 's/^/    /'

--- a/lib/review-comment.sh
+++ b/lib/review-comment.sh
@@ -34,7 +34,118 @@ review_comment_clean_value() {
 }
 
 review_comment_findings_from_output() {
-  printf '%s\n' "$1" | awk '/^- / { print } /^$/ { if (found) exit } /^- / { found = 1 }'
+  printf '%s\n' "$1" | awk '
+    function trim(value) {
+      sub(/^[[:space:]]+/, "", value)
+      sub(/[[:space:]]+$/, "", value)
+      return value
+    }
+    function emit(value) {
+      value = trim(value)
+      if (value == "" || value ~ /^CODEX_REVIEW_(CLEAN|FIXED|BLOCKED)$/) {
+        return
+      }
+      if (!seen[value]++) {
+        print "- " value
+        found = 1
+      }
+    }
+    function flush_pending() {
+      if (pending != "") {
+        emit(pending)
+        pending = ""
+      }
+    }
+    function is_detail_only_heading(value) {
+      value = tolower(trim(value))
+      return value ~ /^(finding|issue|blocking issue|blocker)[[:space:]]*[0-9]*[.:)-]?[[:space:]]*$/
+    }
+    {
+      line = $0
+      sub(/\r$/, "", line)
+      text = trim(line)
+      lower = tolower(text)
+
+      if (text == "") {
+        flush_pending()
+        if (found) {
+          exit
+        }
+        next
+      }
+      if (text ~ /^CODEX_REVIEW_(CLEAN|FIXED|BLOCKED)$/) {
+        flush_pending()
+        next
+      }
+
+      if (text ~ /^[-*+][[:space:]]+/) {
+        flush_pending()
+        sub(/^[-*+][[:space:]]+/, "", text)
+        emit(text)
+        next
+      }
+      if (text ~ /^[0-9]+[.)][[:space:]]+/) {
+        flush_pending()
+        sub(/^[0-9]+[.)][[:space:]]+/, "", text)
+        emit(text)
+        next
+      }
+      if (lower ~ /^#+[[:space:]]*(finding|issue|blocking issue|blocker)[[:space:]]*[0-9]*[.:)-]?[[:space:]]*/) {
+        flush_pending()
+        sub(/^#+[[:space:]]*/, "", text)
+        if (is_detail_only_heading(text)) {
+          pending = text
+        } else {
+          emit(text)
+        }
+        next
+      }
+      if (lower ~ /^(finding|issue|blocking issue|blocker)[[:space:]]*[0-9]*[.:)-][[:space:]]*/) {
+        flush_pending()
+        if (is_detail_only_heading(text)) {
+          pending = text
+        } else {
+          emit(text)
+        }
+        next
+      }
+      if (pending != "") {
+        pending = pending " - " text
+      }
+    }
+    END {
+      flush_pending()
+    }'
+}
+
+review_comment_output_excerpt() {
+  local output="$1"
+  local max_chars="${2:-2000}"
+
+  printf '%s\n' "$output" | awk -v max="$max_chars" '
+    {
+      candidate = (out == "" ? $0 : out "\n" $0)
+      if (length(candidate) > max) {
+        remaining = max - length(out)
+        if (out != "") {
+          remaining--
+        }
+        if (remaining > 0) {
+          out = (out == "" ? substr($0, 1, remaining) : out "\n" substr($0, 1, remaining))
+        }
+        truncated = 1
+        exit
+      }
+      out = candidate
+    }
+    END {
+      if (out != "") {
+        print out
+      }
+      if (truncated) {
+        print "...[truncated]"
+      }
+    }'
 }
 
 format_clean_review_comment() {
@@ -94,7 +205,7 @@ format_review_failure_comment() {
   diagnostics_file="$(review_comment_clean_value "$(review_comment_json_field "$json" diagnostics_file)")"
   diagnostics_events="$(review_comment_clean_value "$(review_comment_json_number "$json" diagnostics_events)")"
   findings_block="$(review_comment_findings_from_output "$output")"
-  output_excerpt="$(printf '%s\n' "$output" | sed -n '1,80p')"
+  output_excerpt="$(review_comment_output_excerpt "$output" 2000)"
 
   {
     if [ "${findings:-0}" != "0" ] || [ -n "$findings_block" ]; then
@@ -132,7 +243,7 @@ format_review_failure_comment() {
 format_advisory_findings_comment() {
   local json="$1"
   local output="$2"
-  local reviewer provider model iterations mode findings findings_block
+  local reviewer provider model iterations mode findings findings_block output_excerpt
 
   reviewer="$(review_comment_clean_value "$(review_comment_json_field "$json" reviewer)")"
   provider="$(review_comment_clean_value "$(review_comment_json_field "$json" provider)")"
@@ -141,6 +252,7 @@ format_advisory_findings_comment() {
   mode="$(review_comment_clean_value "$(review_comment_json_field "$json" mode)")"
   findings="$(review_comment_clean_value "$(review_comment_json_number "$json" findings)")"
   findings_block="$(review_comment_findings_from_output "$output")"
+  output_excerpt="$(review_comment_output_excerpt "$output" 2000)"
 
   {
     printf '%s advisory review found %s finding(s) - provider: %s, model: %s, iterations: %s, mode: %s\n\n' \
@@ -148,7 +260,10 @@ format_advisory_findings_comment() {
     if [ -n "$findings_block" ]; then
       printf '%s\n' "$findings_block"
     else
-      printf 'Review exited with findings, but no bullet-form findings were parsed from reviewer output.\n'
+      printf 'Review exited with findings, but no supported findings format was parsed from reviewer output.\n'
+      if [ -n "$output_excerpt" ]; then
+        printf '\n<details>\n<summary>Review transcript excerpt</summary>\n\n```text\n%s\n```\n</details>\n' "$output_excerpt"
+      fi
     fi
   }
 }

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -261,6 +261,11 @@ if [ -f "$PREFLIGHT_SCRIPT" ]; then
   # shellcheck source=../lib/preflight.sh
   source "$PREFLIGHT_SCRIPT"
 fi
+REVIEW_COMMENT_SCRIPT="$TOUCHSTONE_ROOT/lib/review-comment.sh"
+if [ -f "$REVIEW_COMMENT_SCRIPT" ]; then
+  # shellcheck source=../lib/review-comment.sh
+  source "$REVIEW_COMMENT_SCRIPT"
+fi
 
 # --------------------------------------------------------------------------
 # Skip-event audit log
@@ -2882,12 +2887,17 @@ review_findings_history_file() {
   printf '%s/%s.jsonl' "$(review_findings_history_dir)" "$(review_clean_marker_key "$branch")"
 }
 
-# Strip trailing whitespace from each line and drop empty trailing lines.
-# Findings text comes from the reviewer's stdout, which can include shell
-# color codes or stray indentation; the gate only persists lines that start
-# with `- ` (the BLOCKED contract).
+# Extract and normalize actionable findings from reviewer stdout. The prompt
+# asks for `- path:line` bullets, but hosted reviewers sometimes return
+# numbered lists, Markdown finding headings, or `Issue:` prefixes. Normalize
+# those shapes back to `- ...` so operators see the findings instead of a
+# parser failure.
 extract_findings_block() {
-  printf '%s\n' "$1" | awk '/^- / { print } /^$/ { if (have_finding) exit }'
+  if declare -F review_comment_findings_from_output >/dev/null 2>&1; then
+    review_comment_findings_from_output "$1"
+    return 0
+  fi
+  printf '%s\n' "$1" | awk '/^- / { print; found = 1 } /^$/ { if (found) exit }'
 }
 
 write_review_findings() {
@@ -4487,7 +4497,7 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
 
     CODEX_REVIEW_BLOCKED)
       phase "done — blocked"
-      REVIEW_FINDINGS_COUNT="$(printf '%s\n' "$OUTPUT" | grep -c '^- ' || true)"
+      REVIEW_FINDINGS_COUNT="$(extract_findings_block "$OUTPUT" | grep -c '^- ' || true)"
       blocked_subtitle="${REVIEWER_LABEL} flagged issues to address · push refused"
       tk_verdict fail "PUSH BLOCKED" "$blocked_subtitle"
       printf '%s\n' "$OUTPUT" | sed 's/^/    /'

--- a/tests/test-advisory-at-pr-open.sh
+++ b/tests/test-advisory-at-pr-open.sh
@@ -32,7 +32,11 @@ set -euo pipefail
 printf '{"reviewer":"Conductor","provider":"claude","model":"claude-opus-4-1","peer_provider":"none","iterations":1,"mode":"%s","findings":%s,"exit_reason":"%s"}\n' \
   "${CODEX_REVIEW_MODE:-unknown}" "${CODEX_REVIEW_STUB_FINDINGS:-0}" "${CODEX_REVIEW_STUB_REASON:-clean}" > "$CODEX_REVIEW_SUMMARY_FILE"
 if [ "${CODEX_REVIEW_STUB_EXIT:-0}" != "0" ]; then
-  printf -- '- blocking advisory finding\n'
+  if [ -n "${CODEX_REVIEW_STUB_OUTPUT:-}" ]; then
+    printf '%s\n' "$CODEX_REVIEW_STUB_OUTPUT"
+  else
+    printf -- '- blocking advisory finding\n'
+  fi
   printf 'CODEX_REVIEW_BLOCKED\n'
   exit "$CODEX_REVIEW_STUB_EXIT"
 fi
@@ -100,6 +104,7 @@ run_open_pr() {
       CODEX_REVIEW_STUB_EXIT="${CODEX_REVIEW_STUB_EXIT:-0}" \
       CODEX_REVIEW_STUB_FINDINGS="${CODEX_REVIEW_STUB_FINDINGS:-0}" \
       CODEX_REVIEW_STUB_REASON="${CODEX_REVIEW_STUB_REASON:-clean}" \
+      CODEX_REVIEW_STUB_OUTPUT="${CODEX_REVIEW_STUB_OUTPUT:-}" \
       CODEX_REVIEW_STUB_ENV_LOG="$TEST_DIR/review-env" \
       bash "$RUN_DIR/scripts/open-pr.sh"
   ) >"$output_file" 2>&1
@@ -107,6 +112,7 @@ run_open_pr() {
 
 reset_case() {
   rm -f "$TEST_DIR/comments" "$TEST_DIR/review-env"
+  unset CODEX_REVIEW_STUB_OUTPUT
 }
 
 echo "==> Case 1: clean advisory review posts clean summary"
@@ -155,6 +161,29 @@ if grep -q 'advisory review found 1 finding(s)' "$TEST_DIR/comments" \
   echo "    PASS"
 else
   echo "    FAIL: findings advisory comment missing or PR open blocked" >&2
+  cat "$OUT" >&2
+  [ -f "$TEST_DIR/comments" ] && cat "$TEST_DIR/comments" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo "==> Case 2b: unparseable advisory findings expose raw reviewer output"
+reset_case
+printf '[review]\npreflight_required = false\nadvisory_at_pr_open = true\n# parser fallback case\n' >"$REPO_DIR/.codex-review.toml"
+git -C "$REPO_DIR" add .codex-review.toml
+git -C "$REPO_DIR" commit -m "exercise unparseable advisory" >/dev/null 2>&1
+OUT="$TEST_DIR/unparseable-findings.out"
+CODEX_REVIEW_STUB_EXIT=1 \
+  CODEX_REVIEW_STUB_FINDINGS=1 \
+  CODEX_REVIEW_STUB_REASON=blocked \
+  CODEX_REVIEW_STUB_OUTPUT=$'Reviewer wrote prose only about a real blocker.' \
+  run_open_pr "$OUT"
+if grep -q 'advisory review found 1 finding(s)' "$TEST_DIR/comments" \
+  && grep -q 'Review transcript excerpt' "$TEST_DIR/comments" \
+  && grep -q 'Reviewer wrote prose only about a real blocker' "$TEST_DIR/comments" \
+  && grep -q '^https://example.test/touchstone/pull/456$' "$OUT"; then
+  echo "    PASS"
+else
+  echo "    FAIL: unparseable advisory findings should expose raw reviewer output" >&2
   cat "$OUT" >&2
   [ -f "$TEST_DIR/comments" ] && cat "$TEST_DIR/comments" >&2
   ERRORS=$((ERRORS + 1))

--- a/tests/test-review-comment.sh
+++ b/tests/test-review-comment.sh
@@ -11,6 +11,32 @@ trap 'rm -rf "$TEST_DIR"' EXIT
 echo "==> Test: format_clean_review_comment produces one-line audit text"
 # shellcheck source=../lib/review-comment.sh
 source "$TOUCHSTONE_ROOT/lib/review-comment.sh"
+
+echo "==> Test: review comment parser accepts alternate finding formats"
+PARSER_OUTPUT=$'1. app/main.py:12 - numbered finding\n### Finding 2: lib/review.sh:44 - heading finding\nIssue: missing operator-visible fallback\n### Finding 4\nmulti-line heading detail\nCODEX_REVIEW_BLOCKED'
+PARSER_FINDINGS="$(review_comment_findings_from_output "$PARSER_OUTPUT")"
+EXPECTED_FINDINGS=$'- app/main.py:12 - numbered finding\n- Finding 2: lib/review.sh:44 - heading finding\n- Issue: missing operator-visible fallback\n- Finding 4 - multi-line heading detail'
+if [ "$PARSER_FINDINGS" = "$EXPECTED_FINDINGS" ]; then
+  echo "==> PASS: alternate finding formats normalize to canonical bullets"
+else
+  echo "FAIL: alternate finding parser output mismatch" >&2
+  printf 'expected:\n%s\nactual:\n%s\n' "$EXPECTED_FINDINGS" "$PARSER_FINDINGS" >&2
+  exit 1
+fi
+
+echo "==> Test: unparseable nonzero findings include raw transcript excerpt"
+UNPARSEABLE_OUTPUT=$'Reviewer saw a problem but wrote prose only.\nCODEX_REVIEW_BLOCKED'
+COMMENT="$(format_advisory_findings_comment '{"reviewer":"Conductor","provider":"openrouter","model":"gpt-5.3-codex","peer_provider":"none","iterations":1,"mode":"review-only","findings":1}' "$UNPARSEABLE_OUTPUT")"
+if printf '%s\n' "$COMMENT" | grep -q 'no supported findings format was parsed' \
+  && printf '%s\n' "$COMMENT" | grep -q 'Review transcript excerpt' \
+  && printf '%s\n' "$COMMENT" | grep -q 'Reviewer saw a problem but wrote prose only'; then
+  echo "==> PASS: advisory comment exposes raw unparseable reviewer output"
+else
+  echo "FAIL: unparseable advisory findings should include a raw transcript excerpt" >&2
+  printf '%s\n' "$COMMENT" >&2
+  exit 1
+fi
+
 COMMENT="$(format_clean_review_comment '{"reviewer":"Conductor","provider":"gemini","model":"gemini-2.5-pro","peer_provider":"none","iterations":1,"mode":"review-only","findings":0}')"
 EXPECTED='Conductor review clean - provider: gemini, model: gemini-2.5-pro, peer: none, iterations: 1, mode: review-only, findings: 0'
 if [ "$COMMENT" = "$EXPECTED" ]; then

--- a/tests/test-review-hook.sh
+++ b/tests/test-review-hook.sh
@@ -643,6 +643,63 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
+echo "==> Test: blocked review persists alternate finding formats"
+PARSER_REPO="$TEST_DIR/repo-parser"
+PARSER_BIN="$TEST_DIR/parser-bin"
+PARSER_OUTPUT="$TEST_DIR/parser-output.txt"
+rm -rf "$PARSER_BIN"
+mkdir -p "$PARSER_BIN"
+setup_test_repo "$PARSER_REPO"
+printf 'base\n' >"$PARSER_REPO/example.txt"
+git -C "$PARSER_REPO" add example.txt
+git -C "$PARSER_REPO" commit -m "base" >/dev/null 2>&1
+printf 'changed\n' >>"$PARSER_REPO/example.txt"
+git -C "$PARSER_REPO" add example.txt
+git -C "$PARSER_REPO" commit -m "change" >/dev/null 2>&1
+cat >"$PARSER_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "main"
+EOF
+cat >"$PARSER_BIN/conductor" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "doctor" ]; then printf '{"providers":[{"configured":true}]}\n'; exit 0; fi
+printf '1. example.txt:2 - numbered failure\n'
+printf '### Finding 2\n'
+printf 'heading-only detail survived\n'
+printf 'CODEX_REVIEW_BLOCKED\n'
+EOF
+chmod +x "$PARSER_BIN/gh" "$PARSER_BIN/conductor"
+
+set +e
+(
+  cd "$PARSER_REPO"
+  PATH="$PARSER_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_BRANCH_NAME="feature/parser" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    CODEX_REVIEW_MODE=review-only \
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$PARSER_OUTPUT" 2>&1
+)
+PARSER_EXIT=$?
+set -e
+PARSER_FINDINGS_FILE="$PARSER_REPO/.git/touchstone/reviewer-findings/feature_parser.findings"
+PARSER_HISTORY_FILE="$PARSER_REPO/.git/touchstone/reviewer-findings-history/feature_parser.jsonl"
+if [ "$PARSER_EXIT" -eq 1 ] \
+  && grep -q 'findings:       2' "$PARSER_OUTPUT" \
+  && grep -q -- '- example.txt:2 - numbered failure' "$PARSER_FINDINGS_FILE" \
+  && grep -q -- '- Finding 2 - heading-only detail survived' "$PARSER_FINDINGS_FILE" \
+  && grep -q '"findings_count":2' "$PARSER_HISTORY_FILE"; then
+  echo "==> PASS: alternate finding formats were normalized and persisted"
+else
+  echo "FAIL: expected alternate finding formats to be actionable" >&2
+  echo "exit code: $PARSER_EXIT" >&2
+  cat "$PARSER_OUTPUT" >&2
+  [ -f "$PARSER_FINDINGS_FILE" ] && cat "$PARSER_FINDINGS_FILE" >&2
+  [ -f "$PARSER_HISTORY_FILE" ] && cat "$PARSER_HISTORY_FILE" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
 # ==========================================================================
 # Conductor reviewer tests (Touchstone 2.0+). The v1.x multi-reviewer
 # cascade tests were retired when the single `conductor` adapter shipped;


### PR DESCRIPTION
## Linked Issues

Closes #371

Normalize numbered, heading, and Issue/Finding-prefixed reviewer findings into the canonical bullet format used by the merge gate and PR comments. Surface a bounded raw transcript excerpt when findings are reported but no supported format can be extracted.

Closes #371

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
