### PR TITLE
fix: allow route-backed conductor review auth

### DIFF
--- a/.cursor/rules/conductor-delegation.mdc
+++ b/.cursor/rules/conductor-delegation.mdc
@@ -2,7 +2,7 @@
 description: Use when delegating or routing tasks to a different LLM via the conductor CLI — e.g., cheap second opinions, long-context reads, web search, or offline runs.
 globs: ""
 alwaysApply: false
-managed-by: conductor v0.10.26
+managed-by: conductor v0.10.28
 ---
 
 # Conductor delegation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,7 +219,7 @@ Flag any of the following:
 
 If there are zero blocking issues: "LGTM."
 
-<!-- conductor:begin v0.10.26 -->
+<!-- conductor:begin v0.10.28 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -86,7 +86,7 @@ The shared steering above (agent roles, lifecycle, principles, routing table) is
 
 For deep references on specific topics, read `principles/*.md` files via the routing table in the block above. For project-specific authoring rules and the AI Review Guide, also read `AGENTS.md`.
 
-<!-- conductor:begin v0.10.26 -->
+<!-- conductor:begin v0.10.28 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -1705,8 +1705,28 @@ reviewer_conductor_auth_ok() {
   # Delegate to `conductor doctor --json` — cheap check, makes no upstream
   # calls, confirms at least one provider is configured.
   local doctor_json
-  doctor_json=$(conductor doctor --json 2>/dev/null) || return 1
-  echo "$doctor_json" | grep -q '"configured"[[:space:]]*:[[:space:]]*true'
+  doctor_json=$(conductor doctor --json 2>/dev/null) || doctor_json=""
+  if echo "$doctor_json" | grep -q '"configured"[[:space:]]*:[[:space:]]*true'; then
+    return 0
+  fi
+
+  reviewer_conductor_route_auth_ok
+}
+
+reviewer_conductor_route_auth_ok() {
+  local route_json provider
+  local -a args
+
+  if ! conductor route --help >/dev/null 2>&1; then
+    return 1
+  fi
+
+  args=(route --json --kind review)
+  [ -n "${CONDUCTOR_WITH:-}" ] && args+=(--with "$CONDUCTOR_WITH")
+  route_json="$(conductor "${args[@]}" 2>/dev/null)" || return 1
+  provider="$(conductor_route_json_string_field "$route_json" selected_provider)"
+  [ -n "$provider" ] || provider="$(conductor_route_json_string_field "$route_json" provider)"
+  [ -n "$provider" ]
 }
 
 conductor_inner_timeout() {
@@ -1890,6 +1910,14 @@ conductor_route_json_string_field() {
     | head -1
 }
 
+conductor_route_selected_provider() {
+  local json="$1"
+  local provider
+  provider="$(conductor_route_json_string_field "$json" selected_provider)"
+  [ -n "$provider" ] || provider="$(conductor_route_json_string_field "$json" provider)"
+  printf '%s' "$provider"
+}
+
 conductor_csv_contains() {
   local csv="$1"
   local wanted="$2"
@@ -1973,7 +2001,7 @@ conductor_route_preflight_for_phase() {
   route_rc=$?
   set -e
 
-  provider="$(conductor_route_json_string_field "$route_json" provider)"
+  provider="$(conductor_route_selected_provider "$route_json")"
   error="$(conductor_route_json_string_field "$route_json" error)"
   if [ -z "$error" ] && [ -s "$route_stderr" ]; then
     error="$(tr '\n' ' ' <"$route_stderr" | sed 's/[[:space:]][[:space:]]*/ /g')"

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -1705,8 +1705,28 @@ reviewer_conductor_auth_ok() {
   # Delegate to `conductor doctor --json` — cheap check, makes no upstream
   # calls, confirms at least one provider is configured.
   local doctor_json
-  doctor_json=$(conductor doctor --json 2>/dev/null) || return 1
-  echo "$doctor_json" | grep -q '"configured"[[:space:]]*:[[:space:]]*true'
+  doctor_json=$(conductor doctor --json 2>/dev/null) || doctor_json=""
+  if echo "$doctor_json" | grep -q '"configured"[[:space:]]*:[[:space:]]*true'; then
+    return 0
+  fi
+
+  reviewer_conductor_route_auth_ok
+}
+
+reviewer_conductor_route_auth_ok() {
+  local route_json provider
+  local -a args
+
+  if ! conductor route --help >/dev/null 2>&1; then
+    return 1
+  fi
+
+  args=(route --json --kind review)
+  [ -n "${CONDUCTOR_WITH:-}" ] && args+=(--with "$CONDUCTOR_WITH")
+  route_json="$(conductor "${args[@]}" 2>/dev/null)" || return 1
+  provider="$(conductor_route_json_string_field "$route_json" selected_provider)"
+  [ -n "$provider" ] || provider="$(conductor_route_json_string_field "$route_json" provider)"
+  [ -n "$provider" ]
 }
 
 conductor_inner_timeout() {
@@ -1890,6 +1910,14 @@ conductor_route_json_string_field() {
     | head -1
 }
 
+conductor_route_selected_provider() {
+  local json="$1"
+  local provider
+  provider="$(conductor_route_json_string_field "$json" selected_provider)"
+  [ -n "$provider" ] || provider="$(conductor_route_json_string_field "$json" provider)"
+  printf '%s' "$provider"
+}
+
 conductor_csv_contains() {
   local csv="$1"
   local wanted="$2"
@@ -1973,7 +2001,7 @@ conductor_route_preflight_for_phase() {
   route_rc=$?
   set -e
 
-  provider="$(conductor_route_json_string_field "$route_json" provider)"
+  provider="$(conductor_route_selected_provider "$route_json")"
   error="$(conductor_route_json_string_field "$route_json" error)"
   if [ -z "$error" ] && [ -s "$route_stderr" ]; then
     error="$(tr '\n' ' ' <"$route_stderr" | sed 's/[[:space:]][[:space:]]*/ /g')"

--- a/tests/test-review-hook.sh
+++ b/tests/test-review-hook.sh
@@ -830,6 +830,70 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
+echo "==> Test: pinned route auth allows merge review when doctor misses provider"
+setup_cascade_repo
+rm -f "$CASCADE_CALLS"
+rm -rf "$CASCADE_BIN"
+mkdir -p "$CASCADE_BIN"
+cat >"$CASCADE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "main"
+EOF
+cat >"$CASCADE_BIN/conductor" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  doctor)
+    printf '{"providers":[{"configured":false}]}\n'
+    ;;
+  route)
+    if [ "${2:-}" = "--help" ]; then
+      exit 0
+    fi
+    printf 'route %s\n' "$*" >>"$CASCADE_CALLS"
+    printf '{"selected_provider":"openrouter"}\n'
+    ;;
+  review)
+    printf 'review %s\n' "$*" >>"$CASCADE_CALLS"
+    cat >/dev/null
+    printf 'CODEX_REVIEW_CLEAN\n'
+    ;;
+  *)
+    printf 'unexpected conductor command: %s\n' "$*" >&2
+    exit 99
+    ;;
+esac
+EOF
+chmod +x "$CASCADE_BIN/gh" "$CASCADE_BIN/conductor"
+
+set +e
+(
+  cd "$CASCADE_REPO"
+  PATH="$CASCADE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    CASCADE_CALLS="$CASCADE_CALLS" \
+    CODEX_REVIEW_BASE="HEAD~1" \
+    CODEX_REVIEW_DISABLE_CACHE=1 \
+    CODEX_REVIEW_ON_ERROR=fail-closed \
+    CODEX_REVIEW_PR_NUMBER=123 \
+    TOUCHSTONE_CONDUCTOR_WITH=openrouter \
+    bash "$TOUCHSTONE_ROOT/hooks/codex-review.sh" >"$CASCADE_OUTPUT" 2>&1
+)
+ROUTE_AUTH_EXIT=$?
+set -e
+
+if [ "$ROUTE_AUTH_EXIT" -eq 0 ] \
+  && grep -q '^route .*--kind review .*--with openrouter' "$CASCADE_CALLS" \
+  && grep -q '^review .*--with openrouter' "$CASCADE_CALLS" \
+  && ! grep -q 'No reviewer available' "$CASCADE_OUTPUT"; then
+  echo "==> PASS: pinned route auth allowed review despite doctor miss"
+else
+  echo "FAIL: expected pinned route auth to allow the review" >&2
+  echo "exit code: $ROUTE_AUTH_EXIT" >&2
+  cat "$CASCADE_OUTPUT" >&2
+  [ -f "$CASCADE_CALLS" ] && cat "$CASCADE_CALLS" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
 echo "==> Test: merge review route preflight accepts viable auto route"
 setup_cascade_repo
 rm -f "$CASCADE_CALLS"


### PR DESCRIPTION
## Linked Issues

Closes #426

Closes #426

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
