### PR TITLE
fix(security): harden merge-gate review trust boundary, sync, and auto-update

### DIFF
--- a/.github/workflows/issue-claim-check.yml
+++ b/.github/workflows/issue-claim-check.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout trusted claim-check helper
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           path: .touchstone-claim-base

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,12 @@ homebrew-touchstone/
 .cortex/.index/
 .cortex/pending/
 .cortex/.last-cli-version
+
+# Credentials — never commit secrets while testing providers locally
+.env
+.env.*
+!.env.example
+credentials.json
+*.pem
+*.key
+*.p12

--- a/bootstrap/new-project.sh
+++ b/bootstrap/new-project.sh
@@ -25,6 +25,8 @@
 set -euo pipefail
 
 TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck source=../lib/safe-write.sh
+source "$TOUCHSTONE_ROOT/lib/safe-write.sh"
 # shellcheck source=../lib/install-hooks.sh
 source "$TOUCHSTONE_ROOT/lib/install-hooks.sh"
 # shellcheck source=../lib/touchstone-block.sh
@@ -1012,6 +1014,13 @@ copy_file() {
   local dst="$2"
   local dst_dir
   dst_dir="$(dirname "$dst")"
+
+  # Guard against symlink traversal (final component + ancestor dirs) before the
+  # mkdir/cp below; see touchstone_ensure_safe_dest.
+  if ! touchstone_ensure_safe_dest "$dst" "$PROJECT_DIR" false; then
+    LAST_COPY_CREATED=false
+    return 1
+  fi
   mkdir -p "$dst_dir"
 
   if [ -e "$dst" ]; then
@@ -1036,6 +1045,11 @@ copy_file_force() {
   local dst="$2"
   local backup_path dst_dir
   dst_dir="$(dirname "$dst")"
+
+  # Guard against symlink traversal before any mkdir/cp/backup below.
+  if ! touchstone_ensure_safe_dest "$dst" "$PROJECT_DIR" false; then
+    return 1
+  fi
   mkdir -p "$dst_dir"
 
   if [ -f "$dst" ] && diff -q "$src" "$dst" >/dev/null 2>&1; then
@@ -1401,6 +1415,7 @@ if [ -d "$TOUCHSTONE_ROOT/.git" ]; then
 else
   TOUCHSTONE_SHA="$(cat "$TOUCHSTONE_ROOT/VERSION" 2>/dev/null | tr -d '[:space:]' || echo "unknown")"
 fi
+touchstone_ensure_safe_dest "$PROJECT_DIR/.touchstone-version" "$PROJECT_DIR" false || true
 echo "$TOUCHSTONE_SHA" >"$PROJECT_DIR/.touchstone-version"
 echo ""
 echo "==> Wrote .touchstone-version: $TOUCHSTONE_SHA"
@@ -1715,6 +1730,7 @@ fi
 
 # Write .touchstone-config with project type (skip if already exists).
 if [ ! -f "$PROJECT_DIR/.touchstone-config" ]; then
+  touchstone_ensure_safe_dest "$PROJECT_DIR/.touchstone-config" "$PROJECT_DIR" false || true
   {
     printf '# touchstone project profile. Commit this file so all clones use the same commands.\n'
     printf 'project_type=%s\n' "$INPUT_TYPE"

--- a/bootstrap/update-project.sh
+++ b/bootstrap/update-project.sh
@@ -20,6 +20,8 @@
 set -euo pipefail
 
 TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck source=../lib/safe-write.sh
+source "$TOUCHSTONE_ROOT/lib/safe-write.sh"
 # shellcheck source=../lib/install-hooks.sh
 source "$TOUCHSTONE_ROOT/lib/install-hooks.sh"
 # shellcheck source=../lib/touchstone-block.sh
@@ -176,35 +178,13 @@ relative_project_path() {
   printf '%s' "${path#"$PROJECT_DIR"/}"
 }
 
-# Symlink-safe destination guard for every write into the project. cp, mkdir -p,
-# and redirects all follow symlinks, so a symlink planted at a managed path — or
-# at any ANCESTOR directory of one (e.g. a managed dir replaced by a symlink to
-# somewhere outside the project) — could redirect the write outside the project.
-# Managed paths are always regular files inside real directories, so:
-#   * a symlinked ANCESTOR directory (between dst and PROJECT_DIR) is hostile and
-#     cannot be safely auto-removed -> refuse the write (return 1);
-#   * a symlink at the FINAL component is replaced with the real file (git tracks
-#     the change, so it stays recoverable).
-# Call this BEFORE any mkdir/cp/redirect so the ancestor check also protects the
-# directory creation. Returns 0 when "$dst" is safe to write, 1 to skip it.
+# Thin wrapper over the shared symlink-safe write guard (lib/safe-write.sh),
+# bound to this run's PROJECT_DIR / DRY_RUN. See touchstone_ensure_safe_dest for
+# the full rationale. Call BEFORE any mkdir/cp/redirect into the project.
 ensure_safe_dest() {
-  local dst="$1"
-  local parent next
-  parent="$(dirname "$dst")"
-  while [ "$parent" != "$PROJECT_DIR" ] && [ "$parent" != "/" ] && [ "$parent" != "." ]; do
-    if [ -L "$parent" ]; then
-      echo "    ! refusing to write through symlinked directory: $parent" >&2
-      return 1
-    fi
-    next="$(dirname "$parent")"
-    [ "$next" = "$parent" ] && break
-    parent="$next"
-  done
-  if [ -L "$dst" ]; then
-    echo "    ! replacing unexpected symlink with managed file: $dst" >&2
-    [ "$DRY_RUN" = false ] && rm -f "$dst"
-  fi
-  return 0
+  local dry=false
+  [ "$DRY_RUN" = true ] && dry=true
+  touchstone_ensure_safe_dest "$1" "$PROJECT_DIR" "$dry"
 }
 
 ADDED_PATHS=()

--- a/bootstrap/update-project.sh
+++ b/bootstrap/update-project.sh
@@ -176,6 +176,37 @@ relative_project_path() {
   printf '%s' "${path#"$PROJECT_DIR"/}"
 }
 
+# Symlink-safe destination guard for every write into the project. cp, mkdir -p,
+# and redirects all follow symlinks, so a symlink planted at a managed path — or
+# at any ANCESTOR directory of one (e.g. a managed dir replaced by a symlink to
+# somewhere outside the project) — could redirect the write outside the project.
+# Managed paths are always regular files inside real directories, so:
+#   * a symlinked ANCESTOR directory (between dst and PROJECT_DIR) is hostile and
+#     cannot be safely auto-removed -> refuse the write (return 1);
+#   * a symlink at the FINAL component is replaced with the real file (git tracks
+#     the change, so it stays recoverable).
+# Call this BEFORE any mkdir/cp/redirect so the ancestor check also protects the
+# directory creation. Returns 0 when "$dst" is safe to write, 1 to skip it.
+ensure_safe_dest() {
+  local dst="$1"
+  local parent next
+  parent="$(dirname "$dst")"
+  while [ "$parent" != "$PROJECT_DIR" ] && [ "$parent" != "/" ] && [ "$parent" != "." ]; do
+    if [ -L "$parent" ]; then
+      echo "    ! refusing to write through symlinked directory: $parent" >&2
+      return 1
+    fi
+    next="$(dirname "$parent")"
+    [ "$next" = "$parent" ] && break
+    parent="$next"
+  done
+  if [ -L "$dst" ]; then
+    echo "    ! replacing unexpected symlink with managed file: $dst" >&2
+    [ "$DRY_RUN" = false ] && rm -f "$dst"
+  fi
+  return 0
+}
+
 ADDED_PATHS=()
 BRANCH_CREATED=false
 COMMIT_CREATED=false
@@ -330,6 +361,7 @@ fi
 if [ "$NEEDS_CODEX_REVIEW_MIGRATION" = true ]; then
   echo ""
   echo "==> Migrating .codex-review.toml from v1.x → v2.x shape..."
+  ensure_safe_dest "$PROJECT_DIR/.touchstone-migrate-codex-review.log" || true
   if (
     cd "$PROJECT_DIR" \
       && bash "$TOUCHSTONE_ROOT/bootstrap/migrate-review-config.sh" --no-backup --file "$CODEX_REVIEW_TOML"
@@ -365,6 +397,7 @@ fi
 ADDED=0
 UPDATED=0
 UNCHANGED=0
+SKIPPED_UNSAFE=0
 
 update_file() {
   local src="$1"
@@ -373,16 +406,11 @@ update_file() {
   dst_dir="$(dirname "$dst")"
   rel_path="$(relative_project_path "$dst")"
 
-  # Never write through a symlink at a managed path. `cp` follows symlinks, so a
-  # symlink (including a dangling one) planted in the target tree would make us
-  # clobber or create its target — potentially outside the project. Managed
-  # files are always regular files, so replace an unexpected symlink with the
-  # real file; git tracks the change, so it stays recoverable.
-  if [ -L "$dst" ]; then
-    echo "    ! replacing unexpected symlink with managed file: $dst" >&2
-    if [ "$DRY_RUN" = false ]; then
-      rm -f "$dst"
-    fi
+  # Guard against symlink traversal (final component AND ancestor dirs) before
+  # any mkdir/cp below. See ensure_safe_dest.
+  if ! ensure_safe_dest "$dst"; then
+    SKIPPED_UNSAFE=$((SKIPPED_UNSAFE + 1))
+    return
   fi
 
   if [ ! -f "$dst" ]; then
@@ -482,6 +510,11 @@ update_settings_file() {
   local dst_dir
   dst_dir="$(dirname "$dst")"
 
+  if ! ensure_safe_dest "$dst"; then
+    SKIPPED_UNSAFE=$((SKIPPED_UNSAFE + 1))
+    return
+  fi
+
   if [ ! -f "$dst" ]; then
     if [ "$DRY_RUN" = true ]; then
       echo "    + would add: $dst"
@@ -530,6 +563,11 @@ add_profile_project_template_if_missing() {
   local src="$1" dst="$2"
   local rel_path
   rel_path="$(relative_project_path "$dst")"
+
+  if ! ensure_safe_dest "$dst"; then
+    SKIPPED_UNSAFE=$((SKIPPED_UNSAFE + 1))
+    return 0
+  fi
 
   if [ -f "$dst" ]; then
     # Hand-edited or already-shipped — leave alone. update_file handles
@@ -585,6 +623,7 @@ fi
 
 write_touchstone_manifest() {
   local manifest="$PROJECT_DIR/.touchstone-manifest"
+  ensure_safe_dest "$manifest" || true
   {
     printf '# Managed by touchstone. These paths may be updated by `touchstone update`.\n'
     printf '.touchstone-manifest\n'
@@ -661,12 +700,16 @@ if [ "$DRY_RUN" = false ]; then
     find "$PROJECT_DIR/scripts" -maxdepth 1 -type f -name '*.sh' \
       -exec chmod +x {} + 2>/dev/null || true
   fi
+  ensure_safe_dest "$PROJECT_DIR/.touchstone-version" || true
   echo "$CURRENT_SHA" >"$PROJECT_DIR/.touchstone-version"
   write_touchstone_manifest
 fi
 
 echo ""
 echo "==> Summary: $ADDED added, $UPDATED updated, $UNCHANGED unchanged"
+if [ "$SKIPPED_UNSAFE" -gt 0 ]; then
+  echo "==> WARNING: $SKIPPED_UNSAFE managed path(s) skipped — destination traverses a symlink (see warnings above)." >&2
+fi
 echo "==> Workflow scripts: project-local copies from Touchstone-managed files"
 echo "    Prototype shim runner available for evaluation: touchstone run-script <script>"
 

--- a/bootstrap/update-project.sh
+++ b/bootstrap/update-project.sh
@@ -37,7 +37,7 @@ IN_PLACE=false
 
 usage() {
   echo "Usage: $0 [--dry-run|-n] [--check] [--branch <name>] [--in-place|--no-branch] [--ship]"
-  echo "Env: TOUCHSTONE_FORCE_OVERLAP=1 proceeds even when dirty paths overlap planned writes."
+  echo "Env: TOUCHSTONE_FORCE_OVERLAP=1 proceeds even when dirty paths overlap planned writes (explicit update only; ignored by background auto-sync)."
 }
 
 while [ "$#" -gt 0 ]; do
@@ -373,6 +373,18 @@ update_file() {
   dst_dir="$(dirname "$dst")"
   rel_path="$(relative_project_path "$dst")"
 
+  # Never write through a symlink at a managed path. `cp` follows symlinks, so a
+  # symlink (including a dangling one) planted in the target tree would make us
+  # clobber or create its target — potentially outside the project. Managed
+  # files are always regular files, so replace an unexpected symlink with the
+  # real file; git tracks the change, so it stays recoverable.
+  if [ -L "$dst" ]; then
+    echo "    ! replacing unexpected symlink with managed file: $dst" >&2
+    if [ "$DRY_RUN" = false ]; then
+      rm -f "$dst"
+    fi
+  fi
+
   if [ ! -f "$dst" ]; then
     if [ "$DRY_RUN" = true ]; then
       echo "    + would add: $dst"
@@ -644,7 +656,10 @@ stage_touchstone_manifest_paths() {
 # Ensure scripts are executable and write touchstone metadata.
 if [ "$DRY_RUN" = false ]; then
   if [ -d "$PROJECT_DIR/scripts" ]; then
-    chmod +x "$PROJECT_DIR/scripts/"*.sh 2>/dev/null || true
+    # -type f (find does not follow symlinks here) so we only chmod real files;
+    # a glob would follow a planted symlink and flip perms on its target.
+    find "$PROJECT_DIR/scripts" -maxdepth 1 -type f -name '*.sh' \
+      -exec chmod +x {} + 2>/dev/null || true
   fi
   echo "$CURRENT_SHA" >"$PROJECT_DIR/.touchstone-version"
   write_touchstone_manifest

--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -297,10 +297,24 @@ resolve_trusted_review_file() {
 
 CONFIG_FILE="$(resolve_trusted_review_file .touchstone-review.toml .codex-review.toml)"
 CONFIG_DISPLAY_NAME="$(basename "${RESOLVED_REVIEW_FILE_LABEL:-.touchstone-review.toml}")"
-# No config in the trusted source -> point at a non-existent path so the parser
-# falls through to built-in (safe) defaults rather than the PR head's file.
-if [ -z "$CONFIG_FILE" ]; then
+# No config in the trusted source. Outside the merge gate the working tree IS the
+# source of truth, so fall back to it (an absent file then leaves CONFIG_FILE
+# pointing at a non-existent path, and the `[ -f "$CONFIG_FILE" ]` guard below
+# falls through to built-in safe defaults). Under the merge gate the working tree
+# is the attacker PR head, which may ADD a config that is absent on the base ref;
+# do NOT fall back to it — leave CONFIG_FILE empty so parsing is skipped and the
+# built-in safe defaults apply. (The working-tree fallback here was a bypass: a
+# PR that introduced a brand-new weakened config would have had it honored.)
+if [ -z "$CONFIG_FILE" ] && [ -z "${CODEX_REVIEW_PR_NUMBER:-}" ]; then
   CONFIG_FILE="$REPO_ROOT/.touchstone-review.toml"
+fi
+
+# Test hook: print the resolved config path/name and exit, so regression tests
+# can assert the gate never resolves config from the attacker PR head.
+if [ "${CODEX_REVIEW_TEST_PRINT_CONFIG:-0}" = "1" ]; then
+  printf 'CONFIG_FILE=%s\n' "$CONFIG_FILE"
+  printf 'CONFIG_DISPLAY_NAME=%s\n' "$CONFIG_DISPLAY_NAME"
+  exit 0
 fi
 cd "$REPO_ROOT"
 

--- a/hooks/codex-review.sh
+++ b/hooks/codex-review.sh
@@ -243,19 +243,65 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TOUCHSTONE_ROOT="${TOUCHSTONE_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-resolve_review_config_file() {
-  local repo_root="$1"
-  if [ -f "$repo_root/.touchstone-review.toml" ]; then
-    printf '%s\n' "$repo_root/.touchstone-review.toml"
-  elif [ -f "$repo_root/.codex-review.toml" ]; then
-    printf '%s\n' "$repo_root/.codex-review.toml"
-  else
-    printf '%s\n' "$repo_root/.touchstone-review.toml"
+# Files materialized from the trusted base ref by resolve_trusted_review_file;
+# removed by cleanup_review_process on exit.
+TRUSTED_REVIEW_TMP_FILES=()
+# Canonical (display) name of the file most recently resolved.
+RESOLVED_REVIEW_FILE_LABEL=""
+
+# Resolve a review control file (config or prompt-context) to a path whose
+# CONTENT is trusted, given an ordered list of candidate repo-relative paths.
+#
+# In the merge gate the working tree is the *attacker-controlled PR head*
+# (scripts/merge-pr.sh checks it out before invoking this hook), so reading the
+# review config or prompt-context file from the working tree would let a PR
+# weaken or disable the very guardrails reviewing it (unsafe_paths,
+# safe_by_default, mode, enabled) or inject "trusted project context" straight
+# into the fix-loop prompt. When CODEX_REVIEW_PR_NUMBER is set we therefore read
+# these files from the trusted base ref (CODEX_REVIEW_BASE) — the committed,
+# already-reviewed policy. A PR that adds or edits one of these files only takes
+# effect once it has merged through the gate under the previous policy.
+#
+# Outside the merge gate (local pre-push review) there is no separate trusted
+# base, so the working tree is the source of truth.
+#
+# Echoes a readable path for the first candidate present in the trusted source
+# and sets RESOLVED_REVIEW_FILE_LABEL to its canonical relative path; echoes
+# nothing if no candidate exists (callers fall back to built-in safe defaults).
+resolve_trusted_review_file() {
+  RESOLVED_REVIEW_FILE_LABEL=""
+  local rel tmp
+  if [ -n "${CODEX_REVIEW_PR_NUMBER:-}" ] && [ -n "${CODEX_REVIEW_BASE:-}" ]; then
+    for rel in "$@"; do
+      if git cat-file -e "${CODEX_REVIEW_BASE}:${rel}" 2>/dev/null; then
+        tmp="$(mktemp -t touchstone-trusted-review.XXXXXX)" || return 0
+        if git show "${CODEX_REVIEW_BASE}:${rel}" >"$tmp" 2>/dev/null; then
+          TRUSTED_REVIEW_TMP_FILES+=("$tmp")
+          RESOLVED_REVIEW_FILE_LABEL="$rel"
+          printf '%s\n' "$tmp"
+          return 0
+        fi
+        rm -f "$tmp"
+      fi
+    done
+    return 0
   fi
+  for rel in "$@"; do
+    if [ -f "$REPO_ROOT/$rel" ]; then
+      RESOLVED_REVIEW_FILE_LABEL="$rel"
+      printf '%s\n' "$REPO_ROOT/$rel"
+      return 0
+    fi
+  done
 }
 
-CONFIG_FILE="$(resolve_review_config_file "$REPO_ROOT")"
-CONFIG_DISPLAY_NAME="$(basename "$CONFIG_FILE")"
+CONFIG_FILE="$(resolve_trusted_review_file .touchstone-review.toml .codex-review.toml)"
+CONFIG_DISPLAY_NAME="$(basename "${RESOLVED_REVIEW_FILE_LABEL:-.touchstone-review.toml}")"
+# No config in the trusted source -> point at a non-existent path so the parser
+# falls through to built-in (safe) defaults rather than the PR head's file.
+if [ -z "$CONFIG_FILE" ]; then
+  CONFIG_FILE="$REPO_ROOT/.touchstone-review.toml"
+fi
 cd "$REPO_ROOT"
 
 PREFLIGHT_SCRIPT="$TOUCHSTONE_ROOT/lib/preflight.sh"
@@ -1178,13 +1224,11 @@ should_skip_pre_push_review() {
 # Repo-provided review context
 # --------------------------------------------------------------------------
 
-REVIEW_CONTEXT_FILE=""
-for _candidate in "$REPO_ROOT/.codex-review-context.md" "$REPO_ROOT/.github/codex-review-context.md"; do
-  if [ -f "$_candidate" ]; then
-    REVIEW_CONTEXT_FILE="$_candidate"
-    break
-  fi
-done
+# Read the prompt-context file from the trusted base ref under the merge gate
+# (see resolve_trusted_review_file). This file is injected into the review/fix
+# prompt as trusted project guidance, so a PR must not be able to supply it.
+REVIEW_CONTEXT_FILE="$(resolve_trusted_review_file .codex-review-context.md .github/codex-review-context.md)"
+REVIEW_CONTEXT_FILE_LABEL="${RESOLVED_REVIEW_FILE_LABEL:-}"
 
 path_matches_context_pattern() {
   local path="$1"
@@ -1891,15 +1935,36 @@ conductor_subcommand_for_mode() {
 
 conductor_tools_for_mode() {
   local phase="${1:-review}"
+  local tools
 
   case "$phase:$REVIEW_MODE" in
-    review:diff-only) printf '' ;;
-    review:no-tests) printf 'Read,Grep,Glob' ;;
-    review:*) printf 'Read,Grep,Glob,Bash' ;;
-    fix:no-tests) printf 'Read,Grep,Glob,Edit,Write' ;;
-    fix:*) printf 'Read,Grep,Glob,Bash,Edit,Write' ;;
-    *) printf 'Read,Grep,Glob,Bash' ;;
+    review:diff-only) tools='' ;;
+    review:no-tests) tools='Read,Grep,Glob' ;;
+    review:*) tools='Read,Grep,Glob,Bash' ;;
+    fix:no-tests) tools='Read,Grep,Glob,Edit,Write' ;;
+    fix:*) tools='Read,Grep,Glob,Bash,Edit,Write' ;;
+    *) tools='Read,Grep,Glob,Bash' ;;
   esac
+
+  # Merge-gate hardening: under the merge gate the diff and file contents under
+  # review are attacker-controlled and are a prompt-injection vector into this
+  # tool-enabled loop. Granting Bash there lets injected instructions run
+  # arbitrary commands (exfiltrate secrets, write outside the repo) — side
+  # effects the post-fix unsafe_paths check (a git-diff filter) cannot see. Drop
+  # Bash for PR-gate runs unless explicitly opted in; the deterministic test
+  # gate that runs after Conductor edits still validates behavior.
+  if [ -n "${CODEX_REVIEW_PR_NUMBER:-}" ] \
+    && ! is_truthy "${TOUCHSTONE_REVIEW_ALLOW_GATE_BASH:-false}"; then
+    local filtered="" _t
+    local IFS=','
+    for _t in $tools; do
+      [ "$_t" = "Bash" ] && continue
+      filtered="${filtered:+$filtered,}$_t"
+    done
+    tools="$filtered"
+  fi
+
+  printf '%s' "$tools"
 }
 
 conductor_route_json_string_field() {
@@ -2279,6 +2344,9 @@ REVIEW_LOCK_TOKEN=""
 
 cleanup_review_process() {
   rm -f "$REVIEW_OUTPUT_FILE" "$ASSIST_OUTPUT_FILE" "$REVIEW_STDERR_FILE" "$REVIEW_CONDUCTOR_LOG_FILE"
+  if [ "${#TRUSTED_REVIEW_TMP_FILES[@]}" -gt 0 ]; then
+    rm -f "${TRUSTED_REVIEW_TMP_FILES[@]}" 2>/dev/null || true
+  fi
   rm -f \
     "${SCOPED_LARGE_DIFF_FILE:-}" \
     "${SCOPED_LARGE_DIFF_INCLUDED_PATHS_FILE:-}" \
@@ -2698,7 +2766,7 @@ else
   echo "==> Prompt context: $PROMPT_CONTEXT_DECISION ($PROMPT_CONTEXT_REASON)"
 fi
 if [ -n "$REVIEW_CONTEXT_FILE" ]; then
-  echo "==> Review context: $(basename "$REVIEW_CONTEXT_FILE")"
+  echo "==> Review context: $(basename "${REVIEW_CONTEXT_FILE_LABEL:-$REVIEW_CONTEXT_FILE}")"
 fi
 
 # --------------------------------------------------------------------------

--- a/lib/auto-update.sh
+++ b/lib/auto-update.sh
@@ -165,14 +165,23 @@ touchstone_auto_update() {
     touchstone_auto_update_brew_upgrade
     return $?
   elif [ -d "$TOUCHSTONE_ROOT/.git" ]; then
-    # Running from a git clone — pull.
-    if git -C "$TOUCHSTONE_ROOT" pull --rebase 2>&1 | sed 's/^/    /' >&2; then
-      echo "==> Updated to latest via git pull." >&2
-      TOUCHSTONE_AUTO_UPDATE_REEXEC_PATH="$TOUCHSTONE_ROOT/bin/touchstone"
-      export TOUCHSTONE_AUTO_UPDATE_REEXEC_PATH
-      return "$TOUCHSTONE_AUTO_UPDATE_REEXEC_EXIT"
+    # Running from a git clone. Auto-pulling an unpinned tracking branch and
+    # re-exec'ing it runs whatever the remote HEAD points at *now*, with no
+    # integrity check — a compromised remote would execute on every machine on
+    # the next command. Default to notify-only so fetched code is never run
+    # without an explicit user action. Auto-pull+re-exec is opt-in.
+    if [ "${TOUCHSTONE_AUTO_UPDATE_GIT_PULL:-}" = "1" ]; then
+      if git -C "$TOUCHSTONE_ROOT" pull --rebase 2>&1 | sed 's/^/    /' >&2; then
+        echo "==> Updated to latest via git pull." >&2
+        TOUCHSTONE_AUTO_UPDATE_REEXEC_PATH="$TOUCHSTONE_ROOT/bin/touchstone"
+        export TOUCHSTONE_AUTO_UPDATE_REEXEC_PATH
+        return "$TOUCHSTONE_AUTO_UPDATE_REEXEC_EXIT"
+      fi
+      echo "WARNING: touchstone auto-update via git pull failed; continuing with current version." >&2
+    else
+      echo "==> Update available: v${latest_version}. Run: git -C \"$TOUCHSTONE_ROOT\" pull --rebase" >&2
+      echo "    (set TOUCHSTONE_AUTO_UPDATE_GIT_PULL=1 to auto-pull git-clone installs)" >&2
     fi
-    echo "WARNING: touchstone auto-update via git pull failed; continuing with current version." >&2
   else
     echo "==> Update available: v${latest_version}. Run: brew upgrade touchstone" >&2
   fi
@@ -469,7 +478,11 @@ touchstone_auto_project_sync() {
   dirty_paths="$(touchstone_sync_dirty_paths "$project_dir")"
   overlap_paths="$(touchstone_sync_dirty_overlap_paths "$project_dir" "$TOUCHSTONE_ROOT")"
 
-  if [ -n "$overlap_paths" ] && [ "${TOUCHSTONE_FORCE_OVERLAP:-}" != "1" ]; then
+  # Always skip background auto-sync when dirty paths overlap planned writes.
+  # Unlike an explicit `touchstone update`, auto-sync must never honor
+  # TOUCHSTONE_FORCE_OVERLAP: silently overwriting uncommitted work from an
+  # ambient env var is unrecoverable (managed files are not backed up).
+  if [ -n "$overlap_paths" ]; then
     echo "WARNING: touchstone auto-sync skipped for $project_dir (dirty paths overlap planned touchstone writes)." >&2
     printf '%s\n' "$overlap_paths" | sed 's/^/         - /' >&2
     echo "         Resolve those paths, then run: cd \"$project_dir\" && touchstone update --ship" >&2
@@ -477,10 +490,7 @@ touchstone_auto_project_sync() {
     return 0
   fi
 
-  if [ -n "$overlap_paths" ]; then
-    echo "WARNING: TOUCHSTONE_FORCE_OVERLAP=1 set; auto-sync proceeding despite dirty paths that overlap planned touchstone writes:" >&2
-    printf '%s\n' "$overlap_paths" | sed 's/^/         - /' >&2
-  elif [ -n "$dirty_paths" ]; then
+  if [ -n "$dirty_paths" ]; then
     printf '==> Proceeding with sync past unrelated dirty paths: ' >&2
     printf '%s\n' "$dirty_paths" | touchstone_sync_format_path_list >&2
   fi

--- a/lib/install-skills.sh
+++ b/lib/install-skills.sh
@@ -33,6 +33,13 @@
 #   0 — all requested operations succeeded (no-op counts as success)
 #   1 — source dir missing, target dir not writable, or copy failed
 
+# Shared symlink-safe write guard. Source defensively so this lib works
+# standalone; a no-op when the caller already sourced it.
+if ! command -v touchstone_ensure_safe_dest >/dev/null 2>&1; then
+  # shellcheck source=safe-write.sh
+  source "$(dirname "${BASH_SOURCE[0]}")/safe-write.sh"
+fi
+
 # Skills considered touchstone-owned for the legacy-skill cleanup. Listed
 # explicitly rather than by glob so a hand-added skill that happens to
 # start with "touchstone-" (project's own) is not deleted.
@@ -73,6 +80,11 @@ touchstone_install_skills() {
     [ -d "$skill_dir" ] || continue
     name="$(basename "$skill_dir")"
     target="$user_skills_dir/$name"
+
+    # Never write through a symlink at the skill target (cp -R would follow it
+    # and escape ~/.claude/skills). Replaces a final-component symlink; skips on
+    # a symlinked ancestor.
+    touchstone_ensure_safe_dest "$target" "$user_skills_dir" false || continue
 
     if [ ! -d "$target" ]; then
       cp -R "$skill_dir" "$target"

--- a/lib/safe-write.sh
+++ b/lib/safe-write.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# lib/safe-write.sh — shared symlink-safe write guard for touchstone's
+# bootstrap/sync writers.
+#
+# cp, mkdir -p, and shell redirects all FOLLOW symlinks. When touchstone writes
+# managed files into a project (or installs user-scoped skills), a symlink
+# planted at a managed path — or at any ANCESTOR directory of one — could
+# redirect the write outside the intended tree and clobber or create an
+# arbitrary file. Managed paths are always regular files inside real
+# directories, so this guard:
+#   * hard-refuses a write whose path traverses a symlinked ANCESTOR directory
+#     (between the destination and the trusted root) — an ancestor symlink
+#     cannot be safely auto-removed;
+#   * replaces a symlink at the FINAL path component with the real file (the
+#     write then lands inside the project; git tracks the change, so it stays
+#     recoverable).
+#
+# Call this BEFORE any mkdir/cp/redirect so the ancestor check also protects the
+# directory creation.
+
+# touchstone_ensure_safe_dest <dst> <root> [dry_run]
+#   dst      absolute path that is about to be written
+#   root     trusted boundary; ancestor symlinks are checked from dst up to (but
+#            not including) root. The root itself is the user's chosen location
+#            and is not second-guessed.
+#   dry_run  "true" to skip the actual symlink removal (still reports/decides)
+# Returns 0 when it is safe to write to "$dst", 1 when the write must be skipped.
+touchstone_ensure_safe_dest() {
+  local dst="$1"
+  local root="$2"
+  local dry_run="${3:-false}"
+  local parent next
+
+  parent="$(dirname "$dst")"
+  while [ "$parent" != "$root" ] && [ "$parent" != "/" ] && [ "$parent" != "." ]; do
+    if [ -L "$parent" ]; then
+      echo "    ! refusing to write through symlinked directory: $parent" >&2
+      return 1
+    fi
+    next="$(dirname "$parent")"
+    [ "$next" = "$parent" ] && break
+    parent="$next"
+  done
+
+  if [ -L "$dst" ]; then
+    echo "    ! replacing unexpected symlink with managed file: $dst" >&2
+    [ "$dry_run" != true ] && rm -f "$dst"
+  fi
+  return 0
+}

--- a/lib/touchstone-block.sh
+++ b/lib/touchstone-block.sh
@@ -80,6 +80,15 @@ touchstone_block_apply() {
     return 2
   fi
 
+  # Refuse a symlinked target. This function reads $target and rewrites it in
+  # place; if $target is a symlink it would read AND clobber the link's target,
+  # potentially outside the project. AGENTS.md/GEMINI.md are regular project
+  # files, so a symlink here is anomalous — skip rather than follow it.
+  if [ -L "$target" ]; then
+    echo "ERROR: $target is a symlink — refusing to write the touchstone block through it." >&2
+    return 1
+  fi
+
   # Detect either sentinel pair. Both must be paired (begin AND end), or refuse.
   local has_new_begin=0 has_new_end=0
   grep -qF "$TOUCHSTONE_BLOCK_BEGIN" "$target" && has_new_begin=1

--- a/scripts/cleanup-branches.sh
+++ b/scripts/cleanup-branches.sh
@@ -350,7 +350,7 @@ if [ "$REMOTE_TOO" -eq 1 ] && [ "${#REMOTE_DELETABLE[@]}" -gt 0 ]; then
   for b in "${REMOTE_DELETABLE[@]}"; do
     if [ -n "$REPO_SLUG" ] && gh api -X DELETE "/repos/$REPO_SLUG/git/refs/heads/$b" >/dev/null 2>&1; then
       echo "    deleted remote: origin/$b"
-    elif git push origin --delete "$b" 2>&1; then
+    elif git push origin --delete -- "$b" 2>&1; then
       echo "    deleted remote (via git push fallback): origin/$b"
     else
       echo "    SKIPPED remote (both gh api and git push --delete failed): origin/$b" >&2

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -297,10 +297,24 @@ resolve_trusted_review_file() {
 
 CONFIG_FILE="$(resolve_trusted_review_file .touchstone-review.toml .codex-review.toml)"
 CONFIG_DISPLAY_NAME="$(basename "${RESOLVED_REVIEW_FILE_LABEL:-.touchstone-review.toml}")"
-# No config in the trusted source -> point at a non-existent path so the parser
-# falls through to built-in (safe) defaults rather than the PR head's file.
-if [ -z "$CONFIG_FILE" ]; then
+# No config in the trusted source. Outside the merge gate the working tree IS the
+# source of truth, so fall back to it (an absent file then leaves CONFIG_FILE
+# pointing at a non-existent path, and the `[ -f "$CONFIG_FILE" ]` guard below
+# falls through to built-in safe defaults). Under the merge gate the working tree
+# is the attacker PR head, which may ADD a config that is absent on the base ref;
+# do NOT fall back to it — leave CONFIG_FILE empty so parsing is skipped and the
+# built-in safe defaults apply. (The working-tree fallback here was a bypass: a
+# PR that introduced a brand-new weakened config would have had it honored.)
+if [ -z "$CONFIG_FILE" ] && [ -z "${CODEX_REVIEW_PR_NUMBER:-}" ]; then
   CONFIG_FILE="$REPO_ROOT/.touchstone-review.toml"
+fi
+
+# Test hook: print the resolved config path/name and exit, so regression tests
+# can assert the gate never resolves config from the attacker PR head.
+if [ "${CODEX_REVIEW_TEST_PRINT_CONFIG:-0}" = "1" ]; then
+  printf 'CONFIG_FILE=%s\n' "$CONFIG_FILE"
+  printf 'CONFIG_DISPLAY_NAME=%s\n' "$CONFIG_DISPLAY_NAME"
+  exit 0
 fi
 cd "$REPO_ROOT"
 

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -243,19 +243,65 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TOUCHSTONE_ROOT="${TOUCHSTONE_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-resolve_review_config_file() {
-  local repo_root="$1"
-  if [ -f "$repo_root/.touchstone-review.toml" ]; then
-    printf '%s\n' "$repo_root/.touchstone-review.toml"
-  elif [ -f "$repo_root/.codex-review.toml" ]; then
-    printf '%s\n' "$repo_root/.codex-review.toml"
-  else
-    printf '%s\n' "$repo_root/.touchstone-review.toml"
+# Files materialized from the trusted base ref by resolve_trusted_review_file;
+# removed by cleanup_review_process on exit.
+TRUSTED_REVIEW_TMP_FILES=()
+# Canonical (display) name of the file most recently resolved.
+RESOLVED_REVIEW_FILE_LABEL=""
+
+# Resolve a review control file (config or prompt-context) to a path whose
+# CONTENT is trusted, given an ordered list of candidate repo-relative paths.
+#
+# In the merge gate the working tree is the *attacker-controlled PR head*
+# (scripts/merge-pr.sh checks it out before invoking this hook), so reading the
+# review config or prompt-context file from the working tree would let a PR
+# weaken or disable the very guardrails reviewing it (unsafe_paths,
+# safe_by_default, mode, enabled) or inject "trusted project context" straight
+# into the fix-loop prompt. When CODEX_REVIEW_PR_NUMBER is set we therefore read
+# these files from the trusted base ref (CODEX_REVIEW_BASE) — the committed,
+# already-reviewed policy. A PR that adds or edits one of these files only takes
+# effect once it has merged through the gate under the previous policy.
+#
+# Outside the merge gate (local pre-push review) there is no separate trusted
+# base, so the working tree is the source of truth.
+#
+# Echoes a readable path for the first candidate present in the trusted source
+# and sets RESOLVED_REVIEW_FILE_LABEL to its canonical relative path; echoes
+# nothing if no candidate exists (callers fall back to built-in safe defaults).
+resolve_trusted_review_file() {
+  RESOLVED_REVIEW_FILE_LABEL=""
+  local rel tmp
+  if [ -n "${CODEX_REVIEW_PR_NUMBER:-}" ] && [ -n "${CODEX_REVIEW_BASE:-}" ]; then
+    for rel in "$@"; do
+      if git cat-file -e "${CODEX_REVIEW_BASE}:${rel}" 2>/dev/null; then
+        tmp="$(mktemp -t touchstone-trusted-review.XXXXXX)" || return 0
+        if git show "${CODEX_REVIEW_BASE}:${rel}" >"$tmp" 2>/dev/null; then
+          TRUSTED_REVIEW_TMP_FILES+=("$tmp")
+          RESOLVED_REVIEW_FILE_LABEL="$rel"
+          printf '%s\n' "$tmp"
+          return 0
+        fi
+        rm -f "$tmp"
+      fi
+    done
+    return 0
   fi
+  for rel in "$@"; do
+    if [ -f "$REPO_ROOT/$rel" ]; then
+      RESOLVED_REVIEW_FILE_LABEL="$rel"
+      printf '%s\n' "$REPO_ROOT/$rel"
+      return 0
+    fi
+  done
 }
 
-CONFIG_FILE="$(resolve_review_config_file "$REPO_ROOT")"
-CONFIG_DISPLAY_NAME="$(basename "$CONFIG_FILE")"
+CONFIG_FILE="$(resolve_trusted_review_file .touchstone-review.toml .codex-review.toml)"
+CONFIG_DISPLAY_NAME="$(basename "${RESOLVED_REVIEW_FILE_LABEL:-.touchstone-review.toml}")"
+# No config in the trusted source -> point at a non-existent path so the parser
+# falls through to built-in (safe) defaults rather than the PR head's file.
+if [ -z "$CONFIG_FILE" ]; then
+  CONFIG_FILE="$REPO_ROOT/.touchstone-review.toml"
+fi
 cd "$REPO_ROOT"
 
 PREFLIGHT_SCRIPT="$TOUCHSTONE_ROOT/lib/preflight.sh"
@@ -1178,13 +1224,11 @@ should_skip_pre_push_review() {
 # Repo-provided review context
 # --------------------------------------------------------------------------
 
-REVIEW_CONTEXT_FILE=""
-for _candidate in "$REPO_ROOT/.codex-review-context.md" "$REPO_ROOT/.github/codex-review-context.md"; do
-  if [ -f "$_candidate" ]; then
-    REVIEW_CONTEXT_FILE="$_candidate"
-    break
-  fi
-done
+# Read the prompt-context file from the trusted base ref under the merge gate
+# (see resolve_trusted_review_file). This file is injected into the review/fix
+# prompt as trusted project guidance, so a PR must not be able to supply it.
+REVIEW_CONTEXT_FILE="$(resolve_trusted_review_file .codex-review-context.md .github/codex-review-context.md)"
+REVIEW_CONTEXT_FILE_LABEL="${RESOLVED_REVIEW_FILE_LABEL:-}"
 
 path_matches_context_pattern() {
   local path="$1"
@@ -1891,15 +1935,36 @@ conductor_subcommand_for_mode() {
 
 conductor_tools_for_mode() {
   local phase="${1:-review}"
+  local tools
 
   case "$phase:$REVIEW_MODE" in
-    review:diff-only) printf '' ;;
-    review:no-tests) printf 'Read,Grep,Glob' ;;
-    review:*) printf 'Read,Grep,Glob,Bash' ;;
-    fix:no-tests) printf 'Read,Grep,Glob,Edit,Write' ;;
-    fix:*) printf 'Read,Grep,Glob,Bash,Edit,Write' ;;
-    *) printf 'Read,Grep,Glob,Bash' ;;
+    review:diff-only) tools='' ;;
+    review:no-tests) tools='Read,Grep,Glob' ;;
+    review:*) tools='Read,Grep,Glob,Bash' ;;
+    fix:no-tests) tools='Read,Grep,Glob,Edit,Write' ;;
+    fix:*) tools='Read,Grep,Glob,Bash,Edit,Write' ;;
+    *) tools='Read,Grep,Glob,Bash' ;;
   esac
+
+  # Merge-gate hardening: under the merge gate the diff and file contents under
+  # review are attacker-controlled and are a prompt-injection vector into this
+  # tool-enabled loop. Granting Bash there lets injected instructions run
+  # arbitrary commands (exfiltrate secrets, write outside the repo) — side
+  # effects the post-fix unsafe_paths check (a git-diff filter) cannot see. Drop
+  # Bash for PR-gate runs unless explicitly opted in; the deterministic test
+  # gate that runs after Conductor edits still validates behavior.
+  if [ -n "${CODEX_REVIEW_PR_NUMBER:-}" ] \
+    && ! is_truthy "${TOUCHSTONE_REVIEW_ALLOW_GATE_BASH:-false}"; then
+    local filtered="" _t
+    local IFS=','
+    for _t in $tools; do
+      [ "$_t" = "Bash" ] && continue
+      filtered="${filtered:+$filtered,}$_t"
+    done
+    tools="$filtered"
+  fi
+
+  printf '%s' "$tools"
 }
 
 conductor_route_json_string_field() {
@@ -2279,6 +2344,9 @@ REVIEW_LOCK_TOKEN=""
 
 cleanup_review_process() {
   rm -f "$REVIEW_OUTPUT_FILE" "$ASSIST_OUTPUT_FILE" "$REVIEW_STDERR_FILE" "$REVIEW_CONDUCTOR_LOG_FILE"
+  if [ "${#TRUSTED_REVIEW_TMP_FILES[@]}" -gt 0 ]; then
+    rm -f "${TRUSTED_REVIEW_TMP_FILES[@]}" 2>/dev/null || true
+  fi
   rm -f \
     "${SCOPED_LARGE_DIFF_FILE:-}" \
     "${SCOPED_LARGE_DIFF_INCLUDED_PATHS_FILE:-}" \
@@ -2698,7 +2766,7 @@ else
   echo "==> Prompt context: $PROMPT_CONTEXT_DECISION ($PROMPT_CONTEXT_REASON)"
 fi
 if [ -n "$REVIEW_CONTEXT_FILE" ]; then
-  echo "==> Review context: $(basename "$REVIEW_CONTEXT_FILE")"
+  echo "==> Review context: $(basename "${REVIEW_CONTEXT_FILE_LABEL:-$REVIEW_CONTEXT_FILE}")"
 fi
 
 # --------------------------------------------------------------------------

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -918,7 +918,7 @@ cleanup_local_pr_branch_after_merge() {
   fi
 
   echo "==> Deleting local branch '$branch' after verified squash merge of $reviewed_head ..."
-  if git branch -D "$branch"; then
+  if git branch -D -- "$branch"; then
     echo "==> Local branch '$branch' deleted."
   else
     echo "WARNING: Could not delete local branch '$branch' after verified merge." >&2

--- a/templates/ci/github-validate.yml
+++ b/templates/ci/github-validate.yml
@@ -18,7 +18,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 

--- a/templates/ci/issue-claim-check.yml
+++ b/templates/ci/issue-claim-check.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout trusted claim-check helper
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           path: .touchstone-claim-base

--- a/tests/test-merge-pr.sh
+++ b/tests/test-merge-pr.sh
@@ -301,7 +301,7 @@ case "$*" in
     cp "$GIT_PUSH_HEAD_FILE" "$GH_HEAD_REF_FILE"
     echo "pushed"
     ;;
-  "branch -D feature/test")
+  "branch -D -- feature/test")
     echo "deleted feature/test" > "$GIT_BRANCH_DELETED_FILE"
     echo "Deleted branch feature/test (was pr-head-oid)."
     ;;

--- a/tests/test-review-gate-tools.sh
+++ b/tests/test-review-gate-tools.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# tests/test-review-gate-tools.sh — regression guard for merge-gate tool scoping.
+# Under the merge gate (CODEX_REVIEW_PR_NUMBER set) the diff under review is
+# attacker-controlled and is a prompt-injection vector into the tool-enabled
+# review/fix loop. The Bash tool must be dropped there by default so injected
+# instructions cannot run arbitrary commands; an explicit opt-in restores it.
+# Local pre-push review keeps Bash.
+#
+# We extract conductor_tools_for_mode() (and its truthiness helpers) from the
+# real hook and exercise it directly — no model/provider quota spent.
+#
+# REVIEW_MODE is consumed by the eval'd conductor_tools_for_mode; shellcheck
+# cannot see through eval, so it reports it unused (file-scoped directive).
+# shellcheck disable=SC2034
+set -euo pipefail
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SRC="$TOUCHSTONE_ROOT/hooks/codex-review.sh"
+
+ERRORS=0
+fail() {
+  echo "FAIL: $1" >&2
+  ERRORS=$((ERRORS + 1))
+}
+
+extract_fn() {
+  awk -v fn="$1" '$0 ~ "^"fn"\\(\\) \\{"{f=1} f{print} f&&/^}/{exit}' "$SRC"
+}
+
+# Faithful reconstruction of the truthiness chain the function depends on.
+eval "$(extract_fn trim)"
+eval "$(extract_fn normalize_bool)"
+eval "$(extract_fn is_truthy)"
+eval "$(extract_fn conductor_tools_for_mode)"
+
+tools_for() {
+  # $1 = phase, env: REVIEW_MODE, CODEX_REVIEW_PR_NUMBER, TOUCHSTONE_REVIEW_ALLOW_GATE_BASH
+  conductor_tools_for_mode "$1"
+}
+
+has_bash() { case ",$1," in *,Bash,*) return 0 ;; *) return 1 ;; esac }
+
+# === Merge gate, default: Bash dropped from fix and review ===
+REVIEW_MODE="fix"
+out="$(CODEX_REVIEW_PR_NUMBER=9 tools_for fix)"
+if has_bash "$out"; then fail "gate fix must NOT include Bash by default (got: $out)"; fi
+case ",$out," in *,Edit,*) : ;; *) fail "gate fix must still include Edit (got: $out)" ;; esac
+case ",$out," in *,Write,*) : ;; *) fail "gate fix must still include Write (got: $out)" ;; esac
+
+out="$(CODEX_REVIEW_PR_NUMBER=9 tools_for review)"
+if has_bash "$out"; then fail "gate review must NOT include Bash by default (got: $out)"; fi
+
+# === Merge gate, explicit opt-in: Bash restored ===
+out="$(CODEX_REVIEW_PR_NUMBER=9 TOUCHSTONE_REVIEW_ALLOW_GATE_BASH=1 tools_for fix)"
+has_bash "$out" || fail "gate fix with opt-in must include Bash (got: $out)"
+
+# === Local pre-push (no PR number): Bash retained (unchanged behavior) ===
+out="$(tools_for fix)"
+has_bash "$out" || fail "local fix must include Bash (got: $out)"
+out="$(tools_for review)"
+has_bash "$out" || fail "local review must include Bash (got: $out)"
+
+# === diff-only mode stays empty regardless of gate ===
+REVIEW_MODE="diff-only"
+out="$(CODEX_REVIEW_PR_NUMBER=9 tools_for review)"
+[ -z "$out" ] || fail "diff-only review must grant no tools (got: $out)"
+
+if [ "$ERRORS" -eq 0 ]; then
+  echo "==> PASS: merge gate drops Bash by default; opt-in and local review unaffected"
+else
+  echo "==> FAILED with $ERRORS error(s)" >&2
+  exit 1
+fi

