### PR TITLE
fix(merge): allow audited fail-open bypass markers

### DIFF
--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -5,6 +5,7 @@
 # Usage:
 #   bash scripts/merge-pr.sh <pr-number>
 #   bash scripts/merge-pr.sh <pr-number> --bypass-with-disclosure="<reason>"
+#   bash scripts/merge-pr.sh <pr-number> --bypass-with-disclosure="<reason>" --allow-fail-open-marker
 #
 # What this does:
 #   1. Verifies the PR is open and mergeable.
@@ -23,6 +24,8 @@ set -euo pipefail
 
 PR_NUMBER=""
 BYPASS_REASON=""
+BYPASS_MARKER_SOURCE=""
+BYPASS_MARKER_EVIDENCE=""
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SCRIPT_SYNC_GUARD="$SCRIPT_DIR/../lib/script-sync-guard.sh"
 if [ -f "$SCRIPT_SYNC_GUARD" ]; then
@@ -53,6 +56,7 @@ fi
 REVIEWED_HEAD_OID=""
 PR_HEAD_BRANCH=""
 BYPASS_REVIEW=false
+ALLOW_FAIL_OPEN_MARKER=false
 TOUCHSTONE_MERGE_FAILURE_REASON="nonzero-exit"
 PREFLIGHT_REQUIRED=true
 COMMENT_ON_CLEAN=true
@@ -62,6 +66,9 @@ PREFLIGHT_CACHE_KEY=""
 PREFLIGHT_CACHE_FILE=""
 PREFLIGHT_CACHE_INPUTS=""
 PR_WORKTREE_PATH=""
+TOUCHSTONE_REVIEW_LOG="${TOUCHSTONE_REVIEW_LOG-${HOME:-}/.touchstone-review-log}"
+TOUCHSTONE_REVIEW_LOG_MAX_LINES="${TOUCHSTONE_REVIEW_LOG_MAX_LINES:-1000}"
+TOUCHSTONE_FAIL_OPEN_BYPASS_WINDOW_HOURS="${TOUCHSTONE_FAIL_OPEN_BYPASS_WINDOW_HOURS:-24}"
 
 on_merge_exit() {
   local rc="$?"
@@ -83,6 +90,10 @@ while [ "$#" -gt 0 ]; do
     --bypass-with-disclosure)
       echo "ERROR: --bypass-with-disclosure requires a non-empty reason." >&2
       exit 2
+      ;;
+    --allow-fail-open-marker)
+      ALLOW_FAIL_OPEN_MARKER=true
+      shift
       ;;
     --*)
       echo "ERROR: Unknown option: $1" >&2
