### PR TITLE
fix(review): keep peer review on pinned providers

### DIFF
--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -3629,6 +3629,24 @@ parse_peer_provider() {
   fi
 }
 
+primary_provider_for_peer_review() {
+  local provider
+  provider="$(parse_primary_provider)"
+  if [ -n "$provider" ]; then
+    printf '%s' "$provider"
+    return 0
+  fi
+
+  # If Conductor did not emit parseable provider telemetry, a pinned provider
+  # (or merge-gate route preflight provider) is still a trustworthy exclusion.
+  # Leave truly unknown auto-routed cases empty so peer review skips rather than
+  # risk asking the same provider for a second opinion.
+  provider="$(conductor_effective_with_for_phase review)"
+  if [ -n "$provider" ]; then
+    printf '%s' "$provider"
+  fi
+}
+
 conductor_invocation_label() {
   local conductor_path subcommand
   conductor_path="$(command -v conductor 2>/dev/null || printf 'conductor')"
@@ -3833,7 +3851,7 @@ try_review_fallback_retry() {
 run_peer_review() {
   local primary_output="$1"
   local primary_provider mode
-  primary_provider="$(parse_primary_provider)"
+  primary_provider="$(primary_provider_for_peer_review)"
   mode="peer"
   if [ "${HIGH_SCRUTINY_TRIGGERED:-false}" = true ]; then
     mode="${HIGH_SCRUTINY_MODE:-peer}"

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -3629,6 +3629,24 @@ parse_peer_provider() {
   fi
 }
 
+primary_provider_for_peer_review() {
+  local provider
+  provider="$(parse_primary_provider)"
+  if [ -n "$provider" ]; then
+    printf '%s' "$provider"
+    return 0
+  fi
+
+  # If Conductor did not emit parseable provider telemetry, a pinned provider
+  # (or merge-gate route preflight provider) is still a trustworthy exclusion.
+  # Leave truly unknown auto-routed cases empty so peer review skips rather than
+  # risk asking the same provider for a second opinion.
+  provider="$(conductor_effective_with_for_phase review)"
+  if [ -n "$provider" ]; then
+    printf '%s' "$provider"
+  fi
+}
+
 conductor_invocation_label() {
   local conductor_path subcommand
   conductor_path="$(command -v conductor 2>/dev/null || printf 'conductor')"
@@ -3833,7 +3851,7 @@ try_review_fallback_retry() {
 run_peer_review() {
   local primary_output="$1"
   local primary_provider mode
-  primary_provider="$(parse_primary_provider)"
+  primary_provider="$(primary_provider_for_peer_review)"
   mode="peer"
   if [ "${HIGH_SCRUTINY_TRIGGERED:-false}" = true ]; then
     mode="${HIGH_SCRUTINY_MODE:-peer}"

--- a/tests/test-review-hook.sh
+++ b/tests/test-review-hook.sh
@@ -2460,6 +2460,56 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
+echo "==> Test: peer review uses pinned provider when telemetry is missing"
+setup_ctx_repo
+cat >"$CTX_BIN/conductor" <<'CXEOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = "doctor" ]; then printf '{"providers":[{"configured":true}]}\n'; exit 0; fi
+subcmd="$1"; shift
+printf '%s\n' "$subcmd $*" >> "$CONDUCTOR_ARGS_LOG"
+cat >/dev/null
+case "$subcmd" in
+  review | exec)
+    printf 'Primary review emitted no provider telemetry.\n'
+    printf 'CODEX_REVIEW_CLEAN\n'
+    ;;
+  call)
+    printf 'AGREE\n'
+    printf 'Peer ran with the pinned primary excluded.\n'
+    ;;
+esac
+CXEOF
+chmod +x "$CTX_BIN/conductor"
+{
+  cat "$CTX_REPO/.codex-review.toml" 2>/dev/null || true
+  printf '\n[review.assist]\nenabled = true\nmax_rounds = 1\n'
+} >"$CTX_REPO/.codex-review.toml.tmp" && mv "$CTX_REPO/.codex-review.toml.tmp" "$CTX_REPO/.codex-review.toml"
+git -C "$CTX_REPO" add .codex-review.toml && git -C "$CTX_REPO" commit -m "enable pinned assist" >/dev/null 2>&1
+
+: >"$CONDUCTOR_ARGS_LOG"
+(
+  cd "$CTX_REPO"
+  PATH="$CTX_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CONDUCTOR_ARGS_LOG="$CONDUCTOR_ARGS_LOG" \
+    CODEX_REVIEW_BASE="HEAD~2" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    TOUCHSTONE_CONDUCTOR_WITH=openrouter \
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$CTX_OUTPUT" 2>&1
+)
+
+if grep -q 'peer review' "$CTX_OUTPUT" \
+  && ! grep -q "couldn't identify primary provider" "$CTX_OUTPUT" \
+  && grep -q '^call .*--exclude openrouter' "$CONDUCTOR_ARGS_LOG"; then
+  echo "==> PASS: peer review excluded pinned provider without telemetry"
+else
+  echo "FAIL: peer review should use pinned provider as telemetry fallback" >&2
+  echo "--- CTX_OUTPUT ---" >&2
+  cat "$CTX_OUTPUT" >&2
+  echo "--- conductor args log ---" >&2
+  cat "$CONDUCTOR_ARGS_LOG" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
 echo "==> Test: peer review excludes successful fallback provider"
 setup_ctx_repo
 cat >"$CTX_BIN/conductor" <<'CXEOF'


### PR DESCRIPTION
## Linked Issues

Closes #384

When Conductor does not emit parseable primary-provider telemetry, use the pinned review provider as the peer-review exclusion. This keeps high-scrutiny paths from silently skipping peer review when routing was explicitly pinned or preflighted.

Closes #384

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