--- a/tests/test-review-hook.sh
+++ b/tests/test-review-hook.sh
@@ -1119,8 +1119,8 @@ case "${1:-}" in
     fi
     printf 'route %s\n' "$*" >>"$CASCADE_CALLS"
     case " $* " in
-      *" --tools Read,Grep,Glob,Bash,Edit,Write "*)
-        printf '{"error":"no provider satisfies the routing request. Skipped: claude does not support tools: [Read, Grep, Glob, Bash, Edit, Write]"}\n'
+      *" --tools Read,Grep,Glob,Edit,Write "*)
+        printf '{"error":"no provider satisfies the routing request. Skipped: claude does not support tools: [Read, Grep, Glob, Edit, Write]"}\n'
         exit 2
         ;;
       *)
@@ -1158,7 +1158,7 @@ set -e
 if [ "$ROUTE_PINNED_EXIT" -eq 1 ] \
   && grep -q 'requested provider: claude' "$CASCADE_OUTPUT" \
   && grep -q 'missing capability: .*does not support tools' "$CASCADE_OUTPUT" \
-  && grep -q -- '--tools Read,Grep,Glob,Bash,Edit,Write' "$CASCADE_CALLS" \
+  && grep -q -- '--tools Read,Grep,Glob,Edit,Write' "$CASCADE_CALLS" \
   && ! grep -q 'review should not run' "$CASCADE_CALLS"; then
   echo "==> PASS: pinned nonviable provider failed with missing capability"
 else

