### PR TITLE
fix(worker): fail closed when abandon cannot prove safety

### DIFF
--- a/lib/worker-state.sh
+++ b/lib/worker-state.sh
@@ -33,7 +33,7 @@ touchstone_worker_default_ref() {
     fi
   done
 
-  printf 'origin/main\n'
+  return 1
 }
 
 touchstone_worker_review_marker_key() {
@@ -87,15 +87,24 @@ derive_worker_state() {
   (
     cd "$worktree_path" || exit 0
 
-    base="$(touchstone_worker_default_ref)"
+    if ! base="$(touchstone_worker_default_ref)"; then
+      echo "unknown"
+      exit 0
+    fi
     branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
     [ -n "$branch" ] && [ "$branch" != "HEAD" ] || {
       echo "abandoned"
       exit 0
     }
 
-    has_commits="$(git log "$base..HEAD" --oneline 2>/dev/null | head -1 || true)"
-    has_uncommitted="$(git status --porcelain 2>/dev/null || true)"
+    if ! has_commits="$(git log "$base..HEAD" --oneline --max-count=1 2>/dev/null)"; then
+      echo "unknown"
+      exit 0
+    fi
+    if ! has_uncommitted="$(git status --porcelain 2>/dev/null)"; then
+      echo "unknown"
+      exit 0
+    fi
 
     if [ -z "$has_commits" ]; then
       echo "spawned"

--- a/scripts/worker.sh
+++ b/scripts/worker.sh
@@ -195,7 +195,10 @@ cmd_spawn() {
   repo_root="$(repo_root_or_die)"
   slug="$(sanitize_task_slug "$task")"
   branch="$type/$slug"
-  base_ref="$(cd "$repo_root" && touchstone_worker_default_ref)"
+  if ! base_ref="$(cd "$repo_root" && touchstone_worker_default_ref)"; then
+    echo "ERROR: could not resolve a default branch ref for worker spawn." >&2
+    return 1
+  fi
   base_branch="${base_ref#origin/}"
 
   output="$(cd "$repo_root" && bash "$TOUCHSTONE_ROOT/scripts/spawn-worktree.sh" "$branch")"
@@ -396,9 +399,30 @@ cmd_abandon() {
     echo "ERROR: cannot abandon detached worktree." >&2
     return 1
   }
-  base="$(cd "$worktree_path" && touchstone_worker_default_ref)"
-  unique_commits="$(git -C "$worktree_path" log "$base..HEAD" --oneline 2>/dev/null || true)"
-  dirty_status="$(git -C "$worktree_path" status --porcelain 2>/dev/null || true)"
+  if ! base="$(cd "$worktree_path" && touchstone_worker_default_ref)"; then
+    if [ "$force" != true ]; then
+      echo "ERROR: refusing to abandon $worktree_path; could not resolve a default branch ref." >&2
+      echo "       Use --force only after confirming the work is disposable." >&2
+      return 1
+    fi
+    base=""
+    unique_commits=""
+  elif ! unique_commits="$(git -C "$worktree_path" log "$base..HEAD" --oneline --max-count=1 2>/dev/null)"; then
+    if [ "$force" != true ]; then
+      echo "ERROR: refusing to abandon $worktree_path; could not compare branch '$branch' against $base." >&2
+      echo "       Use --force only after confirming the work is disposable." >&2
+      return 1
+    fi
+    unique_commits=""
+  fi
+  if ! dirty_status="$(git -C "$worktree_path" status --porcelain 2>/dev/null)"; then
+    if [ "$force" != true ]; then
+      echo "ERROR: refusing to abandon $worktree_path; could not inspect uncommitted changes." >&2
+      echo "       Use --force only after confirming the dirty worktree is disposable." >&2
+      return 1
+    fi
+    dirty_status=""
+  fi
 
   if [ -n "$unique_commits" ] && [ "$force" != true ]; then
     echo "ERROR: refusing to abandon $worktree_path; branch '$branch' has commits not merged into $base." >&2

--- a/tests/test-worker.sh
+++ b/tests/test-worker.sh
@@ -204,6 +204,33 @@ if "$TOUCHSTONE_ROOT/bin/touchstone" worker abandon --worktree "$WORKTREE_PATH" 
 fi
 assert_contains "$TEST_DIR/abandon-refuse.out" 'refusing to abandon'
 
+NO_DEFAULT_REPO="$TEST_DIR/no-default-repo"
+NO_DEFAULT_WT="$TEST_DIR/no-default-worktree"
+git init -q -b trunk "$NO_DEFAULT_REPO"
+git -C "$NO_DEFAULT_REPO" config user.name "Touchstone Test"
+git -C "$NO_DEFAULT_REPO" config user.email "touchstone@example.com"
+# Force default-ref discovery to try a configured branch that does not exist,
+# then main/master. This repo intentionally has only trunk plus the worker branch.
+git -C "$NO_DEFAULT_REPO" config init.defaultBranch missing-default
+printf 'base\n' >"$NO_DEFAULT_REPO/file.txt"
+git -C "$NO_DEFAULT_REPO" add file.txt
+git -C "$NO_DEFAULT_REPO" commit -qm "base commit"
+git -C "$NO_DEFAULT_REPO" worktree add -q "$NO_DEFAULT_WT" -b fix/no-default trunk
+printf 'unique\n' >"$NO_DEFAULT_WT/unique.txt"
+git -C "$NO_DEFAULT_WT" add unique.txt
+git -C "$NO_DEFAULT_WT" commit -qm "unique worker work"
+
+NO_DEFAULT_STATUS="$TEST_DIR/no-default-status.json"
+"$TOUCHSTONE_ROOT/bin/touchstone" worker status --worktree "$NO_DEFAULT_WT" --json >"$NO_DEFAULT_STATUS"
+assert_json_value "$NO_DEFAULT_STATUS" state "unknown"
+if "$TOUCHSTONE_ROOT/bin/touchstone" worker abandon --worktree "$NO_DEFAULT_WT" >"$TEST_DIR/abandon-no-default.out" 2>&1; then
+  fail "worker abandon should refuse when default ref cannot be resolved"
+fi
+assert_contains "$TEST_DIR/abandon-no-default.out" 'could not resolve a default branch ref'
+if [ ! -d "$NO_DEFAULT_WT" ]; then
+  fail "worker abandon removed worktree when default ref resolution failed"
+fi
+
 SAFE_JSON="$TEST_DIR/safe-spawn.json"
 SAFE_EVENTS="$TEST_DIR/safe-events.ndjson"
 (


### PR DESCRIPTION
## Linked Issues

Closes #440

Closes-issue: #440

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