@@ -257,11 +268,15 @@ print_review_infra_retry_guidance() {
 BYPASS_REASON="$(trim "$(printf '%s' "$BYPASS_REASON" | tr '\r\n\t' '   ')")"
 
 if [ -z "$PR_NUMBER" ] || ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
-  echo "Usage: bash scripts/merge-pr.sh <pr-number> [--bypass-with-disclosure=\"<reason>\"]" >&2
+  echo "Usage: bash scripts/merge-pr.sh <pr-number> [--bypass-with-disclosure=\"<reason>\" [--allow-fail-open-marker]]" >&2
   exit 2
 fi
 if [ "$BYPASS_REVIEW" = true ] && [ -z "$BYPASS_REASON" ]; then
   echo "ERROR: --bypass-with-disclosure requires a non-empty reason." >&2
+  exit 2
+fi
+if [ "$ALLOW_FAIL_OPEN_MARKER" = true ] && [ "$BYPASS_REVIEW" != true ]; then
+  echo "ERROR: --allow-fail-open-marker requires --bypass-with-disclosure=\"<reason>\"." >&2
   exit 2
 fi
 
@@ -612,6 +627,161 @@ branch_has_clean_review_marker() {
     && [ "$marker_merge_base" = "$merge_base" ]
 }
 
+is_positive_integer() {
+  case "${1:-}" in
+    "" | *[!0-9]*) return 1 ;;
+    *) [ "$1" -gt 0 ] ;;
+  esac
+}
+
+timestamp_to_epoch() {
+  local timestamp="$1"
+
+  date -j -f "%Y-%m-%dT%H:%M:%S%z" "$timestamp" "+%s" 2>/dev/null \
+    || date -d "$timestamp" "+%s" 2>/dev/null
+}
+
+head_oid_matches_logged_sha() {
+  local head_oid="$1"
+  local logged_sha="$2"
+
+  [ -n "$head_oid" ] || return 1
+  [ -n "$logged_sha" ] || return 1
+
+  case "$head_oid" in
+    "$logged_sha"*) return 0 ;;
+  esac
+  case "$logged_sha" in
+    "$head_oid"*) return 0 ;;
+  esac
+  return 1
+}
+
+bypass_reason_mentions_fail_open() {
+  local reason_lower
+  reason_lower="$(printf '%s' "$BYPASS_REASON" | tr '[:upper:]' '[:lower:]')"
+
+  case "$reason_lower" in
+    *fail-open* | *"fail open"* | *provider* | *infra* | *outage* | *timeout* | *"timed out"* | *"reviewer unavailable"* | *"reviewer error"*)
+      return 0
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+branch_has_recent_fail_open_marker() {
+  local branch="$1"
+  local head_oid="$2"
+  local log_file="$TOUCHSTONE_REVIEW_LOG"
+  local window_hours="$TOUCHSTONE_FAIL_OPEN_BYPASS_WINDOW_HOURS"
+  local window_seconds now_epoch tab
+  local timestamp repo_path log_branch logged_sha reason detail
+  local event_epoch age
+
+  [ -n "$log_file" ] || return 1
+  [ "$log_file" != "/dev/null" ] || return 1
+  [ -f "$log_file" ] || return 1
+  is_positive_integer "$window_hours" || return 1
+
+  window_seconds=$((window_hours * 3600))
+  now_epoch="$(date "+%s" 2>/dev/null)" || return 1
+  tab="$(printf '\t')"
+
+  while IFS="$tab" read -r timestamp repo_path log_branch logged_sha reason detail || [ -n "$timestamp" ]; do
+    [ "$log_branch" = "$branch" ] || continue
+    head_oid_matches_logged_sha "$head_oid" "$logged_sha" || continue
+    case "$reason" in
+      FAIL_OPEN_*) ;;
+      *) continue ;;
+    esac
+    case "$detail" in
+      fail-open:*) ;;
+      *) continue ;;
+    esac
+    event_epoch="$(timestamp_to_epoch "$timestamp" 2>/dev/null || true)"
+    [ -n "$event_epoch" ] || continue
+    age=$((now_epoch - event_epoch))
+    # Allow a small future skew between the review hook and merge machine clocks.
+    [ "$age" -ge -300 ] || continue
+    [ "$age" -le "$window_seconds" ] || continue
+
+    BYPASS_MARKER_EVIDENCE="timestamp=$timestamp; repo=$repo_path; branch=$log_branch; sha=$logged_sha; reason=$reason; detail=$detail"
+    return 0
+  done <"$log_file"
+
+  return 1
+}
+
+sanitize_review_log_field() {
+  printf '%s' "$1" | tr '\t\n' '  '
+}
+
+append_review_log_event() {
+  local reason="$1"
+  local detail="$2"
+  local log_file="$TOUCHSTONE_REVIEW_LOG"
+  local timestamp repo_root branch sha tmp_dir tmp_file line_count keep_lines
+
+  [ -n "$log_file" ] || return 0
+  [ "$log_file" != "/dev/null" ] || return 0
+
+  timestamp="$(date '+%Y-%m-%dT%H:%M:%S%z' 2>/dev/null || echo unknown)"
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || echo unknown)"
+  branch="${PR_HEAD_BRANCH:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)}"
+  sha="${REVIEWED_HEAD_OID:-$(git rev-parse HEAD 2>/dev/null || echo unknown)}"
+  if [ "$sha" != "unknown" ] && [ "${#sha}" -gt 12 ]; then
+    sha="${sha:0:12}"
+  fi
+
+  reason="$(sanitize_review_log_field "$reason")"
+  detail="$(sanitize_review_log_field "$detail")"
+  branch="$(sanitize_review_log_field "$branch")"
+
+  tmp_dir="${TMPDIR:-/tmp}"
+  tmp_dir="${tmp_dir%/}"
+  tmp_file="$tmp_dir/touchstone-merge-review-log.$$.tmp"
+
+  if ! mkdir -p "$(dirname "$log_file")" 2>/dev/null; then
+    echo "WARNING: Could not create review audit log directory for $log_file." >&2
+    return 0
+  fi
+
+  if [ -f "$log_file" ]; then
+    line_count="$(wc -l <"$log_file" 2>/dev/null | tr -d ' ')" || line_count=0
+    line_count="${line_count:-0}"
+    if is_positive_integer "$TOUCHSTONE_REVIEW_LOG_MAX_LINES" && [ "$line_count" -ge "$TOUCHSTONE_REVIEW_LOG_MAX_LINES" ]; then
+      keep_lines=$((TOUCHSTONE_REVIEW_LOG_MAX_LINES - 1))
+      tail -n "$keep_lines" "$log_file" >"$tmp_file" 2>/dev/null || : >"$tmp_file"
+    else
+      cat "$log_file" >"$tmp_file" 2>/dev/null || : >"$tmp_file"
+    fi
+  else
+    : >"$tmp_file"
+  fi
+
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$timestamp" "$repo_root" "$branch" "$sha" "$reason" "$detail" \
+    >>"$tmp_file" 2>/dev/null || {
+    rm -f "$tmp_file" 2>/dev/null
+    echo "WARNING: Could not append review audit log entry for $log_file." >&2
+    return 0
+  }
+
+  if ! mv "$tmp_file" "$log_file" 2>/dev/null; then
+    rm -f "$tmp_file" 2>/dev/null
+    echo "WARNING: Could not update review audit log $log_file." >&2
+  fi
+}
+
+record_bypass_audit_log() {
+  local detail
+  detail="reason=$BYPASS_REASON; marker=$BYPASS_MARKER_SOURCE"
+  if [ -n "$BYPASS_MARKER_EVIDENCE" ]; then
+    detail="$detail; evidence=[$BYPASS_MARKER_EVIDENCE]"
+  fi
+  append_review_log_event review-bypass "$detail"
+}
+
 sync_default_branch_after_merge() {
   local current_branch current_worktree default_worktree
 
@@ -781,6 +951,7 @@ print_bypass_banner() {
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! BYPASSING REVIEWER GATE
+!! marker: $BYPASS_MARKER_SOURCE
 !! reason: $BYPASS_REASON
 !! This bypass is recorded on the PR and squash commit.
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -856,7 +1027,14 @@ record_squash_merge() {
 }
 
 record_bypass_comment() {
-  gh pr comment "$PR_NUMBER" --body "Reviewer bypassed via \`--bypass-with-disclosure\`. Reason: $BYPASS_REASON"
+  local body
+  body="Reviewer bypassed via \`--bypass-with-disclosure\`. Marker: $BYPASS_MARKER_SOURCE. Reason: $BYPASS_REASON"
+  if [ -n "$BYPASS_MARKER_EVIDENCE" ]; then
+    body="$body
+
+Fail-open evidence: $BYPASS_MARKER_EVIDENCE"
+  fi
+  gh pr comment "$PR_NUMBER" --body "$body"
 }
 
 post_clean_review_comment() {
@@ -1190,15 +1368,38 @@ run_merge_review() {
       echo "ERROR: Could not compute merge base for PR #$PR_NUMBER head against $default_base_ref." >&2
       exit 1
     fi
-    if ! branch_has_clean_review_marker "$pr_head_branch" "$pr_head_oid" "$current_merge_base"; then
+    BYPASS_MARKER_SOURCE=""
+    BYPASS_MARKER_EVIDENCE=""
+    if branch_has_clean_review_marker "$pr_head_branch" "$pr_head_oid" "$current_merge_base"; then
+      BYPASS_MARKER_SOURCE="clean-review"
+    elif [ "$ALLOW_FAIL_OPEN_MARKER" = true ]; then
+      if ! bypass_reason_mentions_fail_open; then
+        echo "ERROR: Refusing reviewer bypass for PR #$PR_NUMBER." >&2
+        echo "       --allow-fail-open-marker requires a disclosure reason that cites the fail-open reviewer/provider outage." >&2
+        exit 1
+      fi
+      if ! is_positive_integer "$TOUCHSTONE_FAIL_OPEN_BYPASS_WINDOW_HOURS"; then
+        echo "ERROR: TOUCHSTONE_FAIL_OPEN_BYPASS_WINDOW_HOURS must be a positive integer." >&2
+        exit 2
+      fi
+      if ! branch_has_recent_fail_open_marker "$pr_head_branch" "$pr_head_oid"; then
+        echo "ERROR: Refusing reviewer bypass for PR #$PR_NUMBER." >&2
+        echo "       No recent fail-open review-log marker matches branch '$pr_head_branch' at head '$pr_head_oid'." >&2
+        echo "       Looked in: ${TOUCHSTONE_REVIEW_LOG:-<disabled>} (window: ${TOUCHSTONE_FAIL_OPEN_BYPASS_WINDOW_HOURS}h)." >&2
+        echo "       Expected a FAIL_OPEN_* entry with detail 'fail-open:*' for the current branch head." >&2
+        exit 1
+      fi
+      BYPASS_MARKER_SOURCE="fail-open"
+    else
       echo "ERROR: Refusing reviewer bypass for PR #$PR_NUMBER." >&2
       echo "       No prior clean review marker matches branch '$pr_head_branch' at head '$pr_head_oid' and merge base '$current_merge_base'." >&2
-      echo "       Run the reviewer cleanly once before using --bypass-with-disclosure." >&2
+      echo "       Run the reviewer cleanly once before using --bypass-with-disclosure, or pass --allow-fail-open-marker after a recent fail-open review-log event for this branch head." >&2
       exit 1
     fi
-    touchstone_emit_event review_bypass pr_number="$PR_NUMBER" head_sha="$pr_head_oid" reason="$BYPASS_REASON"
+    touchstone_emit_event review_bypass pr_number="$PR_NUMBER" head_sha="$pr_head_oid" reason="$BYPASS_REASON" marker="$BYPASS_MARKER_SOURCE" evidence="$BYPASS_MARKER_EVIDENCE"
     print_bypass_banner
     record_bypass_comment
+    record_bypass_audit_log
     return 0
   fi
 
@@ -1344,7 +1545,7 @@ run_merge_review() {
   else
     echo "       Concrete review findings were reported; fix the findings, then rerun the merge gate." >&2
   fi
-  echo "       Emergency bypass requires an explicit --bypass-with-disclosure reason and a matching prior clean review marker." >&2
+  echo "       Emergency bypass requires an explicit --bypass-with-disclosure reason and either a matching prior clean review marker or --allow-fail-open-marker with recent fail-open evidence." >&2
   post_review_failure_comment "$review_output_file" "$review_infra_failure"
 
   rm -f "$review_output_file"

--- a/tests/test-merge-pr.sh
+++ b/tests/test-merge-pr.sh
@@ -276,7 +276,7 @@ reset_case_files() {
     "$TEST_DIR"/git-sibling-pull* "$TEST_DIR"/gh-merged-marker* \
     "$TEST_DIR"/git-review-head* "$TEST_DIR"/git-push-head* \
     "$TEST_DIR"/gh-head-ref* "$TEST_DIR"/preflight-calls* \
-    "$TEST_DIR"/git-worktree-remove*
+    "$TEST_DIR"/git-worktree-remove* "$TEST_DIR"/touchstone-review-log*
   rm -rf "$GIT_PATH_ROOT"
   mkdir -p "$GIT_PATH_ROOT"
   unset GIT_WORKTREE_LIST
@@ -302,6 +302,7 @@ reset_case_files() {
   unset GIT_WORKTREE_STATUS
   unset GIT_WORKTREE_REMOVE_FAIL
   unset SHELLCHECK_VERSION_LINE
+  unset TOUCHSTONE_FAIL_OPEN_BYPASS_WINDOW_HOURS
 }
 
 run_merge_pr() {
@@ -348,7 +349,24 @@ run_merge_pr() {
     GIT_LOCAL_BRANCH_HEAD="${GIT_LOCAL_BRANCH_HEAD:-pr-head-oid}" \
     PREFLIGHT_CALLS_FILE="${PREFLIGHT_CALLS_FILE:-}" \
     TEST_CURRENT_WORKTREE="${TEST_CURRENT_WORKTREE:-$DEFAULT_FAKE_WORKTREE}" \
+    TOUCHSTONE_REVIEW_LOG="$TEST_DIR/touchstone-review-log" \
+    TOUCHSTONE_FAIL_OPEN_BYPASS_WINDOW_HOURS="${TOUCHSTONE_FAIL_OPEN_BYPASS_WINDOW_HOURS:-24}" \
     bash "$MERGE_SCRIPT_DIR/merge-pr.sh" "$@" >"$output_file" 2>&1
+}
+
+write_fail_open_review_log() {
+  local branch="${1:-feature/test}"
+  local sha="${2:-pr-head-oid}"
+  local reason="${3:-FAIL_OPEN_TIMEOUT}"
+  local detail="${4:-fail-open:timeout waiting for hosted reviewer}"
+  local timestamp="${5:-}"
+
+  if [ -z "$timestamp" ]; then
+    timestamp="$(date '+%Y-%m-%dT%H:%M:%S%z')"
+  fi
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$timestamp" "$DEFAULT_FAKE_WORKTREE" "$branch" "$sha" "$reason" "$detail" \
+    >"$TEST_DIR/touchstone-review-log"
 }
 
 install_preflight_counter_fixture() {
@@ -1104,15 +1122,94 @@ else
   exit 1
 fi
 
+echo "==> Test: fail-open marker bypass requires explicit allow flag"
+reset_case_files
+write_fail_open_review_log
+if run_merge_pr "$TEST_DIR/output-fail-open-no-flag.txt" 123 --bypass-with-disclosure="fail-open reviewer timeout"; then
+  echo "FAIL: fail-open marker bypass without allow flag unexpectedly succeeded" >&2
+  exit 1
+fi
+if grep -q "No prior clean review marker matches branch 'feature/test' at head 'pr-head-oid' and merge base 'base-oid'" "$TEST_DIR/output-fail-open-no-flag.txt" \
+  && [ ! -f "$TEST_DIR/gh-merge-head" ] \
+  && [ ! -f "$TEST_DIR/gh-comment" ] \
+  && [ ! -f "$TEST_DIR/codex-review.log" ]; then
+  echo "==> PASS: fail-open marker is ignored unless explicitly allowed"
+else
+  echo "FAIL: fail-open marker without allow flag did not fail safely" >&2
+  cat "$TEST_DIR/output-fail-open-no-flag.txt" >&2
+  exit 1
+fi
+
+echo "==> Test: fail-open marker bypass requires outage disclosure"
+reset_case_files
+write_fail_open_review_log
+if run_merge_pr "$TEST_DIR/output-fail-open-vague.txt" 123 --bypass-with-disclosure="manual override" --allow-fail-open-marker; then
+  echo "FAIL: fail-open marker bypass with vague disclosure unexpectedly succeeded" >&2
+  exit 1
+fi
+if grep -q -- '--allow-fail-open-marker requires a disclosure reason' "$TEST_DIR/output-fail-open-vague.txt" \
+  && [ ! -f "$TEST_DIR/gh-merge-head" ] \
+  && [ ! -f "$TEST_DIR/gh-comment" ] \
+  && [ ! -f "$TEST_DIR/codex-review.log" ]; then
+  echo "==> PASS: fail-open marker bypass rejects vague disclosure"
+else
+  echo "FAIL: vague fail-open disclosure did not fail safely" >&2
+  cat "$TEST_DIR/output-fail-open-vague.txt" >&2
+  exit 1
+fi
+
+echo "==> Test: fail-open marker bypass requires matching current head"
+reset_case_files
+write_fail_open_review_log feature/test old-head
+if run_merge_pr "$TEST_DIR/output-fail-open-stale.txt" 123 --bypass-with-disclosure="fail-open reviewer infrastructure outage" --allow-fail-open-marker; then
+  echo "FAIL: fail-open marker bypass with stale head unexpectedly succeeded" >&2
+  exit 1
+fi
+if grep -q "No recent fail-open review-log marker matches branch 'feature/test' at head 'pr-head-oid'" "$TEST_DIR/output-fail-open-stale.txt" \
+  && [ ! -f "$TEST_DIR/gh-merge-head" ] \
+  && [ ! -f "$TEST_DIR/gh-comment" ] \
+  && [ ! -f "$TEST_DIR/codex-review.log" ]; then
+  echo "==> PASS: stale fail-open marker rejected"
+else
+  echo "FAIL: stale fail-open marker did not fail safely" >&2
+  cat "$TEST_DIR/output-fail-open-stale.txt" >&2
+  exit 1
+fi
+
+echo "==> Test: fail-open marker bypass records evidence and audit log"
+reset_case_files
+write_fail_open_review_log
+run_merge_pr "$TEST_DIR/output-fail-open-bypass.txt" 123 --bypass-with-disclosure="fail-open reviewer infrastructure outage; deterministic checks clean" --allow-fail-open-marker
+if grep -q 'BYPASSING REVIEWER GATE' "$TEST_DIR/output-fail-open-bypass.txt" \
+  && grep -q 'marker: fail-open' "$TEST_DIR/output-fail-open-bypass.txt" \
+  && grep -q 'reason: fail-open reviewer infrastructure outage; deterministic checks clean' "$TEST_DIR/output-fail-open-bypass.txt" \
+  && grep -q 'Reviewer bypassed via `--bypass-with-disclosure`. Marker: fail-open. Reason: fail-open reviewer infrastructure outage; deterministic checks clean' "$TEST_DIR/gh-comment" \
+  && grep -q 'Fail-open evidence: timestamp=' "$TEST_DIR/gh-comment" \
+  && grep -q 'reason=FAIL_OPEN_TIMEOUT' "$TEST_DIR/gh-comment" \
+  && grep -q '^Reviewer-bypass: fail-open reviewer infrastructure outage; deterministic checks clean$' "$TEST_DIR/gh-merge-body" \
+  && grep -q $'\treview-bypass\t' "$TEST_DIR/touchstone-review-log" \
+  && grep -q 'marker=fail-open' "$TEST_DIR/touchstone-review-log" \
+  && grep -q '^pr-head-oid$' "$TEST_DIR/gh-merge-head" \
+  && [ ! -f "$TEST_DIR/codex-review.log" ]; then
+  echo "==> PASS: fail-open bypass is disclosed, audited, and merged"
+else
+  echo "FAIL: fail-open bypass path did not disclose and merge as expected" >&2
+  cat "$TEST_DIR/output-fail-open-bypass.txt" >&2
+  exit 1
+fi
+
 echo "==> Test: bypass after clean marker records disclosure and trailer"
 reset_case_files
 mkdir -p "$GIT_PATH_ROOT/touchstone/reviewer-clean"
 printf 'result=CODEX_REVIEW_CLEAN\nbranch=feature/test\nhead=pr-head-oid\nmerge_base=base-oid\n' >"$GIT_PATH_ROOT/touchstone/reviewer-clean/feature_test.clean"
 run_merge_pr "$TEST_DIR/output-bypass.txt" 123 --bypass-with-disclosure="reviewer timed out after prior clean review"
 if grep -q 'BYPASSING REVIEWER GATE' "$TEST_DIR/output-bypass.txt" \
+  && grep -q 'marker: clean-review' "$TEST_DIR/output-bypass.txt" \
   && grep -q 'reason: reviewer timed out after prior clean review' "$TEST_DIR/output-bypass.txt" \
-  && grep -q 'Reviewer bypassed via `--bypass-with-disclosure`. Reason: reviewer timed out after prior clean review' "$TEST_DIR/gh-comment" \
+  && grep -q 'Reviewer bypassed via `--bypass-with-disclosure`. Marker: clean-review. Reason: reviewer timed out after prior clean review' "$TEST_DIR/gh-comment" \
   && grep -q '^Reviewer-bypass: reviewer timed out after prior clean review$' "$TEST_DIR/gh-merge-body" \
+  && grep -q $'\treview-bypass\t' "$TEST_DIR/touchstone-review-log" \
+  && grep -q 'marker=clean-review' "$TEST_DIR/touchstone-review-log" \
   && grep -q '^pr-head-oid$' "$TEST_DIR/gh-merge-head" \
   && [ ! -f "$TEST_DIR/codex-review.log" ]; then
   echo "==> PASS: bypass is disclosed and merged with trailer"

--- a/tests/test-review-comment.sh
+++ b/tests/test-review-comment.sh
@@ -160,7 +160,8 @@ chmod +x "$FAKE_BIN/gh" "$FAKE_BIN/git"
 
 reset_fixture() {
   rm -f "$TEST_DIR"/comments "$TEST_DIR"/merge-head "$TEST_DIR"/merge-body \
-    "$TEST_DIR"/review.log "$TEST_DIR"/merged "$TEST_DIR"/checkout "$TEST_DIR"/git-checkout-main
+    "$TEST_DIR"/review.log "$TEST_DIR"/review-audit.log "$TEST_DIR"/merged \
+    "$TEST_DIR"/checkout "$TEST_DIR"/git-checkout-main
   rm -rf "$MERGE_DIR/repo/.git"
   mkdir -p "$MERGE_DIR/repo/.git"
   unset CODEX_REVIEW_STUB_EXIT CODEX_REVIEW_STUB_OUTPUT CODEX_REVIEW_STUB_SUMMARY
@@ -181,6 +182,7 @@ run_merge() {
     CODEX_REVIEW_STUB_EXIT="${CODEX_REVIEW_STUB_EXIT:-0}" \
     CODEX_REVIEW_STUB_OUTPUT="${CODEX_REVIEW_STUB_OUTPUT:-}" \
     CODEX_REVIEW_STUB_SUMMARY="${CODEX_REVIEW_STUB_SUMMARY:-}" \
+    TOUCHSTONE_REVIEW_LOG="$TEST_DIR/review-audit.log" \
     TOUCHSTONE_NO_PREFLIGHT=1 \
     bash "$MERGE_DIR/scripts/merge-pr.sh" "$@" >"$output_file" 2>&1
 }
@@ -255,15 +257,17 @@ else
   exit 1
 fi
 
-echo "==> Test: bypass path still posts only existing disclosure"
+echo "==> Test: bypass path posts audited disclosure without clean comment"
 reset_fixture
 printf '[review]\ncomment_on_clean = true\n' >"$MERGE_DIR/repo/.codex-review.toml"
 mkdir -p "$MERGE_DIR/repo/.git/touchstone/reviewer-clean"
 printf 'result=CODEX_REVIEW_CLEAN\nbranch=feature/test\nhead=pr-head-oid\nmerge_base=base-oid\n' >"$MERGE_DIR/repo/.git/touchstone/reviewer-clean/feature_test.clean"
 run_merge "$TEST_DIR/merge-bypass.txt" 123 --bypass-with-disclosure="reviewer wedged after clean marker"
-if grep -q 'Reviewer bypassed via `--bypass-with-disclosure`. Reason: reviewer wedged after clean marker' "$TEST_DIR/comments" \
+if grep -q 'Reviewer bypassed via `--bypass-with-disclosure`. Marker: clean-review. Reason: reviewer wedged after clean marker' "$TEST_DIR/comments" \
+  && grep -q $'\treview-bypass\t' "$TEST_DIR/review-audit.log" \
+  && grep -q 'marker=clean-review' "$TEST_DIR/review-audit.log" \
   && ! grep -q 'review clean' "$TEST_DIR/comments"; then
-  echo "==> PASS: bypass disclosure unchanged and no clean comment posted"
+  echo "==> PASS: bypass disclosure audited and no clean comment posted"
 else
   echo "FAIL: bypass disclosure path regressed" >&2
   cat "$TEST_DIR/merge-bypass.txt" >&2


### PR DESCRIPTION
## Linked Issues

Closes #372

Closes #372

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