--- a/tests/test-review-trusted-base-config.sh
+++ b/tests/test-review-trusted-base-config.sh
@@ -7,13 +7,21 @@
 # Otherwise a PR could weaken/disable its own guardrails or inject "trusted"
 # project context into the fix-loop prompt.
 #
-# We extract resolve_trusted_review_file() from the real hook and exercise it
-# directly so the test pins the shipped behavior without spending model quota.
+# Two layers of coverage, both offline (no model quota):
+#   1. unit: extract resolve_trusted_review_file() and exercise it directly.
+#   2. integration: run the real hook with CODEX_REVIEW_TEST_PRINT_CONFIG=1,
+#      which prints the finally-resolved CONFIG_FILE and exits. This covers the
+#      script-level fallback — in particular the case where the base ref has NO
+#      config but the PR head ADDS one (the gate must NOT honor it).
 #
+# REPO_ROOT/TRUSTED_REVIEW_TMP_FILES/RESOLVED_REVIEW_FILE_LABEL are consumed by
+# the eval'd resolver; shellcheck can't see through eval (file-scoped directive).
+# shellcheck disable=SC2034
 set -euo pipefail
 
 TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SRC="$TOUCHSTONE_ROOT/hooks/codex-review.sh"
+HOOK="$TOUCHSTONE_ROOT/hooks/codex-review.sh"
 TEST_DIR="$(mktemp -d -t touchstone-test-trusted-base.XXXXXX)"
 trap 'rm -rf "$TEST_DIR"' EXIT
 
