### PR TITLE
fix(review): give peer reviewers diff context

### DIFF
--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -3939,27 +3939,27 @@ High scrutiny: ${HIGH_SCRUTINY_REASON:-none}
 
 Changed files:
 $(if [ -n "$changed_paths" ]; then
-  printf '%s\n' "$changed_paths" | sed '/^$/d; s/^/- /'
-else
-  printf '(none)\n'
-fi)
+    printf '%s\n' "$changed_paths" | sed '/^$/d; s/^/- /'
+  else
+    printf '(none)\n'
+  fi)
 
 Commit messages:
 
 $(git log --reverse --format='### %s%n%n%b' "$MERGE_BASE"..HEAD 2>/dev/null | sed '/^$/N;/^\n$/d')
 $(if [ -n "$REVIEW_CONTEXT_FILE" ]; then
-  printf '\n## Project review context\n\n'
-  cat "$REVIEW_CONTEXT_FILE"
-fi)
+    printf '\n## Project review context\n\n'
+    cat "$REVIEW_CONTEXT_FILE"
+  fi)
 
 ## Diff
 
 \`\`\`diff
 $(if is_truthy "${SCOPED_LARGE_DIFF_REVIEW:-false}" && [ -n "${SCOPED_LARGE_DIFF_FILE:-}" ]; then
-  cat "$SCOPED_LARGE_DIFF_FILE"
-else
-  git diff "$MERGE_BASE"..HEAD 2>/dev/null
-fi)
+    cat "$SCOPED_LARGE_DIFF_FILE"
+  else
+    git diff "$MERGE_BASE"..HEAD 2>/dev/null
+  fi)
 \`\`\`
 
 ## Primary reviewer output

--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -3915,21 +3915,56 @@ run_peer_review() {
 }
 
 build_peer_review_prompt() {
-  local primary_output="$1"
+  local primary_output="$1" changed_paths
+  changed_paths="${PROMPT_CONTEXT_CHANGED_PATHS:-$(git diff --name-only "$MERGE_BASE"..HEAD 2>/dev/null || true)}"
   cat <<EOF
 You are a peer code reviewer giving a second opinion on another AI reviewer's output.
-You are asked to be a QUICK second opinion, NOT to redo the review from scratch.
+You are asked to be a QUICK second opinion, NOT a full independent review.
 
-The primary reviewer examined a code change and produced the output below. Your job:
+Use the branch context and diff below to verify whether the primary reviewer's verdict is credible.
+Do not complain that you cannot see the diff; it is embedded in this prompt.
+
+Your job:
   1. Do you AGREE or DISAGREE with the primary's overall verdict (CLEAN / FIXED / BLOCKED)?
   2. Anything the primary MISSED that you'd flag?
   3. Anything the primary FLAGGED that you think is a false positive?
 
 Keep your response under 300 words. Lead with AGREE or DISAGREE on a line by itself.
 
---- Primary reviewer output: ---
+## Branch context
+
+Base: $BASE
+Merge base: $MERGE_BASE
+High scrutiny: ${HIGH_SCRUTINY_REASON:-none}
+
+Changed files:
+$(if [ -n "$changed_paths" ]; then
+  printf '%s\n' "$changed_paths" | sed '/^$/d; s/^/- /'
+else
+  printf '(none)\n'
+fi)
+
+Commit messages:
+
+$(git log --reverse --format='### %s%n%n%b' "$MERGE_BASE"..HEAD 2>/dev/null | sed '/^$/N;/^\n$/d')
+$(if [ -n "$REVIEW_CONTEXT_FILE" ]; then
+  printf '\n## Project review context\n\n'
+  cat "$REVIEW_CONTEXT_FILE"
+fi)
+
+## Diff
+
+\`\`\`diff
+$(if is_truthy "${SCOPED_LARGE_DIFF_REVIEW:-false}" && [ -n "${SCOPED_LARGE_DIFF_FILE:-}" ]; then
+  cat "$SCOPED_LARGE_DIFF_FILE"
+else
+  git diff "$MERGE_BASE"..HEAD 2>/dev/null
+fi)
+\`\`\`
+
+## Primary reviewer output
+
 $primary_output
---- End primary output ---
 EOF
 }
 

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -3939,27 +3939,27 @@ High scrutiny: ${HIGH_SCRUTINY_REASON:-none}
 
 Changed files:
 $(if [ -n "$changed_paths" ]; then
-  printf '%s\n' "$changed_paths" | sed '/^$/d; s/^/- /'
-else
-  printf '(none)\n'
-fi)
+    printf '%s\n' "$changed_paths" | sed '/^$/d; s/^/- /'
+  else
+    printf '(none)\n'
+  fi)
 
 Commit messages:
 
 $(git log --reverse --format='### %s%n%n%b' "$MERGE_BASE"..HEAD 2>/dev/null | sed '/^$/N;/^\n$/d')
 $(if [ -n "$REVIEW_CONTEXT_FILE" ]; then
-  printf '\n## Project review context\n\n'
-  cat "$REVIEW_CONTEXT_FILE"
-fi)
+    printf '\n## Project review context\n\n'
+    cat "$REVIEW_CONTEXT_FILE"
+  fi)
 
 ## Diff
 
 \`\`\`diff
 $(if is_truthy "${SCOPED_LARGE_DIFF_REVIEW:-false}" && [ -n "${SCOPED_LARGE_DIFF_FILE:-}" ]; then
-  cat "$SCOPED_LARGE_DIFF_FILE"
-else
-  git diff "$MERGE_BASE"..HEAD 2>/dev/null
-fi)
+    cat "$SCOPED_LARGE_DIFF_FILE"
+  else
+    git diff "$MERGE_BASE"..HEAD 2>/dev/null
+  fi)
 \`\`\`
 
 ## Primary reviewer output

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -3915,21 +3915,56 @@ run_peer_review() {
 }
 
 build_peer_review_prompt() {
-  local primary_output="$1"
+  local primary_output="$1" changed_paths
+  changed_paths="${PROMPT_CONTEXT_CHANGED_PATHS:-$(git diff --name-only "$MERGE_BASE"..HEAD 2>/dev/null || true)}"
   cat <<EOF
 You are a peer code reviewer giving a second opinion on another AI reviewer's output.
-You are asked to be a QUICK second opinion, NOT to redo the review from scratch.
+You are asked to be a QUICK second opinion, NOT a full independent review.
 
-The primary reviewer examined a code change and produced the output below. Your job:
+Use the branch context and diff below to verify whether the primary reviewer's verdict is credible.
+Do not complain that you cannot see the diff; it is embedded in this prompt.
+
+Your job:
   1. Do you AGREE or DISAGREE with the primary's overall verdict (CLEAN / FIXED / BLOCKED)?
   2. Anything the primary MISSED that you'd flag?
   3. Anything the primary FLAGGED that you think is a false positive?
 
 Keep your response under 300 words. Lead with AGREE or DISAGREE on a line by itself.
 
---- Primary reviewer output: ---
+## Branch context
+
+Base: $BASE
+Merge base: $MERGE_BASE
+High scrutiny: ${HIGH_SCRUTINY_REASON:-none}
+
+Changed files:
+$(if [ -n "$changed_paths" ]; then
+  printf '%s\n' "$changed_paths" | sed '/^$/d; s/^/- /'
+else
+  printf '(none)\n'
+fi)
+
+Commit messages:
+
+$(git log --reverse --format='### %s%n%n%b' "$MERGE_BASE"..HEAD 2>/dev/null | sed '/^$/N;/^\n$/d')
+$(if [ -n "$REVIEW_CONTEXT_FILE" ]; then
+  printf '\n## Project review context\n\n'
+  cat "$REVIEW_CONTEXT_FILE"
+fi)
+
+## Diff
+
+\`\`\`diff
+$(if is_truthy "${SCOPED_LARGE_DIFF_REVIEW:-false}" && [ -n "${SCOPED_LARGE_DIFF_FILE:-}" ]; then
+  cat "$SCOPED_LARGE_DIFF_FILE"
+else
+  git diff "$MERGE_BASE"..HEAD 2>/dev/null
+fi)
+\`\`\`
+
+## Primary reviewer output
+
 $primary_output
---- End primary output ---
 EOF
 }
 

--- a/tests/test-review-hook.sh
+++ b/tests/test-review-hook.sh
@@ -2586,14 +2586,14 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
-echo "==> Test: high-scrutiny paths auto-enable peer review"
+echo "==> Test: high-scrutiny paths auto-enable peer review with diff context"
 setup_ctx_repo
 cat >"$CTX_BIN/conductor" <<'CXEOF'
 #!/usr/bin/env bash
 if [ "${1:-}" = "doctor" ]; then printf '{"providers":[{"configured":true}]}\n'; exit 0; fi
 subcmd="$1"; shift
 printf '%s\n' "$subcmd $*" >> "$CONDUCTOR_ARGS_LOG"
-cat >/dev/null
+input="$(cat)"
 case "$subcmd" in
   review | exec)
     printf '[conductor] auto -> claude (tier: frontier, model=sonnet)\n' >&2
@@ -2601,6 +2601,9 @@ case "$subcmd" in
     printf 'CODEX_REVIEW_CLEAN\n'
     ;;
   call)
+    if [ -n "${PEER_PROMPT_LOG:-}" ]; then
+      printf '%s\n' "$input" >"$PEER_PROMPT_LOG"
+    fi
     printf 'AGREE\n'
     printf 'Peer agrees on the high-scrutiny diff.\n'
     ;;
@@ -2616,11 +2619,14 @@ mkdir -p "$CTX_REPO/critical"
 printf 'important\n' >"$CTX_REPO/critical/file.txt"
 git -C "$CTX_REPO" add critical/file.txt && git -C "$CTX_REPO" commit -m "touch critical path" >/dev/null 2>&1
 
+PEER_PROMPT_LOG="$TEST_DIR/high-scrutiny-peer-prompt.log"
+: >"$PEER_PROMPT_LOG"
 : >"$CONDUCTOR_ARGS_LOG"
 (
   cd "$CTX_REPO"
   PATH="$CTX_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
     CONDUCTOR_ARGS_LOG="$CONDUCTOR_ARGS_LOG" \
+    PEER_PROMPT_LOG="$PEER_PROMPT_LOG" \
     CODEX_REVIEW_BASE="HEAD~1" \
     CODEX_REVIEW_DISABLE_CACHE=1 \
     bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$CTX_OUTPUT" 2>&1
@@ -2629,14 +2635,21 @@ git -C "$CTX_REPO" add critical/file.txt && git -C "$CTX_REPO" commit -m "touch 
 if grep -q 'High-scrutiny review: configured high-scrutiny path critical/file.txt' "$CTX_OUTPUT" \
   && grep -q 'Review routing: high-risk diff (configured high-scrutiny path critical/file.txt' "$CTX_OUTPUT" \
   && grep -q 'peer review' "$CTX_OUTPUT" \
-  && grep -q '^call .*--exclude claude' "$CONDUCTOR_ARGS_LOG"; then
-  echo "==> PASS: high-scrutiny path triggered peer review"
+  && grep -q '^call .*--exclude claude' "$CONDUCTOR_ARGS_LOG" \
+  && grep -q '## Branch context' "$PEER_PROMPT_LOG" \
+  && grep -q 'High scrutiny: configured high-scrutiny path critical/file.txt' "$PEER_PROMPT_LOG" \
+  && grep -q '## Diff' "$PEER_PROMPT_LOG" \
+  && grep -q '^+important' "$PEER_PROMPT_LOG" \
+  && grep -q '## Primary reviewer output' "$PEER_PROMPT_LOG"; then
+  echo "==> PASS: high-scrutiny path triggered peer review with diff context"
 else
-  echo "FAIL: high-scrutiny path should trigger peer review" >&2
+  echo "FAIL: high-scrutiny path should trigger peer review with diff context" >&2
   echo "--- CTX_OUTPUT ---" >&2
   cat "$CTX_OUTPUT" >&2
   echo "--- conductor args log ---" >&2
   cat "$CONDUCTOR_ARGS_LOG" >&2
+  echo "--- peer prompt ---" >&2
+  cat "$PEER_PROMPT_LOG" >&2
   ERRORS=$((ERRORS + 1))
 fi
 


### PR DESCRIPTION
## Linked Issues

Closes #386

High-scrutiny peer review now receives branch context, changed files, commit messages, optional project context, and the diff so the second opinion can independently evaluate the primary verdict instead of only judging the transcript.

Closes #386

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