@@ -27,13 +35,20 @@ extract_fn() {
   awk -v fn="$1" '$0 ~ "^"fn"\\(\\) \\{"{f=1} f{print} f&&/^}/{exit}' "$SRC"
 }
 
-# --- Build a repo: strict config on base, weakened config + injected context on HEAD.
+new_repo() {
+  local repo="$1"
+  mkdir -p "$repo"
+  git -C "$repo" init -q
+  git -C "$repo" config user.email "t@example.com"
+  git -C "$repo" config user.name "T"
+  git -C "$repo" checkout -q -b main
+}
+
+# ===========================================================================
+# Layer 1 — unit test of resolve_trusted_review_file
+# ===========================================================================
 REPO="$TEST_DIR/repo"
-mkdir -p "$REPO"
-git -C "$REPO" init -q
-git -C "$REPO" config user.email "t@example.com"
-git -C "$REPO" config user.name "T"
-git -C "$REPO" checkout -q -b main
+new_repo "$REPO"
 printf 'safe_by_default = false\n# BASE_STRICT_CONFIG\n' >"$REPO/.touchstone-review.toml"
 git -C "$REPO" add -A
 git -C "$REPO" commit -q -m "base: strict review config"
@@ -45,9 +60,7 @@ printf 'HEAD_INJECTED_CONTEXT\n' >"$REPO/.codex-review-context.md"
 git -C "$REPO" add -A
 git -C "$REPO" commit -q -m "attacker: weaken config + inject context"
 
-# --- Harness around the extracted function.
 run_resolver() {
-  # shellcheck disable=SC2034
   (
     cd "$REPO"
     REPO_ROOT="$REPO"
@@ -55,7 +68,6 @@ run_resolver() {
     RESOLVED_REVIEW_FILE_LABEL=""
     eval "$(extract_fn resolve_trusted_review_file)"
     resolved="$(resolve_trusted_review_file "$@")"
-    printf 'LABEL=%s\n' "$RESOLVED_REVIEW_FILE_LABEL"
     if [ -n "$resolved" ]; then
       printf 'CONTENT<<<\n'
       cat "$resolved"
@@ -66,35 +78,83 @@ run_resolver() {
   )
 }
 
-# === Case A: merge gate (PR context) -> config comes from trusted base ===
 out="$(CODEX_REVIEW_PR_NUMBER=7 CODEX_REVIEW_BASE="$BASE_SHA" \
   run_resolver .touchstone-review.toml .codex-review.toml)"
 echo "$out" | grep -q "BASE_STRICT_CONFIG" \
-  || fail "merge gate must read review config from base ref (expected BASE_STRICT_CONFIG)"
+  || fail "[unit] gate must read config from base ref (expected BASE_STRICT_CONFIG)"
 if echo "$out" | grep -q "HEAD_WEAK_CONFIG"; then
-  fail "merge gate must NOT read review config from attacker PR head (saw HEAD_WEAK_CONFIG)"
+  fail "[unit] gate must NOT read config from attacker PR head"
 fi
 
-# Context file absent on base -> must resolve to nothing (no injection).
 out_ctx="$(CODEX_REVIEW_PR_NUMBER=7 CODEX_REVIEW_BASE="$BASE_SHA" \
   run_resolver .codex-review-context.md .github/codex-review-context.md)"
 echo "$out_ctx" | grep -q "CONTENT=<none>" \
-  || fail "merge gate must not pick up a prompt-context file absent from base"
+  || fail "[unit] gate must not pick up a context file absent from base"
 if echo "$out_ctx" | grep -q "HEAD_INJECTED_CONTEXT"; then
-  fail "merge gate must NOT inject a PR-supplied review-context file"
+  fail "[unit] gate must NOT inject a PR-supplied review-context file"
 fi
 
-# === Case B: local pre-push (no PR context) -> working tree is source of truth ===
 out_local="$(run_resolver .touchstone-review.toml .codex-review.toml)"
 echo "$out_local" | grep -q "HEAD_WEAK_CONFIG" \
-  || fail "local review must read config from the working tree"
+  || fail "[unit] local review must read config from the working tree"
 
-out_local_ctx="$(run_resolver .codex-review-context.md .github/codex-review-context.md)"
-echo "$out_local_ctx" | grep -q "HEAD_INJECTED_CONTEXT" \
-  || fail "local review must read the working-tree context file"
+# ===========================================================================
+# Layer 2 — integration test of the real hook's CONFIG_FILE resolution
+# ===========================================================================
+# run_hook_config <branch-to-checkout> [env assignments...] -> prints CONFIG_FILE=...
+run_hook_config() {
+  local repo="$1"
+  shift
+  (
+    cd "$repo"
+    env "$@" CODEX_REVIEW_TEST_PRINT_CONFIG=1 bash "$HOOK" 2>/dev/null
+  )
+}
+
+config_path_of() { sed -n 's/^CONFIG_FILE=//p' <<<"$1"; }
+
+# --- Scenario A: base HAS config, PR weakens it -> gate uses base (strict) ---
+out="$(run_hook_config "$REPO" CODEX_REVIEW_PR_NUMBER=11 CODEX_REVIEW_BASE="$BASE_SHA")"
+cfg="$(config_path_of "$out")"
+if [ -z "$cfg" ] || ! grep -q "BASE_STRICT_CONFIG" "$cfg" 2>/dev/null; then
+  fail "[integ] gate(base-has-config) must resolve CONFIG_FILE to base content; got '$cfg'"
+fi
+if [ -n "$cfg" ] && grep -q "HEAD_WEAK_CONFIG" "$cfg" 2>/dev/null; then
+  fail "[integ] gate(base-has-config) resolved CONFIG_FILE to the PR head's weakened config"
+fi
+
+# --- Scenario B (the bug): base has NO config, PR ADDS a weakened one ---
+REPO2="$TEST_DIR/repo2"
+new_repo "$REPO2"
+printf 'placeholder\n' >"$REPO2/README.md" # base commit with NO review config
+git -C "$REPO2" add -A
+git -C "$REPO2" commit -q -m "base: no review config"
+BASE2_SHA="$(git -C "$REPO2" rev-parse HEAD)"
+git -C "$REPO2" checkout -q -b attacker2
+printf 'safe_by_default = true\n# PR_ADDED_WEAK_CONFIG\n' >"$REPO2/.touchstone-review.toml"
+git -C "$REPO2" add -A
+git -C "$REPO2" commit -q -m "attacker: introduce weakened config"
+
+out="$(run_hook_config "$REPO2" CODEX_REVIEW_PR_NUMBER=12 CODEX_REVIEW_BASE="$BASE2_SHA")"
+cfg="$(config_path_of "$out")"
+if [ -n "$cfg" ]; then
+  # A non-empty CONFIG_FILE here means the gate fell back to the PR head's file.
+  if grep -q "PR_ADDED_WEAK_CONFIG" "$cfg" 2>/dev/null; then
+    fail "[integ] BUG: gate honored a config the PR introduced (absent on base): $cfg"
+  else
+    fail "[integ] gate(base-no-config) must leave CONFIG_FILE empty; got '$cfg'"
+  fi
+fi
+
+# --- Scenario C: local (no PR number), working tree has config -> use it ---
+out="$(run_hook_config "$REPO2")" # on attacker2 branch, working tree has the config
+cfg="$(config_path_of "$out")"
+if [ -z "$cfg" ] || ! grep -q "PR_ADDED_WEAK_CONFIG" "$cfg" 2>/dev/null; then
+  fail "[integ] local review must read config from the working tree; got '$cfg'"
+fi
 
 if [ "$ERRORS" -eq 0 ]; then
-  echo "==> PASS: review hook reads control files from the trusted base ref under the merge gate"
+  echo "==> PASS: merge gate resolves review config from trusted base, never the PR head (incl. base-absent case)"
 else
   echo "==> FAILED with $ERRORS error(s)" >&2
   exit 1

--- a/tests/test-review-trusted-base-config.sh
+++ b/tests/test-review-trusted-base-config.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# tests/test-review-trusted-base-config.sh — regression guard for the merge-gate
+# trust boundary. Under the merge gate the working tree is the attacker's PR
+# head, so the review hook must read its control files (.touchstone-review.toml,
+# .codex-review-context.md) from the trusted base ref, not the working tree.
+# Otherwise a PR could weaken/disable its own guardrails or inject "trusted"
+# project context into the fix-loop prompt.
+#
+# We extract resolve_trusted_review_file() from the real hook and exercise it
+# directly so the test pins the shipped behavior without spending model quota.
+#
+set -euo pipefail
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SRC="$TOUCHSTONE_ROOT/hooks/codex-review.sh"
+TEST_DIR="$(mktemp -d -t touchstone-test-trusted-base.XXXXXX)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+ERRORS=0
+fail() {
+  echo "FAIL: $1" >&2
+  ERRORS=$((ERRORS + 1))
+}
+
+extract_fn() {
+  awk -v fn="$1" '$0 ~ "^"fn"\\(\\) \\{"{f=1} f{print} f&&/^}/{exit}' "$SRC"
+}
+
+# --- Build a repo: strict config on base, weakened config + injected context on HEAD.
+REPO="$TEST_DIR/repo"
+mkdir -p "$REPO"
+git -C "$REPO" init -q
+git -C "$REPO" config user.email "t@example.com"
+git -C "$REPO" config user.name "T"
+git -C "$REPO" checkout -q -b main
+printf 'safe_by_default = false\n# BASE_STRICT_CONFIG\n' >"$REPO/.touchstone-review.toml"
+git -C "$REPO" add -A
+git -C "$REPO" commit -q -m "base: strict review config"
+BASE_SHA="$(git -C "$REPO" rev-parse HEAD)"
+
+git -C "$REPO" checkout -q -b attacker
+printf 'safe_by_default = true\n# HEAD_WEAK_CONFIG\n' >"$REPO/.touchstone-review.toml"
+printf 'HEAD_INJECTED_CONTEXT\n' >"$REPO/.codex-review-context.md"
+git -C "$REPO" add -A
+git -C "$REPO" commit -q -m "attacker: weaken config + inject context"
+
+# --- Harness around the extracted function.
+run_resolver() {
+  # shellcheck disable=SC2034
+  (
+    cd "$REPO"
+    REPO_ROOT="$REPO"
+    TRUSTED_REVIEW_TMP_FILES=()
+    RESOLVED_REVIEW_FILE_LABEL=""
+    eval "$(extract_fn resolve_trusted_review_file)"
+    resolved="$(resolve_trusted_review_file "$@")"
+    printf 'LABEL=%s\n' "$RESOLVED_REVIEW_FILE_LABEL"
+    if [ -n "$resolved" ]; then
+      printf 'CONTENT<<<\n'
+      cat "$resolved"
+      printf '>>>\n'
+    else
+      printf 'CONTENT=<none>\n'
+    fi
+  )
+}
+
+# === Case A: merge gate (PR context) -> config comes from trusted base ===
+out="$(CODEX_REVIEW_PR_NUMBER=7 CODEX_REVIEW_BASE="$BASE_SHA" \
+  run_resolver .touchstone-review.toml .codex-review.toml)"
+echo "$out" | grep -q "BASE_STRICT_CONFIG" \
+  || fail "merge gate must read review config from base ref (expected BASE_STRICT_CONFIG)"
+if echo "$out" | grep -q "HEAD_WEAK_CONFIG"; then
+  fail "merge gate must NOT read review config from attacker PR head (saw HEAD_WEAK_CONFIG)"
+fi
+
+# Context file absent on base -> must resolve to nothing (no injection).
+out_ctx="$(CODEX_REVIEW_PR_NUMBER=7 CODEX_REVIEW_BASE="$BASE_SHA" \
+  run_resolver .codex-review-context.md .github/codex-review-context.md)"
+echo "$out_ctx" | grep -q "CONTENT=<none>" \
+  || fail "merge gate must not pick up a prompt-context file absent from base"
+if echo "$out_ctx" | grep -q "HEAD_INJECTED_CONTEXT"; then
+  fail "merge gate must NOT inject a PR-supplied review-context file"
+fi
+
+# === Case B: local pre-push (no PR context) -> working tree is source of truth ===
+out_local="$(run_resolver .touchstone-review.toml .codex-review.toml)"
+echo "$out_local" | grep -q "HEAD_WEAK_CONFIG" \
+  || fail "local review must read config from the working tree"
+
+out_local_ctx="$(run_resolver .codex-review-context.md .github/codex-review-context.md)"
+echo "$out_local_ctx" | grep -q "HEAD_INJECTED_CONTEXT" \
+  || fail "local review must read the working-tree context file"
+
+if [ "$ERRORS" -eq 0 ]; then
+  echo "==> PASS: review hook reads control files from the trusted base ref under the merge gate"
+else
+  echo "==> FAILED with $ERRORS error(s)" >&2
+  exit 1
+fi

--- a/tests/test-sync-symlink-safe.sh
+++ b/tests/test-sync-symlink-safe.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# tests/test-sync-symlink-safe.sh — regression guard against symlink-through
+# writes during sync. `cp` follows symlinks, so a symlink planted at a managed
+# path (by a hostile/cloned project tree) would make update_file clobber or
+# CREATE the link target — possibly outside the project. update_file must
+# replace an unexpected symlink with the real managed file instead. The
+# executable-bit pass must likewise skip symlinks.
+#
+# We extract update_file() from the real updater and exercise it directly.
+#
+# DRY_RUN/ADDED/UPDATED/UNCHANGED/ADDED_PATHS are consumed by the eval'd
+# update_file; shellcheck cannot see through eval (file-scoped directive).
+# shellcheck disable=SC2034
+set -euo pipefail
+
+TOUCHSTONE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SRC="$TOUCHSTONE_ROOT/bootstrap/update-project.sh"
+TEST_DIR="$(mktemp -d -t touchstone-test-symlink-safe.XXXXXX)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+ERRORS=0
+fail() {
+  echo "FAIL: $1" >&2
+  ERRORS=$((ERRORS + 1))
+}
+
+extract_fn() {
+  awk -v fn="$1" '$0 ~ "^"fn"\\(\\) \\{"{f=1} f{print} f&&/^}/{exit}' "$SRC"
+}
+
+# Load the real update_file with a minimal stub for its one helper + globals.
+relative_project_path() { printf '%s' "$1"; }
+DRY_RUN=false
+ADDED=0
+UPDATED=0
+UNCHANGED=0
+ADDED_PATHS=()
+eval "$(extract_fn update_file)"
+
+PROJ="$TEST_DIR/project"
+OUTSIDE="$TEST_DIR/outside"
+mkdir -p "$PROJ/scripts" "$OUTSIDE"
+
+# Managed source content we expect to land in the project (and nowhere else).
+MANAGED_SRC="$TEST_DIR/managed-source.sh"
+printf 'MANAGED_CONTENT\n' >"$MANAGED_SRC"
+
+# === Case 1: managed path is a symlink to an EXISTING file outside the project ===
+printf 'PROTECTED_SECRET\n' >"$OUTSIDE/secret"
+ln -s "$OUTSIDE/secret" "$PROJ/scripts/managed-a.sh"
+update_file "$MANAGED_SRC" "$PROJ/scripts/managed-a.sh" >/dev/null 2>&1 || true
+if [ "$(cat "$OUTSIDE/secret")" != "PROTECTED_SECRET" ]; then
+  fail "write through symlink clobbered an outside file (Case 1)"
+fi
+if [ -L "$PROJ/scripts/managed-a.sh" ]; then
+  fail "managed path still a symlink after update (Case 1)"
+fi
+if [ "$(cat "$PROJ/scripts/managed-a.sh" 2>/dev/null)" != "MANAGED_CONTENT" ]; then
+  fail "managed file not written with managed content (Case 1)"
+fi
+
+# === Case 2: managed path is a DANGLING symlink pointing outside the project ===
+ln -s "$OUTSIDE/created-by-attack" "$PROJ/scripts/managed-b.sh"
+update_file "$MANAGED_SRC" "$PROJ/scripts/managed-b.sh" >/dev/null 2>&1 || true
+if [ -e "$OUTSIDE/created-by-attack" ]; then
+  fail "write through dangling symlink CREATED a file outside the project (Case 2)"
+fi
+if [ -L "$PROJ/scripts/managed-b.sh" ]; then
+  fail "managed path still a symlink after update (Case 2)"
+fi
+if [ "$(cat "$PROJ/scripts/managed-b.sh" 2>/dev/null)" != "MANAGED_CONTENT" ]; then
+  fail "managed file not written with managed content (Case 2)"
+fi
+
+# === Case 3: ordinary managed file still updates normally ===
+printf 'OLD\n' >"$PROJ/scripts/managed-c.sh"
+update_file "$MANAGED_SRC" "$PROJ/scripts/managed-c.sh" >/dev/null 2>&1 || true
+if [ "$(cat "$PROJ/scripts/managed-c.sh")" != "MANAGED_CONTENT" ]; then
+  fail "ordinary managed file failed to update (Case 3)"
+fi
+
+# === Case 4: chmod pass must not follow a symlink onto an outside target ===
+printf 'OUTSIDE_EXEC_TARGET\n' >"$OUTSIDE/exec-target"
+chmod 600 "$OUTSIDE/exec-target"
+ln -s "$OUTSIDE/exec-target" "$PROJ/scripts/link.sh"
+# Exact command shipped by update-project.sh:
+find "$PROJ/scripts" -maxdepth 1 -type f -name '*.sh' -exec chmod +x {} + 2>/dev/null || true
+perms="$(ls -l "$OUTSIDE/exec-target" | cut -c1-10)"
+case "$perms" in
+  *x*) fail "chmod followed a symlink and made an outside file executable (perms=$perms)" ;;
+esac
+
+if [ "$ERRORS" -eq 0 ]; then
+  echo "==> PASS: sync never writes through or chmods through symlinks"
+else
+  echo "==> FAILED with $ERRORS error(s)" >&2
+  exit 1
+fi

--- a/tests/test-sync-symlink-safe.sh
+++ b/tests/test-sync-symlink-safe.sh
@@ -1,16 +1,17 @@
 #!/usr/bin/env bash
 #
-# tests/test-sync-symlink-safe.sh — regression guard against symlink-through
-# writes during sync. `cp` follows symlinks, so a symlink planted at a managed
-# path (by a hostile/cloned project tree) would make update_file clobber or
-# CREATE the link target — possibly outside the project. update_file must
-# replace an unexpected symlink with the real managed file instead. The
-# executable-bit pass must likewise skip symlinks.
+# tests/test-sync-symlink-safe.sh — regression guard against symlink-traversal
+# writes during sync. cp/mkdir/redirects all follow symlinks, so a symlink at a
+# managed path — OR at any ancestor directory of one — could make a write land
+# outside the project. Every project-write site routes through ensure_safe_dest,
+# which replaces a final-component symlink with the real file and hard-refuses a
+# symlinked ancestor directory.
 #
-# We extract update_file() from the real updater and exercise it directly.
+# We extract ensure_safe_dest() and update_file() from the real updater and
+# exercise them directly.
 #
-# DRY_RUN/ADDED/UPDATED/UNCHANGED/ADDED_PATHS are consumed by the eval'd
-# update_file; shellcheck cannot see through eval (file-scoped directive).
+# DRY_RUN/ADDED/UPDATED/UNCHANGED/ADDED_PATHS/SKIPPED_UNSAFE/PROJECT_DIR are
+# consumed by the eval'd functions; shellcheck can't see through eval.
 # shellcheck disable=SC2034
 set -euo pipefail
 
@@ -29,70 +30,79 @@ extract_fn() {
   awk -v fn="$1" '$0 ~ "^"fn"\\(\\) \\{"{f=1} f{print} f&&/^}/{exit}' "$SRC"
 }
 
-# Load the real update_file with a minimal stub for its one helper + globals.
 relative_project_path() { printf '%s' "$1"; }
 DRY_RUN=false
 ADDED=0
 UPDATED=0
 UNCHANGED=0
+SKIPPED_UNSAFE=0
 ADDED_PATHS=()
+eval "$(extract_fn ensure_safe_dest)"
 eval "$(extract_fn update_file)"
 
-PROJ="$TEST_DIR/project"
 OUTSIDE="$TEST_DIR/outside"
-mkdir -p "$PROJ/scripts" "$OUTSIDE"
-
-# Managed source content we expect to land in the project (and nowhere else).
+mkdir -p "$OUTSIDE"
 MANAGED_SRC="$TEST_DIR/managed-source.sh"
 printf 'MANAGED_CONTENT\n' >"$MANAGED_SRC"
 
-# === Case 1: managed path is a symlink to an EXISTING file outside the project ===
-printf 'PROTECTED_SECRET\n' >"$OUTSIDE/secret"
-ln -s "$OUTSIDE/secret" "$PROJ/scripts/managed-a.sh"
-update_file "$MANAGED_SRC" "$PROJ/scripts/managed-a.sh" >/dev/null 2>&1 || true
-if [ "$(cat "$OUTSIDE/secret")" != "PROTECTED_SECRET" ]; then
-  fail "write through symlink clobbered an outside file (Case 1)"
-fi
-if [ -L "$PROJ/scripts/managed-a.sh" ]; then
-  fail "managed path still a symlink after update (Case 1)"
-fi
-if [ "$(cat "$PROJ/scripts/managed-a.sh" 2>/dev/null)" != "MANAGED_CONTENT" ]; then
-  fail "managed file not written with managed content (Case 1)"
-fi
+# Each scenario gets a fresh PROJECT_DIR (ensure_safe_dest walks up to it).
+fresh_project() {
+  PROJECT_DIR="$TEST_DIR/proj-$1"
+  mkdir -p "$PROJECT_DIR/scripts"
+}
 
-# === Case 2: managed path is a DANGLING symlink pointing outside the project ===
-ln -s "$OUTSIDE/created-by-attack" "$PROJ/scripts/managed-b.sh"
-update_file "$MANAGED_SRC" "$PROJ/scripts/managed-b.sh" >/dev/null 2>&1 || true
-if [ -e "$OUTSIDE/created-by-attack" ]; then
-  fail "write through dangling symlink CREATED a file outside the project (Case 2)"
-fi
-if [ -L "$PROJ/scripts/managed-b.sh" ]; then
-  fail "managed path still a symlink after update (Case 2)"
-fi
-if [ "$(cat "$PROJ/scripts/managed-b.sh" 2>/dev/null)" != "MANAGED_CONTENT" ]; then
-  fail "managed file not written with managed content (Case 2)"
-fi
+# === Case 1: managed path is a symlink to an EXISTING outside file ===
+fresh_project c1
+printf 'PROTECTED\n' >"$OUTSIDE/secret1"
+ln -s "$OUTSIDE/secret1" "$PROJECT_DIR/scripts/a.sh"
+update_file "$MANAGED_SRC" "$PROJECT_DIR/scripts/a.sh" >/dev/null 2>&1 || true
+[ "$(cat "$OUTSIDE/secret1")" = "PROTECTED" ] || fail "C1: write-through clobbered outside file"
+[ ! -L "$PROJECT_DIR/scripts/a.sh" ] || fail "C1: managed path still a symlink"
+[ "$(cat "$PROJECT_DIR/scripts/a.sh" 2>/dev/null)" = "MANAGED_CONTENT" ] || fail "C1: managed file not written"
 
-# === Case 3: ordinary managed file still updates normally ===
-printf 'OLD\n' >"$PROJ/scripts/managed-c.sh"
-update_file "$MANAGED_SRC" "$PROJ/scripts/managed-c.sh" >/dev/null 2>&1 || true
-if [ "$(cat "$PROJ/scripts/managed-c.sh")" != "MANAGED_CONTENT" ]; then
-  fail "ordinary managed file failed to update (Case 3)"
-fi
+# === Case 2: DANGLING symlink at the managed path ===
+fresh_project c2
+ln -s "$OUTSIDE/created2" "$PROJECT_DIR/scripts/b.sh"
+update_file "$MANAGED_SRC" "$PROJECT_DIR/scripts/b.sh" >/dev/null 2>&1 || true
+[ ! -e "$OUTSIDE/created2" ] || fail "C2: write-through dangling symlink created outside file"
+[ "$(cat "$PROJECT_DIR/scripts/b.sh" 2>/dev/null)" = "MANAGED_CONTENT" ] || fail "C2: managed file not written"
 
-# === Case 4: chmod pass must not follow a symlink onto an outside target ===
-printf 'OUTSIDE_EXEC_TARGET\n' >"$OUTSIDE/exec-target"
-chmod 600 "$OUTSIDE/exec-target"
-ln -s "$OUTSIDE/exec-target" "$PROJ/scripts/link.sh"
-# Exact command shipped by update-project.sh:
-find "$PROJ/scripts" -maxdepth 1 -type f -name '*.sh' -exec chmod +x {} + 2>/dev/null || true
-perms="$(ls -l "$OUTSIDE/exec-target" | cut -c1-10)"
-case "$perms" in
-  *x*) fail "chmod followed a symlink and made an outside file executable (perms=$perms)" ;;
+# === Case 3 (the new finding): a managed ANCESTOR DIRECTORY is a symlink ===
+# `scripts` itself points outside the project. A write to scripts/c.sh must be
+# refused, not redirected through the symlinked dir.
+fresh_project c3
+rm -rf "${PROJECT_DIR:?}/scripts"
+mkdir -p "$OUTSIDE/evil-scripts"
+ln -s "$OUTSIDE/evil-scripts" "$PROJECT_DIR/scripts"
+before_unsafe="$SKIPPED_UNSAFE"
+update_file "$MANAGED_SRC" "$PROJECT_DIR/scripts/c.sh" >/dev/null 2>&1 || true
+[ ! -e "$OUTSIDE/evil-scripts/c.sh" ] || fail "C3: wrote through symlinked ancestor directory"
+[ "$SKIPPED_UNSAFE" -gt "$before_unsafe" ] || fail "C3: skipped-unsafe counter did not increment"
+
+# === Case 4: nested ancestor symlink (.claude -> outside), deeper dst ===
+fresh_project c4
+mkdir -p "$OUTSIDE/evil-claude"
+ln -s "$OUTSIDE/evil-claude" "$PROJECT_DIR/.claude"
+update_file "$MANAGED_SRC" "$PROJECT_DIR/.claude/skills/x/y.md" >/dev/null 2>&1 || true
+[ ! -e "$OUTSIDE/evil-claude/skills" ] || fail "C4: mkdir/cp traversed nested symlinked ancestor"
+
+# === Case 5: ensure_safe_dest accepts a legitimate real path ===
+fresh_project c5
+mkdir -p "$PROJECT_DIR/principles"
+ensure_safe_dest "$PROJECT_DIR/principles/ok.md" || fail "C5: refused a legitimate real path"
+
+# === Case 6: chmod pass must not follow a symlink onto an outside target ===
+fresh_project c6
+printf 'X\n' >"$OUTSIDE/exec6"
+chmod 600 "$OUTSIDE/exec6"
+ln -s "$OUTSIDE/exec6" "$PROJECT_DIR/scripts/link.sh"
+find "$PROJECT_DIR/scripts" -maxdepth 1 -type f -name '*.sh' -exec chmod +x {} + 2>/dev/null || true
+case "$(ls -l "$OUTSIDE/exec6" | cut -c1-10)" in
+  *x*) fail "C6: chmod followed a symlink onto an outside file" ;;
 esac
 
 if [ "$ERRORS" -eq 0 ]; then
-  echo "==> PASS: sync never writes through or chmods through symlinks"
+  echo "==> PASS: sync never writes/chmods through a symlink at the final path or any ancestor dir"
 else
   echo "==> FAILED with $ERRORS error(s)" >&2
   exit 1

--- a/tests/test-sync-symlink-safe.sh
+++ b/tests/test-sync-symlink-safe.sh
@@ -37,6 +37,9 @@ UPDATED=0
 UNCHANGED=0
 SKIPPED_UNSAFE=0
 ADDED_PATHS=()
+# update_file's ensure_safe_dest wrapper delegates to the shared guard.
+# shellcheck source=../lib/safe-write.sh
+source "$TOUCHSTONE_ROOT/lib/safe-write.sh"
 eval "$(extract_fn ensure_safe_dest)"
 eval "$(extract_fn update_file)"
 
@@ -100,6 +103,38 @@ find "$PROJECT_DIR/scripts" -maxdepth 1 -type f -name '*.sh' -exec chmod +x {} +
 case "$(ls -l "$OUTSIDE/exec6" | cut -c1-10)" in
   *x*) fail "C6: chmod followed a symlink onto an outside file" ;;
 esac
+
+# === Case 7: shared guard touchstone_ensure_safe_dest directly ===
+fresh_project c7
+# final-component symlink -> replaced (returns 0)
+ln -s "$OUTSIDE/secret7" "$PROJECT_DIR/scripts/final.sh"
+printf 'KEEP\n' >"$OUTSIDE/secret7"
+touchstone_ensure_safe_dest "$PROJECT_DIR/scripts/final.sh" "$PROJECT_DIR" false || fail "C7: rejected a final-component symlink instead of replacing"
+[ ! -L "$PROJECT_DIR/scripts/final.sh" ] || fail "C7: final-component symlink not removed"
+[ "$(cat "$OUTSIDE/secret7")" = "KEEP" ] || fail "C7: removing final symlink touched its target"
+# symlinked ancestor -> hard refuse (returns 1)
+rm -rf "${PROJECT_DIR:?}/scripts"
+ln -s "$OUTSIDE" "$PROJECT_DIR/scripts"
+if touchstone_ensure_safe_dest "$PROJECT_DIR/scripts/x.sh" "$PROJECT_DIR" false; then
+  fail "C7: accepted a write through a symlinked ancestor"
+fi
+# legitimate real path -> accept
+fresh_project c7b
+mkdir -p "$PROJECT_DIR/lib"
+touchstone_ensure_safe_dest "$PROJECT_DIR/lib/real.sh" "$PROJECT_DIR" false || fail "C7: refused a legitimate real path"
+
+# === Case 8: touchstone_block_apply refuses a symlinked AGENTS.md/GEMINI.md ===
+# shellcheck source=../lib/touchstone-block.sh
+source "$TOUCHSTONE_ROOT/lib/touchstone-block.sh"
+fresh_project c8
+printf 'OUTSIDE_AGENTS\n' >"$OUTSIDE/real-agents.md"
+ln -s "$OUTSIDE/real-agents.md" "$PROJECT_DIR/AGENTS.md"
+set +e
+touchstone_block_apply "$PROJECT_DIR/AGENTS.md" "$TOUCHSTONE_ROOT" >/dev/null 2>&1
+rc=$?
+set -e
+[ "$rc" -ne 0 ] || fail "C8: touchstone_block_apply did not refuse a symlinked target"
+[ "$(cat "$OUTSIDE/real-agents.md")" = "OUTSIDE_AGENTS" ] || fail "C8: block_apply wrote through the symlink to the outside file"
 
 if [ "$ERRORS" -eq 0 ]; then
   echo "==> PASS: sync never writes/chmods through a symlink at the final path or any ancestor dir"


### PR DESCRIPTION
Defense-in-depth: pass `--` before untrusted branch names in
`git branch -D` (merge-pr.sh) and `git push origin --delete` (cleanup-
branches.sh) so a branch name can never be parsed as an option. No working
exploit today (git refnames cannot lead with `-`), but it removes the
class. Updates the merge-pr git mock to the hardened argument form.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
